### PR TITLE
Implement async witx functions for a Wasmtime host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,30 +571,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1478,6 +1458,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,12 +2139,10 @@ name = "witx-bindgen-gen-wasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures-channel",
- "futures-executor",
- "futures-util",
  "heck",
  "structopt",
  "test-helpers",
+ "tokio",
  "wasmtime",
  "wasmtime-wasi",
  "witx-bindgen-gen-core",
@@ -2185,6 +2186,7 @@ dependencies = [
  "async-trait",
  "bitflags",
  "thiserror",
+ "tokio",
  "tracing",
  "wasmtime",
  "witx-bindgen-wasmtime-impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,10 +571,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2116,6 +2136,9 @@ name = "witx-bindgen-gen-wasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
  "heck",
  "structopt",
  "test-helpers",

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -1461,6 +1461,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     operands[0], operands[1]
                 ));
             }
+            Instruction::CompletionCallback { .. } => unreachable!(),
             Instruction::ReturnAsyncImport { .. } => unreachable!(),
 
             Instruction::I32Load { offset } => {

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -2176,6 +2176,7 @@ impl witx2::abi::Bindgen for Bindgen<'_, '_> {
             }
 
             witx2::abi::Instruction::ReturnAsyncExport { .. } => todo!(),
+            witx2::abi::Instruction::CompletionCallback { .. } => todo!(),
             witx2::abi::Instruction::ReturnAsyncImport { .. } => todo!(),
 
             witx2::abi::Instruction::Witx { instr: _ } => {

--- a/crates/gen-wasmtime/Cargo.toml
+++ b/crates/gen-wasmtime/Cargo.toml
@@ -20,9 +20,7 @@ test-helpers = { path = '../test-helpers', features = ['witx-bindgen-gen-wasmtim
 wasmtime = "0.30.0"
 wasmtime-wasi = "0.30.0"
 witx-bindgen-wasmtime = { path = '../wasmtime', features = ['tracing', 'async'] }
-futures-executor = "0.3"
-futures-channel = "0.3"
-futures-util = "0.3"
+tokio = { version = "1.0", features = ['rt', 'sync', 'macros', 'rt-multi-thread', 'time'] }
 
 [features]
 old-witx-compat = ['witx-bindgen-gen-core/old-witx-compat']

--- a/crates/gen-wasmtime/Cargo.toml
+++ b/crates/gen-wasmtime/Cargo.toml
@@ -20,6 +20,9 @@ test-helpers = { path = '../test-helpers', features = ['witx-bindgen-gen-wasmtim
 wasmtime = "0.30.0"
 wasmtime-wasi = "0.30.0"
 witx-bindgen-wasmtime = { path = '../wasmtime', features = ['tracing', 'async'] }
+futures-executor = "0.3"
+futures-channel = "0.3"
+futures-util = "0.3"
 
 [features]
 old-witx-compat = ['witx-bindgen-gen-core/old-witx-compat']

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -1291,6 +1291,28 @@ impl Generator for Wasmtime {
                                 }})
                             }},
                         )?;
+                        linker.func_wrap(
+                            \"canonical_abi\",
+                            \"event_new\",
+                            move |mut caller: wasmtime::Caller<'_, T>, cb: u32, data: u32| {{
+                                witx_bindgen_wasmtime::rt::Async::event_new(
+                                    caller,
+                                    cb,
+                                    data,
+                                )
+                            }},
+                        )?;
+                        linker.func_wrap(
+                            \"canonical_abi\",
+                            \"event_signal\",
+                            move |mut caller: wasmtime::Caller<'_, T>, handle: u32, arg: u32| {{
+                                witx_bindgen_wasmtime::rt::Async::event_signal(
+                                    caller,
+                                    handle,
+                                    arg,
+                                )
+                            }},
+                        )?;
                     ",
                 ));
             }

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -917,7 +917,7 @@ impl Generator for Wasmtime {
                     self.src.push_str("type ");
                     self.src.push_str(&handle.to_camel_case());
                     self.src.push_str(": std::fmt::Debug");
-                    if is_async {
+                    if is_async || any_async_func {
                         self.src.push_str(" + Send + Sync");
                     }
                     self.src.push_str(";\n");

--- a/crates/gen-wasmtime/tests/codegen.rs
+++ b/crates/gen-wasmtime/tests/codegen.rs
@@ -9,9 +9,6 @@ mod exports {
     test_helpers::codegen_wasmtime_export!(
         "*.witx"
 
-        // TODO: implement async support
-        "!async_functions.witx"
-
         // If you want to exclude a specific test you can include it here with
         // gitignore glob syntax:
         //
@@ -27,9 +24,6 @@ mod exports {
 mod imports {
     test_helpers::codegen_wasmtime_import!(
         "*.witx"
-
-        // TODO: implement async support
-        "!async_functions.witx"
 
         // TODO: these use push/pull buffer which isn't implemented in the test
         // generator just yet

--- a/crates/rust-wasm/src/futures.rs
+++ b/crates/rust-wasm/src/futures.rs
@@ -1,10 +1,11 @@
 //! Helper library support for `async` witx functions, used for both
 
-use std::cell::RefCell;
+use self::event::{Event, Signal};
+use std::cell::{Cell, RefCell};
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 use std::sync::Arc;
 use std::task::*;
 
@@ -19,12 +20,112 @@ pub unsafe extern "C" fn async_export_done(_ctx: i32, _ptr: i32) {
     panic!("only supported on wasm");
 }
 
-struct PollingWaker {
-    state: RefCell<State>,
+/// Runs the `future` provided to completion, polling the future whenever its
+/// waker receives a call to `wake`.
+pub fn execute(future: Pin<Box<dyn Future<Output = ()>>>) {
+    Task::execute(future)
+}
+
+struct Task {
+    future: Pin<Box<dyn Future<Output = ()>>>,
+    waker: Arc<WasmWaker>,
+}
+
+impl Task {
+    fn execute(future: Pin<Box<dyn Future<Output = ()>>>) {
+        Box::new(Task {
+            future,
+            waker: Arc::new(WasmWaker {
+                state: Cell::new(State::Woken),
+            }),
+        })
+        .signal()
+    }
+}
+
+impl Signal for Task {
+    fn signal(mut self: Box<Self>) {
+        // First, reset our state to `polling` to indicate that we're actively
+        // polling the future that we own.
+        let waker = self.waker.clone();
+        match waker.state.replace(State::Polling) {
+            // This shouldn't be possible since if a waiting event is pending
+            // then we shouldn't be woken up to signal.
+            State::Waiting(_) => panic!("signaled but event is present"),
+
+            // This also shouldn't be possible since if the previous state were
+            // polling then we shouldn't be restarting another round of polling.
+            State::Polling => panic!("poll-in-poll"),
+
+            // This is the expected state, which is to say that we should be
+            // previously woken with some event having been consumed, which
+            // left a `Woken` marker here.
+            State::Woken => {}
+        }
+
+        // Perform the Rust Dance to poll the future.
+        let rust_waker = waker.clone().into();
+        let mut cx = Context::from_waker(&rust_waker);
+        match self.future.as_mut().poll(&mut cx) {
+            // If the future has finished there's nothing else left to do but
+            // destroy the future, so we do so here through the dtor for `self`
+            // in an early-return.
+            Poll::Ready(()) => return,
+
+            // If the future isn't ready then logic below handles the wakeup
+            // procedure.
+            Poll::Pending => {}
+        }
+
+        // Our future isn't ready but we should be scheduled to wait on some
+        // event from within the future. Configure the state of the waker
+        // after-the-fact to have an interface-types-provided "event" which,
+        // when woken, will basically re-invoke this method.
+        let event = Event::new(self);
+        match waker.state.replace(State::Waiting(event)) {
+            // This state shouldn't be possible because we're the only ones
+            // inserting a `Waiting` state here, so if something else set that
+            // it's highly unexpected.
+            State::Waiting(_) => unreachable!(),
+
+            // This is the expected state most of the time where we're replacing
+            // the `Polling` state that was configured above. This means we've
+            // switched from polling-to-waiting so we can safely return now and
+            // wait for our result.
+            State::Polling => {}
+
+            // This is a slightly tricky state where we received a `wake()`
+            // while we were polling. In this situation we replace the state
+            // back to `Woken` and signal the event ourselves.
+            State::Woken => {
+                let event = match waker.state.replace(State::Woken) {
+                    State::Waiting(event) => event,
+                    _ => unreachable!(),
+                };
+                event.signal();
+            }
+        }
+    }
+}
+
+/// This is the internals of the `Waker` that's specific to wasm.
+///
+/// For now this is pretty simple where this maintains a state enum where the
+/// main interesting state is an "event" that gets a signal to start re-polling
+/// the future. This event-based-wakeup has two consequences:
+///
+/// * If the `wake()` comes from another Rust coroutine then we'll correctly
+///   execute the Rust poll on the original coroutine's context.
+/// * If the `wake()` comes from an async import completing then it means the
+///   completion callback will do a tiny bit of work to signal the event, and
+///   then the real work will happen later when the event's callback is
+///   enqueued.
+struct WasmWaker {
+    state: Cell<State>,
 }
 
 enum State {
-    Waiting(Pin<Box<dyn Future<Output = ()>>>),
+    Waiting(Event),
     Polling,
     Woken,
 }
@@ -34,83 +135,33 @@ enum State {
 // an alternative implementation for threaded WebAssembly when that comes about
 // to host runtimes off-the-web.
 #[cfg(not(target_feature = "atomics"))]
-unsafe impl Send for PollingWaker {}
+unsafe impl Send for WasmWaker {}
 #[cfg(not(target_feature = "atomics"))]
-unsafe impl Sync for PollingWaker {}
+unsafe impl Sync for WasmWaker {}
 
-/// Runs the `future` provided to completion, polling the future whenever its
-/// waker receives a call to `wake`.
-pub fn execute(future: impl Future<Output = ()> + 'static) {
-    let waker = Arc::new(PollingWaker {
-        state: RefCell::new(State::Waiting(Box::pin(future))),
-    });
-    waker.wake()
-}
-
-impl Wake for PollingWaker {
+impl Wake for WasmWaker {
     fn wake(self: Arc<Self>) {
-        let mut state = self.state.borrow_mut();
-        let mut future = match mem::replace(&mut *state, State::Polling) {
-            // We are the first wake to come in to wake-up this future. This
-            // means that we need to actually poll the future, so leave the
-            // `Polling` state in place.
-            State::Waiting(future) => future,
+        match self.state.replace(State::Woken) {
+            // We found a waiting event, yay! Signal that to wake it up and then
+            // there's nothing much else for us to do.
+            State::Waiting(event) => event.signal(),
 
-            // Otherwise the future is either already polling or it was already
-            // woken while it was being polled, in both instances we reset the
-            // state back to `Woken` and then we return. This means that the
-            // future is owned by some previous stack frame and will drive the
-            // future as necessary.
-            State::Polling | State::Woken => {
-                *state = State::Woken;
-                return;
-            }
-        };
-        drop(state);
+            // this `wake` happened during the poll of the future itself, which
+            // is ok and the future will consume our `Woken` status when it's
+            // done polling.
+            State::Polling => {}
 
-        // Create the futures waker/context from ourselves, used for polling.
-        let waker = self.clone().into();
-        let mut cx = Context::from_waker(&waker);
-        loop {
-            match future.as_mut().poll(&mut cx) {
-                // The future is finished! By returning here we destroy the
-                // future and release all of its resources.
-                Poll::Ready(()) => break,
-
-                // The future has work yet-to-do, so continue below.
-                Poll::Pending => {}
-            }
-
-            let mut state = self.state.borrow_mut();
-            match *state {
-                // This means that we were not woken while we were polling and
-                // the state is as it was when we took out the future before. By
-                // `Pending` being returned at this point we're guaranteed that
-                // our waker will be woken up at some point in the future, which
-                // will come look at this future again. This means that we
-                // simply store our future and return, since this call to `wake`
-                // is now finished.
-                State::Polling => {
-                    *state = State::Waiting(future);
-                    break;
-                }
-
-                // This means that we received a call to `wake` while we were
-                // polling. Ideally we'd enqueue some sort of microtask-tick
-                // here or something like that but for now we just loop around
-                // and poll again.
-                State::Woken => {}
-
-                // This shouldn't be possible since we own the future, and no
-                // one else should insert another future here.
-                State::Waiting(_) => unreachable!(),
-            }
+            // This is perhaps a concurrent wake where we already woke up the
+            // main future. That's ok, we're still in the `Woken` state and it's
+            // still someone else's responsibility to manage wakeups at this
+            // point.
+            State::Woken => {}
         }
     }
 }
 
 pub struct Oneshot<T> {
-    inner: Weak<OneshotInner<T>>,
+    inner: Rc<OneshotInner<T>>,
 }
 
 pub struct Sender<T> {
@@ -130,12 +181,17 @@ enum OneshotState<T> {
 impl<T> Oneshot<T> {
     /// Returns a new "oneshot" channel as well as a completion callback.
     pub fn new() -> (Oneshot<T>, Sender<T>) {
+        // TODO: this oneshot implementation does not correctly handle "hangups"
+        // on either the sender or receiver side. This really only works with
+        // the exact codegen that we have right now and if it's used for
+        // anything else then this implementation needs to be updated (or this
+        // should use something off-the-shelf from the ecosystem)
         let inner = Rc::new(OneshotInner {
             state: RefCell::new(OneshotState::Start),
         });
         (
             Oneshot {
-                inner: Rc::downgrade(&inner),
+                inner: inner.clone(),
             },
             Sender { inner },
         )
@@ -146,13 +202,7 @@ impl<T> Future for Oneshot<T> {
     type Output = T;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        let inner = match self.inner.upgrade() {
-            Some(inner) => inner,
-            // Technically this isn't possible in the initial draft of interface
-            // types unless there's some serious bug somewhere.
-            None => panic!("completion callback was canceled"),
-        };
-        let mut state = inner.state.borrow_mut();
+        let mut state = self.inner.state.borrow_mut();
         match mem::replace(&mut *state, OneshotState::Start) {
             OneshotState::Done(t) => Poll::Ready(t),
             OneshotState::Waiting(_) | OneshotState::Start => {
@@ -175,12 +225,7 @@ impl<T> Sender<T> {
     }
 
     pub fn send(self, val: T) {
-        let mut state = self.inner.state.borrow_mut();
-        let prev = mem::replace(&mut *state, OneshotState::Done(val));
-        // Must `drop` before the `wake` below because waking may induce
-        // polling which would induce another `borrow_mut` which would
-        // conflict with this `borrow_mut` otherwise.
-        drop(state);
+        let prev = mem::replace(&mut *self.inner.state.borrow_mut(), OneshotState::Done(val));
 
         match prev {
             // nothing has polled the returned future just yet, so we just
@@ -193,16 +238,72 @@ impl<T> Sender<T> {
             OneshotState::Waiting(waker) => waker.wake(),
 
             // Shouldn't be possible, this is the only closure that writes
-            // `Done` and this can only be invoked once.
+            // `Done` and this can only be invoked once. Additionally since
+            // `self` exists we shouldn't be closed yet which is only written in
+            // `Drop`
             OneshotState::Done(_) => unreachable!(),
         }
     }
 }
 
-impl<T> Drop for OneshotInner<T> {
-    fn drop(&mut self) {
-        if let OneshotState::Waiting(waker) = &*self.state.borrow() {
-            waker.wake_by_ref();
+mod event {
+    use std::mem;
+
+    #[cfg(target_arch = "wasm32")]
+    #[link(wasm_import_module = "canonical_abi")]
+    extern "C" {
+        fn event_new(cb: usize, cbdata: usize) -> u32;
+        fn event_signal(handle: u32, arg: u32);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn event_new(_: usize, _: usize) -> u32 {
+        unreachable!()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe extern "C" fn event_signal(_: u32, _: u32) {
+        unreachable!()
+    }
+
+    pub struct Event(u32);
+
+    pub trait Signal {
+        fn signal(self: Box<Self>);
+    }
+
+    impl Event {
+        pub fn new<S>(to_signal: Box<S>) -> Event
+        where
+            S: Signal,
+        {
+            unsafe {
+                let to_signal = Box::into_raw(to_signal);
+                let handle = event_new(signal::<S> as usize, to_signal as usize);
+                return Event(handle);
+            }
+
+            unsafe extern "C" fn signal<S: Signal>(data: usize, is_drop: u32) {
+                let data = Box::from_raw(data as *mut S);
+                if is_drop == 0 {
+                    data.signal();
+                }
+            }
+        }
+
+        pub fn signal(self) {
+            unsafe {
+                event_signal(self.0, 0);
+                mem::forget(self);
+            }
+        }
+    }
+
+    impl Drop for Event {
+        fn drop(&mut self) {
+            unsafe {
+                event_signal(self.0, 1);
+            }
         }
     }
 }

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -51,3 +51,7 @@ test = false
 [[bin]]
 name = "async_functions"
 test = false
+
+[[bin]]
+name = "async_raw"
+test = false

--- a/crates/test-rust-wasm/src/bin/async_raw.rs
+++ b/crates/test-rust-wasm/src/bin/async_raw.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/async_raw/wasm.rs");
+
+fn main() {}

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -12,6 +12,7 @@ wasmtime = "0.30.0"
 witx-bindgen-wasmtime-impl = { path = "../wasmtime-impl", version = "0.1" }
 tracing-lib = { version = "0.1.26", optional = true, package = 'tracing' }
 async-trait = { version = "0.1.50", optional = true }
+tokio = { version = "1.12", features = ['rt', 'sync'], optional = true }
 
 [features]
 # Enables generated code to emit events via the `tracing` crate whenever wasm is
@@ -21,7 +22,7 @@ tracing = ['tracing-lib', 'witx-bindgen-wasmtime-impl/tracing']
 
 # Enables async support for generated code, although when enabled this still
 # needs to be configured through the macro invocation.
-async = ['async-trait', 'witx-bindgen-wasmtime-impl/async']
+async = ['async-trait', 'witx-bindgen-wasmtime-impl/async', 'tokio', 'wasmtime/async']
 
 # Enables the ability to parse the old s-expression-based `*.witx` format.
 old-witx-compat = ['witx-bindgen-wasmtime-impl/old-witx-compat']

--- a/crates/wasmtime/src/futures.rs
+++ b/crates/wasmtime/src/futures.rs
@@ -1,0 +1,295 @@
+use crate::rt::RawMem;
+use crate::slab::Slab;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use wasmtime::Table;
+use wasmtime::{StoreContextMut, Trap};
+
+pub struct Async<T> {
+    exports: Slab<FutureState>,
+
+    table: Option<Table>,
+
+    /// List of imports that we're waiting on.
+    ///
+    /// This is a list of async imports that have been called as part of calling
+    /// wasm and are registered here. When these imports complete they produce a
+    /// result which then itself produces another future. The result is given a
+    /// `StoreContextMut` and is expected to further execute WebAssembly,
+    /// translating the results of the async host import to wasm and then
+    /// invoking the wasm completion callback. When the wasm completion callback
+    /// is finished then the future is complete.
+    //
+    // TODO: should this be in `FutureState` because imports-called are a
+    // per-export thing?
+    imports: Vec<Pin<Box<dyn Future<Output = ImportResult<T>> + Send>>>,
+}
+
+impl<T> Default for Async<T> {
+    fn default() -> Async<T> {
+        Async {
+            exports: Slab::default(),
+            imports: Vec::new(),
+            table: None,
+        }
+    }
+}
+
+struct FutureState {
+    results: Vec<i64>, // TODO: shouldn't need to heap-allocate this
+    done: bool,
+}
+
+pub type HostFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+/// The result of a host import. This is mostly synthesized by bindings and
+/// represents that a host import produces a closure. The closure is given
+/// context to execute WebAssembly and then the execution itself results in a
+/// future. This returned future represents the completion of the WebAssembly
+/// itself.
+pub type ImportResult<T> = Box<
+    dyn for<'a> FnOnce(
+            &'a mut StoreContextMut<'_, T>,
+        ) -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>
+        + Send,
+>;
+
+impl<T> Async<T> {
+    /// Implementation of the `async_export_done` canonical ABI function.
+    ///
+    /// The first two parameters are provided by wasm itself, and the `mem` is
+    /// the wasm's linear memory. The first parameter `cx` is the original value
+    /// returned by `start_async_export` and indicates which call to which
+    /// export is being completed. The `ptr` is a pointer into `mem` where the
+    /// encoded results are located.
+    pub fn async_export_done(&mut self, cx: i32, ptr: i32, mem: &[u8]) -> Result<(), Trap> {
+        let cx = cx as u32;
+        let dst = self
+            .exports
+            .get_mut(cx)
+            .ok_or_else(|| Trap::new("async context not valid"))?;
+        if dst.done {
+            return Err(Trap::new("async context not valid"));
+        }
+        dst.done = true;
+        for slot in dst.results.iter_mut() {
+            let ptr = (ptr as u32)
+                .checked_add(8)
+                .ok_or_else(|| Trap::new("pointer to async completion not valid"))?;
+            *slot = mem.load(ptr as i32)?;
+        }
+        Ok(())
+    }
+
+    /// Registers a new future returned from an async import.
+    ///
+    /// This function is used when an async import is invoked by wasm. The
+    /// asynchronous import is represented as a future and when the future
+    /// completes it needs to call the completion callback in WebAssembly. The
+    /// invocation of the completion callback is represented by the output of
+    /// the future here, the `ImportResult` which is a closure that takes a
+    /// store context and invokes WebAssembly (further in an async fashion).
+    ///
+    /// Note that this doesn't actually do anything, it simply enqueues the
+    /// future internally. The future will actually be driven from the
+    /// `wait_for_async_export` function below.
+    pub fn register_async_import(
+        &mut self,
+        future: impl Future<Output = ImportResult<T>> + Send + 'static,
+    ) {
+        self.imports.push(Box::pin(future));
+    }
+
+    /// Blocks on the completion of an asynchronous export.
+    ///
+    /// This function is used to await the result of an async export. In other
+    /// words this is used to wait for wasm to invoke the completion callback
+    /// with the `async_cx` specified.
+    ///
+    /// This will "block" for one of two reasons:
+    ///
+    /// * First is that an async import was called and the wasm's completion
+    ///   callback wasn't called yet. In this scenario this function will block
+    ///   on the completion of the async import.
+    ///
+    /// * Second is the execution of the wasm's own import completion callback.
+    ///   This execution of WebAssembly may be asynchronous due to things like
+    ///   fuel context switching or similar.
+    ///
+    /// This function invokes WebAssembly within `cx` and will not return until
+    /// the completion callback for `async_cx` is invoked. When the completion
+    /// callback is invoked the results of the callback are written into
+    /// `results`. The `get_state` method is used to extract an `Async<T>` from
+    /// the store state within `cx`.
+    ///
+    /// This returns `Ok(())` when the completion callback was successfully
+    /// invoked, but it may also return `Err(trap)` if a trap happens while
+    /// executing a wasm completion callback for an import.
+    pub async fn call_async_export(
+        cx: &mut StoreContextMut<'_, T>,
+        results: &mut [i64],
+        get_state: &(dyn Fn(&mut T) -> &mut Async<T> + Send + Sync),
+        invoke_wasm: impl for<'a> FnOnce(
+            &'a mut StoreContextMut<'_, T>,
+            i32,
+        )
+            -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>,
+    ) -> Result<(), Trap> {
+        // First register a new export happening in our slab of running
+        // `exports` futures.
+        //
+        // NB: at this time due to take `&mut StoreContextMut` as an argument to
+        // this function it means that the size of `exports` is at most one. In
+        // the future this will probably take some sort of async mutex and only
+        // hold the mutex when wasm is running to allow concurrent execution of
+        // wasm.
+        let async_cx = get_state(cx.data_mut()).exports.insert(FutureState {
+            results: vec![0; results.len()],
+            done: false,
+        });
+
+        // Once the registration is made we immediately construct the
+        // `WaitForAsyncExport` helper struct. The destructor of this struct
+        // will forcibly remove the registration we just made above to prevent
+        // leaking anything if the wasm future is dropped and forgotten about.
+        let waiter = WaitForAsyncExport {
+            cx,
+            async_cx,
+            get_state,
+        };
+
+        // Now that things are set up this is the original invocation of
+        // WebAssembly. This invocation is itself asynchronous hence we await
+        // the result here.
+        invoke_wasm(waiter.cx, async_cx as i32).await?;
+
+        // Once we've invoked the export then it's our job to wait for the
+        // `async_export_done` function to get invoked. That happens here as we
+        // observer the state of `async_cx` within `state.exports`. If it's not
+        // finished yet then that means that we need to wait for the next of a
+        // set of futures to complete (those in `state.imports`), which is
+        // deferred to the `WaitForNextFuture` helper struct.
+        loop {
+            let state = (waiter.get_state)(waiter.cx.data_mut());
+            if state.exports.get(async_cx).unwrap().done {
+                break;
+            }
+
+            let result = WaitForNextFuture { state }.await?;
+
+            // TODO: while this is executing we're not polling the futures
+            // inside of `Async<T>`, is that ok? Will this need to poll the
+            // future inside the state in parallel with the async wasm here to
+            // ensure that things work out as expected.
+            result(waiter.cx).await?;
+        }
+
+        // If we're here then that means that the `async_export_done` function
+        // was called, which means taht we can copy the results into the final
+        // `results` slice.
+        let future = (waiter.get_state)(waiter.cx.data_mut())
+            .exports
+            .get(async_cx)
+            .unwrap();
+        assert_eq!(results.len(), future.results.len());
+        results.copy_from_slice(&future.results);
+        return Ok(());
+
+        /// This is a helper struct used to remove `async_cx` from `cx` on drop.
+        ///
+        /// This ensures that if any wasm returns a trap or if the future itself
+        /// is entirely dropped that we properly clean things up and don't leak
+        /// the export's async status and allow it to accidentally be
+        /// "completed" by someone else.
+        struct WaitForAsyncExport<'a, 'b, 'c, 'd, T> {
+            cx: &'a mut StoreContextMut<'b, T>,
+            async_cx: u32,
+            get_state: &'c (dyn Fn(&mut T) -> &mut Async<T> + Send + Sync + 'd),
+        }
+
+        impl<T> Drop for WaitForAsyncExport<'_, '_, '_, '_, T> {
+            fn drop(&mut self) {
+                (self.get_state)(self.cx.data_mut())
+                    .exports
+                    .remove(self.async_cx)
+                    .unwrap();
+            }
+        }
+    }
+
+    /// Returns the previously configured function table via `set_table`.
+    //
+    // TODO: this probably isn't the right interface, need to figure out a
+    // better way to pass this table (and other intrinsics to the wasm instance)
+    // around.
+    pub fn table(&self) -> Table {
+        self.table.expect("table wasn't set yet")
+    }
+
+    /// Stores a table to later get returned by `table()`.
+    //
+    // TODO: like `table`, this probably isn't the right interface
+    pub fn set_table(&mut self, table: Table) {
+        assert!(self.table.is_none(), "table already set");
+        self.table = Some(table);
+    }
+}
+
+struct WaitForNextFuture<'a, T> {
+    state: &'a mut Async<T>,
+}
+
+impl<T> Future for WaitForNextFuture<'_, T> {
+    type Output = Result<ImportResult<T>, Trap>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // If there aren't any active imports then that means that WebAssembly
+        // hasn't invoked the completion callback for an export but it also
+        // didn't call any imports to block on anything. That means that the
+        // completion callback will never be called which is an error, so
+        // simulate a trap happening and report it to the embedder.
+        if self.state.imports.len() == 0 {
+            return Poll::Ready(Err(Trap::new(
+                "wasm isn't waiting on any imports but export completion callback wasn't called",
+            )));
+        }
+
+        // If we have imports then we'll "block" this current future on one of
+        // the sub-futures within `self.state.imports`. By polling at least one
+        // future that means we'll get re-awakened whenever the sub-future is
+        // ready and we'll check here again.
+        //
+        // If anything is ready we return the first item that we get. This means
+        // that if any import has its result ready then we propagate the result
+        // outwards which will invoke the completion callback for that import's
+        // execution. If, after running the import completion callback, the
+        // export completion callback still hasn't been invoked then we'll come
+        // back here and look for other finished imports.
+        //
+        // TODO: this can theoretically exhibit quadratic behavior if the wasm
+        // calls tons and tons of imports. This should use a more intelligent
+        // future-polling mechanism to avoid re-polling everything we're not
+        // interested in every time.
+        for (i, import) in self.state.imports.iter_mut().enumerate() {
+            match import.as_mut().poll(cx) {
+                Poll::Ready(value) => {
+                    drop(self.state.imports.swap_remove(i));
+                    return Poll::Ready(Ok(value));
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+fn _assert() {
+    fn _assert_send<T: Send>(_: &T) {}
+
+    fn _test(x: &mut StoreContextMut<'_, ()>) {
+        let f = Async::<()>::call_async_export(x, &mut [], &|_| panic!(), |_, _| panic!());
+        _assert_send(&f);
+    }
+}

--- a/crates/wasmtime/src/futures.rs
+++ b/crates/wasmtime/src/futures.rs
@@ -1,295 +1,822 @@
-use crate::rt::RawMem;
 use crate::slab::Slab;
+use std::any::Any;
+use std::cell::{Cell, RefCell};
 use std::future::Future;
+use std::mem;
 use std::pin::Pin;
-use std::task::{Context, Poll};
-use wasmtime::Table;
-use wasmtime::{StoreContextMut, Trap};
+use std::sync::{Arc, Weak};
+use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedSender};
+use tokio::task::JoinHandle;
+use wasmtime::{AsContextMut, Caller, Memory, Store, StoreContextMut, Table, Trap};
 
 pub struct Async<T> {
-    exports: Slab<FutureState>,
+    function_table: Table,
 
-    table: Option<Table>,
-
-    /// List of imports that we're waiting on.
+    /// Channel used to send messages to the main event loop where this
+    /// `Async<T>` is managed.
     ///
-    /// This is a list of async imports that have been called as part of calling
-    /// wasm and are registered here. When these imports complete they produce a
-    /// result which then itself produces another future. The result is given a
-    /// `StoreContextMut` and is expected to further execute WebAssembly,
-    /// translating the results of the async host import to wasm and then
-    /// invoking the wasm completion callback. When the wasm completion callback
-    /// is finished then the future is complete.
-    //
-    // TODO: should this be in `FutureState` because imports-called are a
-    // per-export thing?
-    imports: Vec<Pin<Box<dyn Future<Output = ImportResult<T>> + Send>>>,
+    /// Note that this is stored in a `Weak` pointer to not hold a strong
+    /// reference to it because this `Async<T>` is owned by the event loop which
+    /// is otherwise terminated when the `Sender<T>` is gone, hence if this were
+    /// a strong reference it would loop forever.
+    ///
+    /// The main strong reference to this channel is held by a generated struct
+    /// that will live in user code on some other task. Other references to this
+    /// sender, also weak though, will live in each imported async host function
+    /// when invoked.
+    sender: Weak<Sender<Message<T>>>,
+
+    /// The list of active WebAssembly coroutines that are executing in this
+    /// event loop.
+    ///
+    /// Note that for now the term "coroutine" here is specifically used for the
+    /// interface-types notion of a coroutine and does not correspond to a
+    /// literal coroutine/fiber on the host. Interface types coroutines are only
+    /// implemented right now with the callback ABI, meaning there's no
+    /// coroutine in the sense of "there's a suspended host stack" somewhere.
+    /// Instead wasm retains all state necessary for resumption and such.
+    ///
+    /// This list of active coroutines will have one-per-export called and when
+    /// suspended the coroutines here are all guaranteed to have pending imports
+    /// they're waiting on.
+    ///
+    /// Note that internally `Coroutines<T>` is simply a `Slab<Coroutine<T>>`
+    /// and is only structured this way to have lookups via `&CoroutineId`
+    /// instead of `u32` as slabs do.
+    coroutines: RefCell<Coroutines<T>>,
+
+    /// The "currently active" coroutine.
+    ///
+    /// This is used to persist state in the host about what coroutine is
+    /// currently active so that when an import is called we can automatically
+    /// assign that import's "thread" of execution to the currently active
+    /// coroutine, adding it to the right import list. This enables keeping
+    /// track on the host for what imports are used where and what to cancel
+    /// whenever one coroutine aborts (if at all).
+    cur_wasm_coroutine: CoroutineId,
+
+    /// The next unique ID to hand out to a coroutine.
+    ///
+    /// This is a monotonically increasing counter which is intended to be
+    /// unique for all coroutines for the lifetime of a program. This is a
+    /// generational index of sorts which prevents accidentally resuing slab
+    /// indices in the `coroutines` array.
+    cur_unique_id: Cell<u64>,
 }
 
-impl<T> Default for Async<T> {
-    fn default() -> Async<T> {
-        Async {
-            exports: Slab::default(),
-            imports: Vec::new(),
-            table: None,
-        }
-    }
+/// An "integer" identifier for a coroutine.
+///
+/// This is used to uniquely identify a logical coroutine of WebAssembly
+/// execution, and internally contains the slab index it's stored at as well as
+/// a unique generational ID.
+#[derive(Copy, Clone)]
+pub struct CoroutineId {
+    slab_index: u32,
+    unique_id: u64,
 }
 
-struct FutureState {
-    results: Vec<i64>, // TODO: shouldn't need to heap-allocate this
-    done: bool,
+struct Coroutines<T> {
+    slab: Slab<Coroutine<T>>,
+}
+
+enum Message<T> {
+    Execute(Start<T>, Complete<T>, UnboundedSender<CoroutineResult>),
+    RunNoCoroutine(RunStandalone<T>, UnboundedSender<CoroutineResult>),
+    FinishImport(Callback<T>, CoroutineId, u32),
+    Cancel(CoroutineId),
+}
+
+struct Coroutine<T> {
+    /// A unique ID for this coroutine which is used to ensure that even if this
+    /// coroutine's slab index is reused a `CoroutineId` uniquely points to one
+    /// logical coroutine. This mostly comes up where when a coroutine exits
+    /// early due to a trap we need to make sure that even if the slab slot is
+    /// reused we don't accidentally use some future coroutine for lingering
+    /// completion callbacks.
+    unique_id: u64,
+
+    /// A list of spawned tasks corresponding to imported host functions that
+    /// this coroutine is waiting on. This list is appended to whenever an async
+    /// host function is invoked and it's removed from when the host function
+    /// completes (and the message gets back to the main loop).
+    ///
+    /// The primary purpose of this list is so that when a coroutine fails (via
+    /// a trap) that all of the spawned host work for the coroutine can exit
+    /// ASAP via an `abort()` signal on the `JoinHandle<T>`.
+    pending_imports: Slab<JoinHandle<()>>,
+
+    /// The number of imports that we're waiting on, corresponding to the number
+    /// of present entries in `pending_imports`.
+    num_pending_imports: usize,
+
+    /// A callback to invoke whenever a coroutine's `async_export_done`
+    /// completion callback is invoked. This is used by the host to deserialize
+    /// the results from WebAssembly (possibly doing things like wasm
+    /// malloc/free) and then sending the results on a channel.
+    ///
+    /// Typically this contains a `Sender<T>` internally within this closure
+    /// which gets a message once all the wasm arguments have been successfully
+    /// deserialized.
+    complete: Option<Complete<T>>,
+
+    sender: UnboundedSender<CoroutineResult>,
+    cancel_task: Option<JoinHandle<()>>,
 }
 
 pub type HostFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-
-/// The result of a host import. This is mostly synthesized by bindings and
-/// represents that a host import produces a closure. The closure is given
-/// context to execute WebAssembly and then the execution itself results in a
-/// future. This returned future represents the completion of the WebAssembly
-/// itself.
-pub type ImportResult<T> = Box<
+pub type CoroutineResult = Result<Box<dyn Any + Send>, Trap>;
+pub type Start<T> = Box<
+    dyn for<'a> FnOnce(
+            &'a mut StoreContextMut<'_, T>,
+            u32,
+        ) -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>
+        + Send,
+>;
+pub type Callback<T> = Box<
     dyn for<'a> FnOnce(
             &'a mut StoreContextMut<'_, T>,
         ) -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>
         + Send,
 >;
-
-impl<T> Async<T> {
-    /// Implementation of the `async_export_done` canonical ABI function.
-    ///
-    /// The first two parameters are provided by wasm itself, and the `mem` is
-    /// the wasm's linear memory. The first parameter `cx` is the original value
-    /// returned by `start_async_export` and indicates which call to which
-    /// export is being completed. The `ptr` is a pointer into `mem` where the
-    /// encoded results are located.
-    pub fn async_export_done(&mut self, cx: i32, ptr: i32, mem: &[u8]) -> Result<(), Trap> {
-        let cx = cx as u32;
-        let dst = self
-            .exports
-            .get_mut(cx)
-            .ok_or_else(|| Trap::new("async context not valid"))?;
-        if dst.done {
-            return Err(Trap::new("async context not valid"));
-        }
-        dst.done = true;
-        for slot in dst.results.iter_mut() {
-            let ptr = (ptr as u32)
-                .checked_add(8)
-                .ok_or_else(|| Trap::new("pointer to async completion not valid"))?;
-            *slot = mem.load(ptr as i32)?;
-        }
-        Ok(())
-    }
-
-    /// Registers a new future returned from an async import.
-    ///
-    /// This function is used when an async import is invoked by wasm. The
-    /// asynchronous import is represented as a future and when the future
-    /// completes it needs to call the completion callback in WebAssembly. The
-    /// invocation of the completion callback is represented by the output of
-    /// the future here, the `ImportResult` which is a closure that takes a
-    /// store context and invokes WebAssembly (further in an async fashion).
-    ///
-    /// Note that this doesn't actually do anything, it simply enqueues the
-    /// future internally. The future will actually be driven from the
-    /// `wait_for_async_export` function below.
-    pub fn register_async_import(
-        &mut self,
-        future: impl Future<Output = ImportResult<T>> + Send + 'static,
-    ) {
-        self.imports.push(Box::pin(future));
-    }
-
-    /// Blocks on the completion of an asynchronous export.
-    ///
-    /// This function is used to await the result of an async export. In other
-    /// words this is used to wait for wasm to invoke the completion callback
-    /// with the `async_cx` specified.
-    ///
-    /// This will "block" for one of two reasons:
-    ///
-    /// * First is that an async import was called and the wasm's completion
-    ///   callback wasn't called yet. In this scenario this function will block
-    ///   on the completion of the async import.
-    ///
-    /// * Second is the execution of the wasm's own import completion callback.
-    ///   This execution of WebAssembly may be asynchronous due to things like
-    ///   fuel context switching or similar.
-    ///
-    /// This function invokes WebAssembly within `cx` and will not return until
-    /// the completion callback for `async_cx` is invoked. When the completion
-    /// callback is invoked the results of the callback are written into
-    /// `results`. The `get_state` method is used to extract an `Async<T>` from
-    /// the store state within `cx`.
-    ///
-    /// This returns `Ok(())` when the completion callback was successfully
-    /// invoked, but it may also return `Err(trap)` if a trap happens while
-    /// executing a wasm completion callback for an import.
-    pub async fn call_async_export(
-        cx: &mut StoreContextMut<'_, T>,
-        results: &mut [i64],
-        get_state: &(dyn Fn(&mut T) -> &mut Async<T> + Send + Sync),
-        invoke_wasm: impl for<'a> FnOnce(
+pub type Complete<T> = Box<
+    dyn for<'a> FnOnce(
             &'a mut StoreContextMut<'_, T>,
             i32,
-        )
-            -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>,
-    ) -> Result<(), Trap> {
-        // First register a new export happening in our slab of running
-        // `exports` futures.
-        //
-        // NB: at this time due to take `&mut StoreContextMut` as an argument to
-        // this function it means that the size of `exports` is at most one. In
-        // the future this will probably take some sort of async mutex and only
-        // hold the mutex when wasm is running to allow concurrent execution of
-        // wasm.
-        let async_cx = get_state(cx.data_mut()).exports.insert(FutureState {
-            results: vec![0; results.len()],
-            done: false,
-        });
+            wasmtime::Memory,
+        ) -> Pin<Box<dyn Future<Output = CoroutineResult> + Send + 'a>>
+        + Send,
+>;
+pub type RunStandalone<T> = Box<
+    dyn for<'a> FnOnce(
+            &'a mut StoreContextMut<'_, T>,
+        ) -> Pin<Box<dyn Future<Output = CoroutineResult> + Send + 'a>>
+        + Send,
+>;
 
-        // Once the registration is made we immediately construct the
-        // `WaitForAsyncExport` helper struct. The destructor of this struct
-        // will forcibly remove the registration we just made above to prevent
-        // leaking anything if the wasm future is dropped and forgotten about.
-        let waiter = WaitForAsyncExport {
-            cx,
-            async_cx,
-            get_state,
+impl<T: 'static> Async<T> {
+    /// Spawns a new task which will manage async execution of wasm within the
+    /// `store` provided.
+    pub fn spawn(mut store: Store<T>, function_table: Table) -> AsyncHandle<T>
+    where
+        T: Send,
+    {
+        // This channel is the primary point of communication into the task that
+        // we're going to spawn. This'll be bounded to ensure it doesn't get
+        // overrun, and additionally the sender will be stored in an `Arc` to
+        // ensure that the returned handle is the only owning handle and the
+        // intenral weak handle held by `Async<T>` doesn't keep it alive to let
+        // the task terminate gracefully.
+        let (sender, receiver) = mpsc::channel(5 /* TODO: should this be configurable? */);
+        let sender = Arc::new(sender);
+        let mut cx = Async {
+            function_table,
+            sender: Arc::downgrade(&sender),
+            coroutines: RefCell::new(Coroutines {
+                slab: Slab::default(),
+            }),
+            cur_wasm_coroutine: CoroutineId {
+                slab_index: u32::MAX,
+                unique_id: u64::MAX,
+            },
+            cur_unique_id: Cell::new(0),
         };
 
-        // Now that things are set up this is the original invocation of
-        // WebAssembly. This invocation is itself asynchronous hence we await
-        // the result here.
-        invoke_wasm(waiter.cx, async_cx as i32).await?;
-
-        // Once we've invoked the export then it's our job to wait for the
-        // `async_export_done` function to get invoked. That happens here as we
-        // observer the state of `async_cx` within `state.exports`. If it's not
-        // finished yet then that means that we need to wait for the next of a
-        // set of futures to complete (those in `state.imports`), which is
-        // deferred to the `WaitForNextFuture` helper struct.
-        loop {
-            let state = (waiter.get_state)(waiter.cx.data_mut());
-            if state.exports.get(async_cx).unwrap().done {
-                break;
-            }
-
-            let result = WaitForNextFuture { state }.await?;
-
-            // TODO: while this is executing we're not polling the futures
-            // inside of `Async<T>`, is that ok? Will this need to poll the
-            // future inside the state in parallel with the async wasm here to
-            // ensure that things work out as expected.
-            result(waiter.cx).await?;
-        }
-
-        // If we're here then that means that the `async_export_done` function
-        // was called, which means taht we can copy the results into the final
-        // `results` slice.
-        let future = (waiter.get_state)(waiter.cx.data_mut())
-            .exports
-            .get(async_cx)
-            .unwrap();
-        assert_eq!(results.len(), future.results.len());
-        results.copy_from_slice(&future.results);
-        return Ok(());
-
-        /// This is a helper struct used to remove `async_cx` from `cx` on drop.
-        ///
-        /// This ensures that if any wasm returns a trap or if the future itself
-        /// is entirely dropped that we properly clean things up and don't leak
-        /// the export's async status and allow it to accidentally be
-        /// "completed" by someone else.
-        struct WaitForAsyncExport<'a, 'b, 'c, 'd, T> {
-            cx: &'a mut StoreContextMut<'b, T>,
-            async_cx: u32,
-            get_state: &'c (dyn Fn(&mut T) -> &mut Async<T> + Send + Sync + 'd),
-        }
-
-        impl<T> Drop for WaitForAsyncExport<'_, '_, '_, '_, T> {
-            fn drop(&mut self) {
-                (self.get_state)(self.cx.data_mut())
-                    .exports
-                    .remove(self.async_cx)
-                    .unwrap();
-            }
-        }
+        tokio::spawn(async move { cx.run(&mut store.as_context_mut(), receiver).await });
+        AsyncHandle { sender }
     }
 
-    /// Returns the previously configured function table via `set_table`.
-    //
-    // TODO: this probably isn't the right interface, need to figure out a
-    // better way to pass this table (and other intrinsics to the wasm instance)
-    // around.
-    pub fn table(&self) -> Table {
-        self.table.expect("table wasn't set yet")
-    }
+    pub fn spawn_import(
+        future: impl Future<Output = Callback<T>> + Send + 'static,
+    ) -> Result<(), Trap> {
+        Self::with(|cx| {
+            let sender = cx.sender.clone();
+            // Register a new pending import for the currently executing wasm
+            // coroutine. This will ensure that full completion of this
+            // coroutine is delayed until this import is resolved.
+            let coroutine_id = cx.cur_wasm_coroutine;
+            let mut coroutines = cx.coroutines.borrow_mut();
+            let coroutine = coroutines
+                .get_mut(&coroutine_id)
+                .ok_or_else(|| Trap::new("cannot call async import from non-async export"))?;
+            let pending_import_id = coroutine.pending_imports.next_id();
+            coroutine.num_pending_imports += 1;
 
-    /// Stores a table to later get returned by `table()`.
-    //
-    // TODO: like `table`, this probably isn't the right interface
-    pub fn set_table(&mut self, table: Table) {
-        assert!(self.table.is_none(), "table already set");
-        self.table = Some(table);
-    }
-}
+            // Note that `tokio::spawn` is used here to allow the `future` for
+            // this import to execute in parallel, not just concurrently. The
+            // result is re-acquired via sending a message on our internal
+            // channel.
+            let task = tokio::spawn(async move {
+                let import_result = future.await;
 
-struct WaitForNextFuture<'a, T> {
-    state: &'a mut Async<T>,
-}
-
-impl<T> Future for WaitForNextFuture<'_, T> {
-    type Output = Result<ImportResult<T>, Trap>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // If there aren't any active imports then that means that WebAssembly
-        // hasn't invoked the completion callback for an export but it also
-        // didn't call any imports to block on anything. That means that the
-        // completion callback will never be called which is an error, so
-        // simulate a trap happening and report it to the embedder.
-        if self.state.imports.len() == 0 {
-            return Poll::Ready(Err(Trap::new(
-                "wasm isn't waiting on any imports but export completion callback wasn't called",
-            )));
-        }
-
-        // If we have imports then we'll "block" this current future on one of
-        // the sub-futures within `self.state.imports`. By polling at least one
-        // future that means we'll get re-awakened whenever the sub-future is
-        // ready and we'll check here again.
-        //
-        // If anything is ready we return the first item that we get. This means
-        // that if any import has its result ready then we propagate the result
-        // outwards which will invoke the completion callback for that import's
-        // execution. If, after running the import completion callback, the
-        // export completion callback still hasn't been invoked then we'll come
-        // back here and look for other finished imports.
-        //
-        // TODO: this can theoretically exhibit quadratic behavior if the wasm
-        // calls tons and tons of imports. This should use a more intelligent
-        // future-polling mechanism to avoid re-polling everything we're not
-        // interested in every time.
-        for (i, import) in self.state.imports.iter_mut().enumerate() {
-            match import.as_mut().poll(cx) {
-                Poll::Ready(value) => {
-                    drop(self.state.imports.swap_remove(i));
-                    return Poll::Ready(Ok(value));
+                // If the main task has exited for some reason then it'll never
+                // receive our result, but that's ok since we're trying to
+                // complete a wasm import and if the main task isn't there to
+                // receive it there's nothing else to do with this result. This
+                // being an error is theoretically possible but should be rare.
+                if let Some(sender) = sender.upgrade() {
+                    let send_result = sender
+                        .send(Message::FinishImport(
+                            import_result,
+                            coroutine_id,
+                            pending_import_id,
+                        ))
+                        .await;
+                    drop(send_result);
                 }
-                Poll::Pending => {}
+            });
+
+            let id = coroutine.pending_imports.insert(task);
+            assert_eq!(id, pending_import_id);
+            Ok(())
+        })
+    }
+
+    async fn run(
+        &mut self,
+        store: &mut StoreContextMut<'_, T>,
+        mut receiver: Receiver<Message<T>>,
+    ) {
+        // Infinitely process messages on `receiver` which represent events such as
+        // requests to invoke an export or completion of an import which results in
+        // execution of a completion callback.
+        while let Some(msg) = receiver.recv().await {
+            let coroutines = self.coroutines.get_mut();
+            let (to_execute, coroutine_id) = match msg {
+                // This message is the start of a new task ("coroutine" in
+                // interface-types-vernacular) so we allocate a new task in our
+                // slab and set up its state.
+                //
+                // Note that we spawn a "helper" task here to send a message to
+                // our channel when the `sender` specified here is disconnected.
+                // That scenario means that this coroutine is cancelled and by
+                // sending a message into our channel we can start processing
+                // that.
+                Message::Execute(run, complete, sender) => {
+                    let unique_id = self.cur_unique_id.get();
+                    self.cur_unique_id.set(unique_id + 1);
+                    let coroutine_id = coroutines.next_id(unique_id);
+                    let my_sender = self.sender.clone();
+                    let await_close_sender = sender.clone();
+                    let cancel_task = tokio::spawn(async move {
+                        await_close_sender.closed().await;
+                        // if the main task is gone one way or another we ignore
+                        // the error here since no one's going to receive it
+                        // anyway and all relevant work should be cancelled.
+                        if let Some(sender) = my_sender.upgrade() {
+                            drop(sender.send(Message::Cancel(coroutine_id)).await);
+                        }
+                    });
+                    coroutines.insert(Coroutine {
+                        unique_id,
+                        complete: Some(complete),
+                        sender,
+                        pending_imports: Slab::default(),
+                        num_pending_imports: 0,
+                        cancel_task: Some(cancel_task),
+                    });
+                    (ToExecute::Start(run, coroutine_id.slab_index), coroutine_id)
+                }
+
+                // This message means that we need to execute `run` specified
+                // which is a "non blocking"-in-the-coroutine-sense wasm
+                // function. This is basically "go run that single callback" and
+                // is currently only used for things like resource destructors.
+                // These aren't allowed to call blocking functions and a trap is
+                // generated if they try to call a blocking function (since
+                // there isn't a coroutine set up).
+                //
+                // Note that here we avoid allocating a coroutine entirely since
+                // this isn't actually a coroutine, which means that any attempt
+                // to call a blocking function will be met with failure (a
+                // trap). Additionally note that the actual execution of the
+                // wasm here is select'd against the closure of the `sender`
+                // here as well, since if the runtime becomes disinterested in
+                // the result of this async call we can interrupt and abort the
+                // wasm.
+                //
+                // Finally note that if the wasm completes but we fail to send
+                // the result of the wasm to the receiver then we ignore the
+                // error since that was basically a race between wasm exiting
+                // and the sender being closed.
+                //
+                // TODO: should this dropped result/error get logged/processed
+                // somewhere?
+                Message::RunNoCoroutine(run, sender) => {
+                    tokio::select! {
+                        r = tls::scope(self, run(store)) => {
+                            let is_trap = r.is_err();
+                            let _ = sender.send(r);
+
+                            // Shut down this reactor if a trap happened because
+                            // the instance is now in an indeterminate state.
+                            if is_trap {
+                                break;
+                            }
+                        }
+                        _ = sender.closed() => break,
+                    }
+                    continue;
+                }
+
+                // This message indicates that an import has completed and
+                // the completion callback for the wasm must be executed.
+                // This, plus the serialization of the arguments into wasm
+                // according to the canonical ABI, is represented by
+                // `run`.
+                //
+                // Note, though, that in some cases we don't actually run
+                // the completion callback. For example if a previous
+                // completion callback for this wasm task has failed with a
+                // trap we don't continue to run completion callbacks for
+                // the wasm task. This situation is indicated when the
+                // coroutine is not actually present in our `coroutines`
+                // list, so we do a lookup here before allowing execution. When
+                // the coroutine isn't present we simply skip this message which
+                // will run destructors for any relevant host values.
+                Message::FinishImport(run, coroutine_id, import_id) => {
+                    let coroutine = match coroutines.get_mut(&coroutine_id) {
+                        Some(c) => c,
+                        None => continue,
+                    };
+                    coroutine.pending_imports.remove(import_id).unwrap();
+                    coroutine.num_pending_imports -= 1;
+                    (ToExecute::Callback(run), coroutine_id)
+                }
+
+                // This message indicates that the specified coroutine has been
+                // cancelled, meaning that the sender which would send back the
+                // result of the coroutine is now a closed channel that we can
+                // no longer send a message along. Our response to this is to
+                // remove the coroutine, and its destructor will trigger further
+                // cancellation if necessary.
+                //
+                // Note that this message may race with the actual completion of
+                // the coroutine so we don't assert that the ID specified here
+                // is actually in our list. If a coroutine is removed though we
+                // assume that the wasm is now in an indeterminate state which
+                // results in aborting this reactor task. If nothing is removed
+                // then we assume the race was properly resolved and we skip
+                // this message.
+                Message::Cancel(coroutine_id) => {
+                    if coroutines.remove(&coroutine_id).is_some() {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            // Actually execute the WebAssembly callback. The call to
+            // `to_execute.run` here is what will actually execute WebAssembly
+            // asynchronously, and note that it's also executed within a
+            // `tls::scope` to ensure that the `tls::with` function will work
+            // for the duration of the future.
+            //
+            // Also note, though, that we want to be able to cancel the
+            // execution of this WebAssembly if the caller becomes disinterested
+            // in the result. This happens by using the `closed()` method on the
+            // channel back to the sender, and if that happens we abort wasm
+            // entirely and abort the whole coroutine by removing it later.
+            //
+            // If this wasm operations is aborted then we exit this loop
+            // entirely and tear down this reactor task. That triggers
+            // cancellation of all spawned sub-tasks and sibling coroutines, and
+            // the rationale for this is that we zapped wasm while it was
+            // executing so it's now in an indeterminate state and not one that
+            // we can resume.
+            //
+            // TODO: this is a `clone()`-per-callback which is probably cheap,
+            // but this is also a sort of wonky setup so this may wish to change
+            // in the future.
+            let cancel_signal = coroutines.get_mut(&coroutine_id).unwrap().sender.clone();
+            let prev_coroutine_id = mem::replace(&mut self.cur_wasm_coroutine, coroutine_id);
+            let result = tokio::select! {
+                r = tls::scope(self, to_execute.run(store)) => r,
+                _ = cancel_signal.closed() => break,
+            };
+            self.cur_wasm_coroutine = prev_coroutine_id;
+
+            let coroutines = self.coroutines.get_mut();
+            let coroutine = coroutines.get_mut(&coroutine_id).unwrap();
+            if let Err(trap) = result {
+                // Our WebAssembly callback trapped. That means that this
+                // entire coroutine is now in a failure state. No further
+                // wasm callbacks will be invoked and the coroutine is
+                // removed from out internal list to invoke the failure
+                // callback, informing what trap caused the failure.
+                //
+                // Note that this reopens `coroutine_id.slab_index` to get
+                // possibly reused, intentionally so, which is why
+                // `CoroutineId` is a form of generational ID which is
+                // resilient to this form of reuse. In other words when we
+                // remove the result here if in the future a pending import
+                // for this coroutine completes we'll simply discard the
+                // message.
+                //
+                // Any error in sending the trap along the coroutine's channel
+                // is ignored since we can race with the coroutine getting
+                // dropped.
+                //
+                // TODO: should the trap still be sent somewhere? Is this ok to
+                // simply ignore?
+                //
+                // Finally we exit the reactor in this case because traps
+                // typically represent fatal conditions for wasm where we can't
+                // really resume since it may be in an indeterminate state (wasm
+                // can't handle traps itself), so after we inform the original
+                // coroutine of the original trap we break out and cancel all
+                // further execution.
+                let coroutine = coroutines.remove(&coroutine_id).unwrap();
+                let _ = coroutine.sender.send(Err(trap));
+                break;
+            } else if coroutine.num_pending_imports == 0 {
+                // Our wasm callback succeeded, and there are no pending
+                // imports for this coroutine.
+                //
+                // In this state it means that the coroutine has completed
+                // since no further work can possibly happen for the
+                // coroutine. This means that we can safely remove it from
+                // our internal list.
+                //
+                // If the coroutine's completion wasn't ever signaled,
+                // however, then that indicates a bug in the wasm code
+                // itself. This bug is translated into a trap which will get
+                // reported to the caller to inform the original invocation
+                // of the export that the result of the coroutine never
+                // actually came about.
+                //
+                // Note that like above a failure to send a trap along the
+                // channel is ignored since we raced with the caller becoming
+                // disinterested in the result which is fine to happen at any
+                // time.
+                //
+                // TODO: should the trap still be sent somewhere? Is this ok to
+                // simply ignore?
+                //
+                // TODO: should this tear down the reactor as well, despite it
+                // being a synthetically created trap?
+                let coroutine = coroutines.remove(&coroutine_id).unwrap();
+                if coroutine.complete.is_some() {
+                    let _ = coroutine
+                        .sender
+                        .send(Err(Trap::new("completion callback never called")));
+                }
+            } else {
+                // Our wasm callback succeeded, and there are pending
+                // imports for this coroutine.
+                //
+                // This means that the coroutine isn't finished yet so we
+                // simply turn the loop and wait for something else to
+                // happen. We'll next be executing WebAssembly when one of
+                // the coroutine's imports finish.
             }
         }
+    }
 
-        Poll::Pending
+    pub async fn async_export_done(
+        mut caller: Caller<'_, T>,
+        task_id: i32,
+        ptr: i32,
+        mem: Memory,
+    ) -> Result<(), Trap> {
+        // Extract the completion callback registered in Rust for the `task_id`.
+        // This will deserialize all of the canonical ABI results specified by
+        // `ptr`, and presumably send the result on some sort of channel back to the
+        // task that originally invoked the wasm.
+        let task_id = task_id as u32;
+        let complete = Self::with(|cx| {
+            let mut coroutines = cx.coroutines.borrow_mut();
+            let coroutine = coroutines
+                .slab
+                .get_mut(task_id)
+                .ok_or_else(|| Trap::new("async context not valid"))?;
+            coroutine
+                .complete
+                .take()
+                .ok_or_else(|| Trap::new("async context not valid"))
+        })?;
+
+        // Note that this is an async-enabled call to allow `call_async` for things
+        // like fuel in case the completion callback needs to invoke wasm
+        // asychronously for things like deallocation.
+        let result = complete(&mut caller.as_context_mut(), ptr, mem).await?;
+
+        // With the final result of the coroutine we send this along the channel
+        // back to the original task which was waiting for the result. Note that
+        // this send may fail if we're racing with cancellation of this task,
+        // and if cancellation happens we translate that to a trap to ensure
+        // that wasm is cleaned up quickly (as oppose to waiting for the next
+        // yield point where it should get cleaned up anyway).
+        Self::with(|cx| {
+            let mut coroutines = cx.coroutines.borrow_mut();
+            let coroutine = coroutines.slab.get_mut(task_id).unwrap();
+            coroutine
+                .sender
+                .send(Ok(result))
+                .map_err(|_| Trap::new("task has been cancelled"))
+        })
+    }
+
+    // TODO: this is a pretty bad interface to manage the table with...
+    pub fn function_table() -> Table {
+        Self::with(|cx| cx.function_table)
+    }
+
+    fn with<R>(f: impl FnOnce(&Async<T>) -> R) -> R {
+        tls::with(|cx| f(cx.downcast_ref().unwrap()))
     }
 }
 
-fn _assert() {
-    fn _assert_send<T: Send>(_: &T) {}
+impl<T> Coroutines<T> {
+    fn next_id(&self, unique_id: u64) -> CoroutineId {
+        CoroutineId {
+            unique_id,
+            slab_index: self.slab.next_id(),
+        }
+    }
 
-    fn _test(x: &mut StoreContextMut<'_, ()>) {
-        let f = Async::<()>::call_async_export(x, &mut [], &|_| panic!(), |_, _| panic!());
-        _assert_send(&f);
+    fn insert(&mut self, coroutine: Coroutine<T>) -> CoroutineId {
+        let unique_id = coroutine.unique_id;
+        let slab_index = self.slab.insert(coroutine);
+        CoroutineId {
+            unique_id,
+            slab_index,
+        }
+    }
+
+    fn get_mut(&mut self, id: &CoroutineId) -> Option<&mut Coroutine<T>> {
+        let entry = self.slab.get_mut(id.slab_index)?;
+        if entry.unique_id == id.unique_id {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    fn remove(&mut self, id: &CoroutineId) -> Option<Coroutine<T>> {
+        let entry = self.slab.get_mut(id.slab_index)?;
+        if entry.unique_id == id.unique_id {
+            self.slab.remove(id.slab_index)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Drop for Coroutine<T> {
+    fn drop(&mut self) {
+        // When a coroutine is removed and dropped from the internal list of
+        // coroutines then we're no longer interested in any of the results for
+        // any of the spawned tasks. This means we can proactively cancel
+        // anything that this coroutine might be waiting on (imported functions)
+        // plus the task that's used to send a message to the "main loop" on
+        // cancellation.
+        if let Some(task) = &self.cancel_task {
+            task.abort();
+        }
+        for task in self.pending_imports.iter() {
+            task.abort();
+        }
+    }
+}
+
+enum ToExecute<T> {
+    Start(Start<T>, u32),
+    Callback(Callback<T>),
+}
+
+impl<T> ToExecute<T> {
+    async fn run(self, store: &mut StoreContextMut<'_, T>) -> Result<(), Trap> {
+        match self {
+            ToExecute::Start(cb, val) => cb(store, val).await,
+            ToExecute::Callback(cb) => cb(store).await,
+        }
+    }
+}
+
+pub struct AsyncHandle<T> {
+    sender: Arc<Sender<Message<T>>>,
+}
+
+impl<T: Send> AsyncHandle<T> {
+    /// Executes a new WebAssembly in the "reactor" that this handle is
+    /// connected to.
+    ///
+    /// This function will execute `start` as the initial callback for the
+    /// asynchronous WebAssembly to be executed. This closure receives the
+    /// `Store<T>` via a handle as well as the coroutine ID that's associated
+    /// with this new coroutine. It's expected that this callback produces a
+    /// future which represents the execution of the initial WebAssembly
+    /// callback, handling all canonical ABI translations internally.
+    ///
+    /// The second `complete` callback is invoked when the wasm indicates that
+    /// it's finished executing (the `async_export_done` intrinsic wasm
+    /// import). This is expected to produce the final result of the function.
+    ///
+    /// This function is an `async` function which is expected to be `.await`'d.
+    /// If this function's future is dropped or cancelled then the coroutine
+    /// that this executes will also be dropped/cancelled. If a wasm trap
+    /// happens then that will be returned here and the coroutine will be
+    /// cancelled.
+    ///
+    /// Note that it is possible for wasm to invoke the completion callback and
+    /// still trap. In situations like that the trap is returned from this
+    /// function.
+    pub async fn execute<U>(
+        &self,
+        start: impl for<'a> FnOnce(
+                &'a mut StoreContextMut<'_, T>,
+                u32,
+            )
+                -> Pin<Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>>
+            + Send
+            + 'static,
+        complete: impl for<'a> FnOnce(
+                &'a mut StoreContextMut<'_, T>,
+                i32,
+                wasmtime::Memory,
+            )
+                -> Pin<Box<dyn Future<Output = Result<U, Trap>> + Send + 'a>>
+            + Send
+            + 'static,
+    ) -> Result<U, Trap>
+    where
+        U: Send + 'static,
+    {
+        // Note that this channel should have at most 2 messages ever sent on it
+        // so it's easier to deal with an unbounded channel rather than a
+        // bounded channel.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // Send a request to our "reactor task" which indicates that we'd like
+        // to start execution of a new WebAssembly coroutine. The start/complete
+        // callbacks provided here are the implementation of the canonical ABI
+        // for this particular coroutine.
+        //
+        // Note that failure to send here turns into a trap. This can happen
+        // when the reactor task is torn down, taking the receiver with it. When
+        // wasm traps this can happen, and this means that the wasm is no longer
+        // present for execution so we continue to propagate traps with a new
+        // synthetic trap here.
+        self.sender
+            .send(Message::Execute(
+                Box::new(start),
+                Box::new(move |store, ptr, mem| {
+                    Box::pin(async move {
+                        let val = complete(store, ptr, mem).await?;
+                        Ok(Box::new(val) as Box<dyn Any + Send>)
+                    })
+                }),
+                tx,
+            ))
+            .await
+            .map_err(|_| Trap::new("wasm reactor task has gone away -- sibling trap?"))?;
+
+        // This is a bit of a tricky dance. Once WebAssembly is requested to be
+        // executed there are a number of outcomes that can happen here:
+        //
+        // 1. The WebAssembly coroutine could complete successfully. This means
+        //    that it eventually invokes the completion callback and no traps
+        //    happened. In this case the completion value is sent on the channel
+        //    and then when the wasm is all finished then the sending half of
+        //    the channel is destroyed.
+        //
+        // 2. The WebAssembly coroutine could trap before invoking its
+        //    completion callback. In this scenario the first message is a trap
+        //    and there will be no second message because the coroutine is
+        //    destroyed after a trap.
+        //
+        // 3. The WebAssembly coroutine could give us a completed value
+        //    successfully, but then afterwards may trap. In this situation the
+        //    first message received is the completed value of the coroutine,
+        //    and the second message will be the trap that occurred.
+        //
+        // 4. Finally a the reactor coudl get torn down because of wasm hitting
+        //    a trap (leaving it in an indeterminate state) or a bug in the
+        //    reactor that panicked.
+        //
+        // Overall this leads us to two separate `.await` calls. The first
+        // `.await` receives the first message and "propagates" traps in (4)
+        // assuming that the reactor is gone due to a wasm trap. This first
+        // result is `Ok` in (1)/(3), and it's `Err` in the case of (2).
+        //
+        // The second `.await` will wait for the full completion of the
+        // coroutine in (1) but then receive `None`, should immediately receive
+        // `None` for (2), and will receive a trap with (3). In all situations
+        // we are guaranteed that after the second message the coroutine is
+        // deleted and cleaned up.
+        //
+        // Note that receiving `Ok` as the second message is not possible
+        // because the completion callback is invoked at most once and it's only
+        // invoked if no trap has happened, which means that a successful
+        // completion callback is guaranteed to be the first message.
+        //
+        // TODO: the time that passes between the first `.await` and the second
+        // `.await` is not exposed with this function's signature. This is
+        // simply a bland async function that returns the result, but embedders
+        // may want to process a successful result which later traps. This API
+        // should probably be redesigned to accommodate this.
+        let result = rx
+            .recv()
+            .await
+            .ok_or_else(|| Trap::new("wasm reactor task has gone away -- sibling trap?"))?;
+        match rx.recv().await {
+            Some(Err(trap)) => Err(trap),
+            Some(Ok(_)) => unreachable!(),
+            None => result.map(|e| *e.downcast().ok().unwrap()),
+        }
+    }
+
+    pub async fn run_no_coroutine<U>(
+        &self,
+        run: impl for<'a> FnOnce(
+                &'a mut StoreContextMut<'_, T>,
+            )
+                -> Pin<Box<dyn Future<Output = Result<U, Trap>> + Send + 'a>>
+            + Send
+            + 'static,
+    ) -> Result<U, Trap>
+    where
+        U: Send + 'static,
+    {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.sender
+            .send(Message::RunNoCoroutine(
+                Box::new(move |store| {
+                    Box::pin(async move {
+                        let val = run(store).await?;
+                        Ok(Box::new(val) as Box<dyn Any + Send>)
+                    })
+                }),
+                tx,
+            ))
+            .await
+            .ok()
+            .expect("reactor task should be present");
+        rx.recv()
+            .await
+            .unwrap()
+            .map(|e| *e.downcast().ok().unwrap())
+    }
+}
+
+mod tls {
+    use std::any::Any;
+    use std::cell::Cell;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    thread_local!(static CUR: Cell<*const (dyn Any + Send)> = Cell::new(&0));
+
+    pub async fn scope<T>(
+        val: &mut (dyn Any + Send + 'static),
+        future: impl Future<Output = T>,
+    ) -> T {
+        struct SetTls<'a, F> {
+            val: &'a mut (dyn Any + Send + 'static),
+            future: F,
+        }
+
+        impl<F: Future> Future for SetTls<'_, F> {
+            type Output = F::Output;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+                let (val, future) = unsafe {
+                    let inner = self.get_unchecked_mut();
+                    (
+                        Pin::new_unchecked(&mut inner.val),
+                        Pin::new_unchecked(&mut inner.future),
+                    )
+                };
+
+                let x: &&mut (dyn Any + Send + 'static) = val.as_ref().get_ref();
+                set(&**x, || future.poll(cx))
+            }
+        }
+
+        SetTls { val, future }.await
+    }
+
+    pub fn set<R>(val: &(dyn Any + Send + 'static), f: impl FnOnce() -> R) -> R {
+        return CUR.with(|slot| {
+            let prev = slot.replace(val);
+            let _reset = Reset(slot, prev);
+            f()
+        });
+
+        struct Reset<'a, T: Copy>(&'a Cell<T>, T);
+
+        impl<T: Copy> Drop for Reset<'_, T> {
+            fn drop(&mut self) {
+                self.0.set(self.1);
+            }
+        }
+    }
+
+    pub fn with<R>(f: impl FnOnce(&(dyn Any + Send)) -> R) -> R {
+        CUR.with(|slot| {
+            let val = slot.get();
+            unsafe { f(&*val) }
+        })
     }
 }

--- a/crates/wasmtime/src/slab.rs
+++ b/crates/wasmtime/src/slab.rs
@@ -12,6 +12,10 @@ enum Entry<T> {
 }
 
 impl<T> Slab<T> {
+    pub fn next_id(&self) -> u32 {
+        self.next as u32
+    }
+
     pub fn insert(&mut self, item: T) -> u32 {
         if self.next == self.storage.len() {
             self.storage.push(Entry::Empty {
@@ -53,6 +57,13 @@ impl<T> Slab<T> {
                 None
             }
         }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.storage.iter().filter_map(|i| match i {
+            Entry::Full(t) => Some(t),
+            Entry::Empty { .. } => None,
+        })
     }
 }
 

--- a/tests/codegen/async_functions.witx
+++ b/tests/codegen/async_functions.witx
@@ -12,5 +12,8 @@ resource Response {
   body: async function() -> list<u8>
   status: function() -> u32
   status_text: function() -> string
-
 }
+
+resource some_resource
+
+resource_to_resource: async function(x: some_resource) -> some_resource

--- a/tests/codegen/async_functions.witx
+++ b/tests/codegen/async_functions.witx
@@ -5,3 +5,12 @@ async_results: async function() -> (u32, string, list<string>)
 resource async_resource {
   frob: async function()
 }
+
+fetch: async function(url: string) -> Response
+
+resource Response {
+  body: async function() -> list<u8>
+  status: function() -> u32
+  status_text: function() -> string
+
+}

--- a/tests/runtime/async_functions/exports.witx
+++ b/tests/runtime/async_functions/exports.witx
@@ -2,3 +2,11 @@ thunk: async function()
 allocated_bytes: function() -> u32
 
 test_concurrent: async function()
+
+concurrent_export: async function(idx: u32)
+
+infinite_loop_async: async function()
+infinite_loop: function()
+
+call_import_then_trap: async function()
+call_infinite_import: async function()

--- a/tests/runtime/async_functions/host.rs
+++ b/tests/runtime/async_functions/host.rs
@@ -1,26 +1,38 @@
-witx_bindgen_wasmtime::import!("./tests/runtime/async_functions/imports.witx");
-
 use anyhow::Result;
-use futures_channel::oneshot::{channel, Receiver, Sender};
-use futures_util::FutureExt;
 use imports::*;
-use wasmtime::{Engine, Linker, Module, Store};
-use witx_bindgen_wasmtime::{Async, HostFuture};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+use wasmtime::{Config, Engine, Linker, Module, Store, TrapCode};
+use witx_bindgen_wasmtime::HostFuture;
+
+witx_bindgen_wasmtime::export!({
+    paths: ["./tests/runtime/async_functions/imports.witx"],
+    async: *,
+});
 
 #[derive(Default)]
 pub struct MyImports {
-    thunk_hit: bool,
     unblock1: Option<Sender<()>>,
     unblock2: Option<Sender<()>>,
     unblock3: Option<Sender<()>>,
     wait1: Option<Receiver<()>>,
     wait2: Option<Receiver<()>>,
     wait3: Option<Receiver<()>>,
+
+    concurrent1: Option<Receiver<()>>,
+    concurrent2: Option<Receiver<()>>,
+
+    iloop_close_on_drop: Option<Sender<()>>,
+    iloop_entered: Option<Sender<()>>,
+
+    import_cancelled_signal: Option<Sender<()>>,
+    import_cancelled_entered: Vec<Sender<()>>,
 }
 
+#[witx_bindgen_wasmtime::async_trait]
 impl Imports for MyImports {
     fn thunk(&mut self) -> HostFuture<()> {
-        self.thunk_hit = true;
         Box::pin(async {
             async {}.await;
         })
@@ -28,7 +40,7 @@ impl Imports for MyImports {
 
     fn concurrent1(&mut self, a: u32) -> HostFuture<u32> {
         assert_eq!(a, 1);
-        self.unblock1.take().unwrap().send(()).unwrap();
+        self.unblock1.take();
         let wait = self.wait1.take().unwrap();
         Box::pin(async move {
             wait.await.unwrap();
@@ -38,7 +50,7 @@ impl Imports for MyImports {
 
     fn concurrent2(&mut self, a: u32) -> HostFuture<u32> {
         assert_eq!(a, 2);
-        self.unblock2.take().unwrap().send(()).unwrap();
+        self.unblock2.take();
         let wait = self.wait2.take().unwrap();
         Box::pin(async move {
             wait.await.unwrap();
@@ -48,60 +60,116 @@ impl Imports for MyImports {
 
     fn concurrent3(&mut self, a: u32) -> HostFuture<u32> {
         assert_eq!(a, 3);
-        self.unblock3.take().unwrap().send(()).unwrap();
+        self.unblock3.take();
         let wait = self.wait3.take().unwrap();
         Box::pin(async move {
             wait.await.unwrap();
             a + 10
         })
     }
-}
 
-witx_bindgen_wasmtime::export!("./tests/runtime/async_functions/exports.witx");
-
-fn run(wasm: &str) -> Result<()> {
-    struct Context {
-        wasi: wasmtime_wasi::WasiCtx,
-        imports: MyImports,
-        async_: Async<Context>,
-        exports: exports::ExportsData,
+    fn concurrent_export_helper(&mut self, idx: u32) -> HostFuture<()> {
+        let rx = if idx == 0 {
+            self.concurrent1.take().unwrap()
+        } else {
+            self.concurrent2.take().unwrap()
+        };
+        Box::pin(async move {
+            drop(rx.await);
+        })
     }
 
-    let engine = Engine::default();
+    async fn iloop_entered(&mut self) {
+        drop(self.iloop_entered.take());
+    }
+
+    fn import_to_cancel(&mut self) -> HostFuture<()> {
+        let signal = self.import_cancelled_signal.take();
+        drop(self.import_cancelled_entered.pop());
+        Box::pin(async move {
+            tokio::time::sleep(Duration::new(1_000, 0)).await;
+            drop(signal);
+        })
+    }
+}
+
+witx_bindgen_wasmtime::import!({
+    async: *,
+    paths: ["./tests/runtime/async_functions/exports.witx"],
+});
+
+struct Context {
+    wasi: wasmtime_wasi::WasiCtx,
+    imports: MyImports,
+    exports: exports::ExportsData,
+}
+
+fn run(wasm: &str) -> Result<()> {
+    let mut config = Config::new();
+    config.async_support(true);
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
     let module = Module::from_file(&engine, wasm)?;
     let mut linker = Linker::<Context>::new(&engine);
-    imports::add_imports_to_linker(&mut linker, |cx| (&mut cx.imports, &mut cx.async_))?;
+    imports::add_to_linker(&mut linker, |cx| &mut cx.imports)?;
     wasmtime_wasi::add_to_linker(&mut linker, |cx| &mut cx.wasi)?;
+    exports::Exports::add_to_linker(&mut linker, |cx| &mut cx.exports)?;
 
-    let mut store = Store::new(
-        &engine,
-        Context {
-            wasi: crate::default_wasi(),
-            imports: MyImports::default(),
-            async_: Default::default(),
-            exports: Default::default(),
-        },
-    );
-    let (exports, _instance) =
-        exports::Exports::instantiate(&mut store, &module, &mut linker, |cx| {
-            (&mut cx.exports, &mut cx.async_)
-        })?;
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(run_async(&engine, &module, &linker))
+}
 
-    let import = &mut store.data_mut().imports;
+async fn run_async(engine: &Engine, module: &Module, linker: &Linker<Context>) -> Result<()> {
+    let instantiate = |imports| async {
+        let mut store = Store::new(
+            &engine,
+            Context {
+                wasi: crate::default_wasi(),
+                imports,
+                exports: Default::default(),
+            },
+        );
+        store.add_fuel(10_000)?;
+        store.out_of_fuel_async_yield(u64::MAX, 10_000);
+        let instance = linker.instantiate_async(&mut store, &module).await?;
+        exports::Exports::new(store, &instance, |cx| &mut cx.exports)
+    };
+
+    let mut import = MyImports::default();
 
     // Initialize various channels which we use as synchronization points to
     // test the concurrent aspect of async wasm. The first channels here are
     // used to wait for host functions to get entered by the wasm.
-    let (a, mut wait1) = channel();
+    let (a, wait1) = channel();
     import.unblock1 = Some(a);
-    let (a, mut wait2) = channel();
+    let (a, wait2) = channel();
     import.unblock2 = Some(a);
-    let (a, mut wait3) = channel();
+    let (a, wait3) = channel();
     import.unblock3 = Some(a);
+    let (tx, mut rx) = mpsc::channel::<()>(10);
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+        assert!(wait1.await.is_err());
+        drop(tx2);
+    });
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+        assert!(wait2.await.is_err());
+        drop(tx2);
+    });
+    tokio::spawn(async move {
+        assert!(wait3.await.is_err());
+        drop(tx);
+    });
 
-    // This second set of channels are used to unblock host futures that wasm
-    // calls, simulating work that returns back to the host and takes some time
-    // to complete.
+    let (concurrent1, a) = channel();
+    let (concurrent2, b) = channel();
+    import.concurrent1 = Some(a);
+    import.concurrent2 = Some(b);
+
+    // This second set of channels are used to unblock host futures that
+    // wasm calls, simulating work that returns back to the host and takes
+    // some time to complete.
     let (unblock1, b) = channel();
     import.wait1 = Some(b);
     let (unblock2, b) = channel();
@@ -109,40 +177,166 @@ fn run(wasm: &str) -> Result<()> {
     let (unblock3, b) = channel();
     import.wait3 = Some(b);
 
-    futures_executor::block_on(async {
-        exports.thunk(&mut store).await?;
-        assert!(store.data_mut().imports.thunk_hit);
+    let exports = instantiate(import).await?;
+    exports.thunk().await?;
 
-        let mut future = Box::pin(exports.test_concurrent(&mut store)).fuse();
+    let future = exports.test_concurrent();
+    tokio::pin!(future);
 
-        // wait for all three concurrent methods to get entered. Note that we
-        // poll the `future` while we're here as well to run any callbacks
-        // inside as necessary, but it shouldn't ever finish.
-        let mut done = 0;
-        while done < 3 {
-            futures_util::select! {
-                _ = future => unreachable!(),
-                r = wait1 => { r.unwrap(); done += 1; }
-                r = wait2 => { r.unwrap(); done += 1; }
-                r = wait3 => { r.unwrap(); done += 1; }
+    // wait for all three concurrent methods to get entered, where once this
+    // happens they'll all drop the handles to `rx`, meaning that when
+    // entered we'll see the `rx` channel get closed.
+    tokio::select! {
+        _ = &mut future => unreachable!(),
+        r = rx.recv() => assert!(r.is_none()),
+    }
+
+    // Now we can "complete" the async task that each function was waiting
+    // on. Our original future shouldn't be done until they're all complete.
+    unblock3.send(()).unwrap();
+    unblock2.send(()).unwrap();
+    unblock1.send(()).unwrap();
+    future.await?;
+
+    // Test concurrent exports can be invoked, here we call wasm
+    // concurrently twice and complete the second one first, ensuring the
+    // first one isn't finished, and then we complete the first and assert
+    // it's done.
+    let a = exports.concurrent_export(0);
+    tokio::pin!(a);
+    let b = exports.concurrent_export(1);
+    drop(concurrent2);
+    tokio::select! {
+        r = &mut a => panic!("got result {:?}", r),
+        r = b => r.unwrap(),
+    }
+    drop(concurrent1);
+    a.await.unwrap();
+
+    // Cancelling an infinite loop drops the reactor and the reactor doesn't
+    // execute forever. This will only work if `tx`, owned by the reactor, will
+    // get dropped when we cancel execution of the infinite loop.
+    let (tx, rx) = channel();
+    let (tx2, rx2) = channel();
+    let mut imports = MyImports::default();
+    imports.iloop_close_on_drop = Some(tx);
+    imports.iloop_entered = Some(tx2);
+    let exports = instantiate(imports).await?;
+    {
+        let iloop = exports.infinite_loop();
+        tokio::pin!(iloop);
+        // execute the iloop long enough to get into wasm and we'll get the
+        // signal when the `rx2` channel is closed.
+        tokio::select! {
+            _ = &mut iloop => unreachable!(),
+            r = rx2 => assert!(r.is_err()),
+        }
+    }
+    assert!(rx.await.is_err());
+    drop(exports);
+
+    // Same as above, but an infinite loop in an async exported wasm function
+    let (tx, rx) = channel();
+    let (tx2, rx2) = channel();
+    let mut imports = MyImports::default();
+    imports.iloop_close_on_drop = Some(tx);
+    imports.iloop_entered = Some(tx2);
+    let exports = instantiate(imports).await?;
+    {
+        let iloop = exports.infinite_loop_async();
+        tokio::pin!(iloop);
+        // execute the iloop long enough to get into wasm and we'll get the
+        // signal when the `rx2` channel is closed.
+        tokio::select! {
+            _ = &mut iloop => unreachable!(),
+            r = rx2 => assert!(r.is_err()),
+        }
+    }
+    assert!(rx.await.is_err());
+    drop(exports);
+
+    // A trap from WebAssembly should result in cancelling all imported tasks.
+    // execute forever. This will only work if `tx`, owned by the reactor, will
+    // get dropped when we cancel execution of the infinite loop.
+    let (tx, rx) = channel();
+    let mut imports = MyImports::default();
+    imports.import_cancelled_signal = Some(tx);
+    let trap = instantiate(imports)
+        .await?
+        .call_import_then_trap()
+        .await
+        .unwrap_err();
+    assert!(
+        trap.trap_code() == Some(TrapCode::UnreachableCodeReached),
+        "bad error: {}",
+        trap
+    );
+    assert!(rx.await.is_err());
+
+    // Dropping the owned version of the bindings should recursively tear down
+    // the reactor task since it's got nothing else to do at that point.
+    let (tx, rx) = channel();
+    let mut imports = MyImports::default();
+    imports.import_cancelled_signal = Some(tx);
+    instantiate(imports).await?;
+    assert!(rx.await.is_err());
+
+    // Cancelling (dropping) the outer task transitively tears down the reactor
+    // and cancels imported tasks.
+    let (tx, rx) = channel();
+    let (tx2, rx2) = channel();
+    let mut imports = MyImports::default();
+    imports.import_cancelled_signal = Some(tx);
+    imports.import_cancelled_entered.push(tx2);
+    let exports = instantiate(imports).await?;
+    {
+        let f = exports.call_infinite_import();
+        tokio::pin!(f);
+        // execute the wasm long enough to get into it and we'll get the
+        // signal when the `rx2` channel is closed.
+        tokio::select! {
+            _ = &mut f => unreachable!(),
+            r = rx2 => assert!(r.is_err()),
+        }
+    }
+    assert!(rx.await.is_err());
+    drop(exports);
+
+    // With multiple concurrent exports if one of them is cancelled then they
+    // all get cancelled.
+    let (tx, rx) = channel();
+    let (tx2, rx2) = channel();
+    let mut imports = MyImports::default();
+    imports.import_cancelled_entered.push(tx);
+    imports.import_cancelled_entered.push(tx2);
+    let exports = instantiate(imports).await?;
+    let a = exports.call_infinite_import();
+    let b = exports.call_infinite_import();
+    {
+        tokio::pin!(a);
+        {
+            tokio::pin!(b);
+            // Run this select twice to ensure both futures get into the import within wasm.
+            tokio::select! {
+                _ = &mut a => unreachable!(),
+                _ = &mut b => unreachable!(),
+                r = rx2 => assert!(r.is_err()),
             }
+            tokio::select! {
+                _ = &mut a => unreachable!(),
+                _ = &mut b => unreachable!(),
+                r = rx => assert!(r.is_err()),
+            }
+            // ... `b` is now dropped here
         }
+        let err = a.await.unwrap_err();
+        assert!(
+            err.to_string().contains("wasm reactor task has gone away"),
+            "bad error: {}",
+            err
+        );
+    }
+    drop(exports);
 
-        // Now we can "complete" the async task that each function was waiting
-        // on. Our original future shouldn't be done until they're all complete.
-        unblock3.send(()).unwrap();
-        futures_util::select! {
-            _ = future => unreachable!(),
-            default => {}
-        }
-        unblock2.send(()).unwrap();
-        futures_util::select! {
-            _ = future => unreachable!(),
-            default => {}
-        }
-        unblock1.send(()).unwrap();
-        future.await?;
-
-        Ok(())
-    })
+    Ok(())
 }

--- a/tests/runtime/async_functions/host.rs
+++ b/tests/runtime/async_functions/host.rs
@@ -1,0 +1,148 @@
+witx_bindgen_wasmtime::import!("./tests/runtime/async_functions/imports.witx");
+
+use anyhow::Result;
+use futures_channel::oneshot::{channel, Receiver, Sender};
+use futures_util::FutureExt;
+use imports::*;
+use wasmtime::{Engine, Linker, Module, Store};
+use witx_bindgen_wasmtime::{Async, HostFuture};
+
+#[derive(Default)]
+pub struct MyImports {
+    thunk_hit: bool,
+    unblock1: Option<Sender<()>>,
+    unblock2: Option<Sender<()>>,
+    unblock3: Option<Sender<()>>,
+    wait1: Option<Receiver<()>>,
+    wait2: Option<Receiver<()>>,
+    wait3: Option<Receiver<()>>,
+}
+
+impl Imports for MyImports {
+    fn thunk(&mut self) -> HostFuture<()> {
+        self.thunk_hit = true;
+        Box::pin(async {
+            async {}.await;
+        })
+    }
+
+    fn concurrent1(&mut self, a: u32) -> HostFuture<u32> {
+        assert_eq!(a, 1);
+        self.unblock1.take().unwrap().send(()).unwrap();
+        let wait = self.wait1.take().unwrap();
+        Box::pin(async move {
+            wait.await.unwrap();
+            a + 10
+        })
+    }
+
+    fn concurrent2(&mut self, a: u32) -> HostFuture<u32> {
+        assert_eq!(a, 2);
+        self.unblock2.take().unwrap().send(()).unwrap();
+        let wait = self.wait2.take().unwrap();
+        Box::pin(async move {
+            wait.await.unwrap();
+            a + 10
+        })
+    }
+
+    fn concurrent3(&mut self, a: u32) -> HostFuture<u32> {
+        assert_eq!(a, 3);
+        self.unblock3.take().unwrap().send(()).unwrap();
+        let wait = self.wait3.take().unwrap();
+        Box::pin(async move {
+            wait.await.unwrap();
+            a + 10
+        })
+    }
+}
+
+witx_bindgen_wasmtime::export!("./tests/runtime/async_functions/exports.witx");
+
+fn run(wasm: &str) -> Result<()> {
+    struct Context {
+        wasi: wasmtime_wasi::WasiCtx,
+        imports: MyImports,
+        async_: Async<Context>,
+        exports: exports::ExportsData,
+    }
+
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, wasm)?;
+    let mut linker = Linker::<Context>::new(&engine);
+    imports::add_imports_to_linker(&mut linker, |cx| (&mut cx.imports, &mut cx.async_))?;
+    wasmtime_wasi::add_to_linker(&mut linker, |cx| &mut cx.wasi)?;
+
+    let mut store = Store::new(
+        &engine,
+        Context {
+            wasi: crate::default_wasi(),
+            imports: MyImports::default(),
+            async_: Default::default(),
+            exports: Default::default(),
+        },
+    );
+    let (exports, _instance) =
+        exports::Exports::instantiate(&mut store, &module, &mut linker, |cx| {
+            (&mut cx.exports, &mut cx.async_)
+        })?;
+
+    let import = &mut store.data_mut().imports;
+
+    // Initialize various channels which we use as synchronization points to
+    // test the concurrent aspect of async wasm. The first channels here are
+    // used to wait for host functions to get entered by the wasm.
+    let (a, mut wait1) = channel();
+    import.unblock1 = Some(a);
+    let (a, mut wait2) = channel();
+    import.unblock2 = Some(a);
+    let (a, mut wait3) = channel();
+    import.unblock3 = Some(a);
+
+    // This second set of channels are used to unblock host futures that wasm
+    // calls, simulating work that returns back to the host and takes some time
+    // to complete.
+    let (unblock1, b) = channel();
+    import.wait1 = Some(b);
+    let (unblock2, b) = channel();
+    import.wait2 = Some(b);
+    let (unblock3, b) = channel();
+    import.wait3 = Some(b);
+
+    futures_executor::block_on(async {
+        exports.thunk(&mut store).await?;
+        assert!(store.data_mut().imports.thunk_hit);
+
+        let mut future = Box::pin(exports.test_concurrent(&mut store)).fuse();
+
+        // wait for all three concurrent methods to get entered. Note that we
+        // poll the `future` while we're here as well to run any callbacks
+        // inside as necessary, but it shouldn't ever finish.
+        let mut done = 0;
+        while done < 3 {
+            futures_util::select! {
+                _ = future => unreachable!(),
+                r = wait1 => { r.unwrap(); done += 1; }
+                r = wait2 => { r.unwrap(); done += 1; }
+                r = wait3 => { r.unwrap(); done += 1; }
+            }
+        }
+
+        // Now we can "complete" the async task that each function was waiting
+        // on. Our original future shouldn't be done until they're all complete.
+        unblock3.send(()).unwrap();
+        futures_util::select! {
+            _ = future => unreachable!(),
+            default => {}
+        }
+        unblock2.send(()).unwrap();
+        futures_util::select! {
+            _ = future => unreachable!(),
+            default => {}
+        }
+        unblock1.send(()).unwrap();
+        future.await?;
+
+        Ok(())
+    })
+}

--- a/tests/runtime/async_functions/host.ts
+++ b/tests/runtime/async_functions/host.ts
@@ -80,14 +80,12 @@ async function run() {
       throw new Error('unsupported');
     },
   };
-  let instance: WebAssembly.Instance;
-  addImportsToImports(importObj, imports, name => instance.exports[name]);
+  addImportsToImports(importObj, imports);
   const wasi = addWasiToImports(importObj);
 
   const wasm = new Exports();
   await wasm.instantiate(getWasm(), importObj);
   wasi.start(wasm.instance);
-  instance = wasm.instance;
 
   const initBytes = wasm.allocatedBytes();
   console.log("calling initial async function");

--- a/tests/runtime/async_functions/imports.witx
+++ b/tests/runtime/async_functions/imports.witx
@@ -3,3 +3,9 @@ thunk: async function()
 concurrent1: async function(a: u32) -> u32
 concurrent2: async function(a: u32) -> u32
 concurrent3: async function(a: u32) -> u32
+
+concurrent_export_helper: async function(idx: u32)
+
+iloop_entered: function()
+
+import_to_cancel: async function()

--- a/tests/runtime/async_functions/wasm.rs
+++ b/tests/runtime/async_functions/wasm.rs
@@ -20,4 +20,27 @@ impl exports::Exports for Exports {
 
         assert_eq!(futures_util::join!(a2, a3, a1), (12, 13, 11));
     }
+
+    async fn concurrent_export(idx: u32) {
+        imports::concurrent_export_helper(idx).await
+    }
+
+    async fn infinite_loop_async() {
+        imports::iloop_entered();
+        loop {}
+    }
+
+    fn infinite_loop() {
+        imports::iloop_entered();
+        loop {}
+    }
+
+    async fn call_import_then_trap() {
+        let _f = imports::import_to_cancel();
+        std::arch::wasm32::unreachable();
+    }
+
+    async fn call_infinite_import() {
+        imports::import_to_cancel().await;
+    }
 }

--- a/tests/runtime/async_raw/exports.witx
+++ b/tests/runtime/async_raw/exports.witx
@@ -1,0 +1,12 @@
+complete_immediately: async function()
+completion_not_called: async function()
+complete_twice: async function()
+complete_then_trap: async function()
+assert_coroutine_id_zero: async function()
+
+not_async_export_done: function()
+not_async_calls_async: function()
+
+import_callback_null: async function()
+import_callback_wrong_type: async function()
+import_callback_bad_index: async function()

--- a/tests/runtime/async_raw/host.rs
+++ b/tests/runtime/async_raw/host.rs
@@ -1,0 +1,161 @@
+use anyhow::Result;
+use wasmtime::{Config, Engine, Linker, Module, Store};
+use witx_bindgen_wasmtime::HostFuture;
+
+witx_bindgen_wasmtime::export!({
+    async: *,
+    paths: ["./tests/runtime/async_raw/imports.witx"],
+});
+
+#[derive(Default)]
+struct MyImports;
+
+impl imports::Imports for MyImports {
+    fn thunk(&mut self) -> HostFuture<()> {
+        Box::pin(async {})
+    }
+}
+
+witx_bindgen_wasmtime::import!({
+    async: *,
+    paths: ["./tests/runtime/async_raw/exports.witx"],
+});
+
+fn run(wasm: &str) -> Result<()> {
+    struct Context {
+        wasi: wasmtime_wasi::WasiCtx,
+        imports: MyImports,
+        exports: exports::ExportsData,
+    }
+
+    let mut config = Config::new();
+    config.async_support(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::from_file(&engine, wasm)?;
+    let mut linker = Linker::<Context>::new(&engine);
+    imports::add_to_linker(&mut linker, |cx| &mut cx.imports)?;
+    wasmtime_wasi::add_to_linker(&mut linker, |cx| &mut cx.wasi)?;
+    exports::Exports::add_to_linker(&mut linker, |cx| &mut cx.exports)?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let instantiate = || async {
+            let mut store = Store::new(
+                &engine,
+                Context {
+                    wasi: crate::default_wasi(),
+                    imports: MyImports::default(),
+                    exports: Default::default(),
+                },
+            );
+            let instance = linker.instantiate_async(&mut store, &module).await?;
+            exports::Exports::new(store, &instance, |cx| &mut cx.exports)
+        };
+
+        // it's ok to call the completion callback immediately, and the first
+        // coroutine is always zero.
+        let exports = instantiate().await?;
+        exports.complete_immediately().await?;
+        exports.assert_coroutine_id_zero().await?;
+        exports.assert_coroutine_id_zero().await?;
+
+        // if the completion callback is never called that's a trap
+        let err = instantiate()
+            .await?
+            .completion_not_called()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("completion callback never called"),
+            "bad error: {}",
+            err,
+        );
+
+        // the completion callback can only be called once
+        let err = instantiate().await?.complete_twice().await.unwrap_err();
+        assert!(
+            err.to_string().contains("async context not valid"),
+            "bad error: {}",
+            err,
+        );
+
+        // if the trap happens after the completion callback... something
+        // happens, for now a trap.
+        let err = instantiate().await?.complete_then_trap().await.unwrap_err();
+        assert!(
+            err.trap_code() == Some(wasmtime::TrapCode::UnreachableCodeReached),
+            "bad error: {:?}",
+            err
+        );
+
+        // If a non-async export tries to call the completion callback for
+        // async exports that's an error.
+        let err = instantiate()
+            .await?
+            .not_async_export_done()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("async context not valid"),
+            "bad error: {}",
+            err,
+        );
+
+        // If a non-async export tries to call an async import that's an error.
+        let err = instantiate()
+            .await?
+            .not_async_calls_async()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot call async import from non-async export"),
+            "bad error: {}",
+            err,
+        );
+
+        // The import callback specified cannot be null
+        let err = instantiate()
+            .await?
+            .import_callback_null()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("callback was a null function"),
+            "bad error: {}",
+            err,
+        );
+
+        // The import callback specified must have the right type.
+        let err = instantiate()
+            .await?
+            .import_callback_wrong_type()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("type mismatch with parameters"),
+            "bad error: {}",
+            err,
+        );
+
+        // The import callback specified must point to a valid table index
+        let err = instantiate()
+            .await?
+            .import_callback_bad_index()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid function index"),
+            "bad error: {}",
+            err,
+        );
+
+        // when wasm traps due to one reason or another all future requests to
+        // execute wasm fail
+        let exports = instantiate().await?;
+        assert!(exports.import_callback_null().await.is_err());
+        assert!(exports.complete_immediately().await.is_err());
+
+        Ok(())
+    })
+}

--- a/tests/runtime/async_raw/host.ts
+++ b/tests/runtime/async_raw/host.ts
@@ -1,0 +1,54 @@
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
+import { getWasm, addWasiToImports } from "./helpers.js";
+// @ts-ignore
+import * as assert from 'assert';
+
+async function run() {
+  const importObj = {};
+  const imports: Imports = {
+    async thunk() {}
+  };
+
+  async function instantiate() {
+    let instance: WebAssembly.Instance;
+    addImportsToImports(importObj, imports, name => instance.exports[name]);
+    const wasi = addWasiToImports(importObj);
+
+    const wasm = new Exports();
+    await wasm.instantiate(getWasm(), importObj);
+    wasi.start(wasm.instance);
+    instance = wasm.instance;
+    return wasm;
+  }
+
+  let wasm = await instantiate();
+  await wasm.completeImmediately();
+  await wasm.assertCoroutineIdZero();
+  await wasm.assertCoroutineIdZero();
+
+  wasm = await instantiate();
+  await assert.rejects(wasm.completionNotCalled(), /blocked coroutine with 0 pending callbacks/);
+
+  wasm = await instantiate();
+  await assert.rejects(wasm.completeTwice(), /cannot complete coroutine twice/);
+
+  wasm = await instantiate();
+  await assert.rejects(wasm.completeThenTrap(), /unreachable/);
+
+  wasm = await instantiate();
+  assert.throws(() => wasm.notAsyncExportDone(), /invalid coroutine index/);
+
+  wasm = await instantiate();
+  await assert.rejects(wasm.importCallbackNull(), /table index is a null function/);
+
+  // TODO: this is the wrong error from this, but it's not clear how best to do
+  // type-checks in JS...
+  wasm = await instantiate();
+  await assert.rejects(wasm.importCallbackWrongType(), /0 pending callbacks/);
+
+  wasm = await instantiate();
+  await assert.rejects(wasm.importCallbackBadIndex(), RangeError);
+}
+
+await run()

--- a/tests/runtime/async_raw/host.ts
+++ b/tests/runtime/async_raw/host.ts
@@ -11,14 +11,12 @@ async function run() {
   };
 
   async function instantiate() {
-    let instance: WebAssembly.Instance;
-    addImportsToImports(importObj, imports, name => instance.exports[name]);
+    addImportsToImports(importObj, imports);
     const wasi = addWasiToImports(importObj);
 
     const wasm = new Exports();
     await wasm.instantiate(getWasm(), importObj);
     wasi.start(wasm.instance);
-    instance = wasm.instance;
     return wasm;
   }
 

--- a/tests/runtime/async_raw/imports.witx
+++ b/tests/runtime/async_raw/imports.witx
@@ -1,0 +1,1 @@
+thunk: async function()

--- a/tests/runtime/async_raw/wasm.rs
+++ b/tests/runtime/async_raw/wasm.rs
@@ -1,0 +1,82 @@
+use std::arch::wasm32;
+
+#[link(wasm_import_module = "canonical_abi")]
+extern "C" {
+    pub fn async_export_done(ctx: i32, ptr: i32);
+}
+
+#[link(wasm_import_module = "imports")]
+extern "C" {
+    pub fn thunk(cb: i32, ptr: i32);
+}
+
+#[no_mangle]
+pub extern "C" fn complete_immediately(ctx: i32) {
+    unsafe {
+        async_export_done(ctx, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn completion_not_called(_ctx: i32) {}
+
+#[no_mangle]
+pub extern "C" fn complete_twice(ctx: i32) {
+    unsafe {
+        async_export_done(ctx, 0);
+        async_export_done(ctx, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn complete_then_trap(ctx: i32) {
+    unsafe {
+        async_export_done(ctx, 0);
+        wasm32::unreachable();
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn assert_coroutine_id_zero(ctx: i32) {
+    unsafe {
+        assert_eq!(ctx, 0);
+        async_export_done(ctx, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn not_async_export_done() {
+    unsafe {
+        async_export_done(0, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn not_async_calls_async() {
+    extern "C" fn callback(_x: i32) {}
+    unsafe {
+        thunk(callback as i32, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn import_callback_null(_cx: i32) {
+    unsafe {
+        thunk(0, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn import_callback_wrong_type(_cx: i32) {
+    extern "C" fn callback() {}
+    unsafe {
+        thunk(callback as i32, 0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn import_callback_bad_index(_cx: i32) {
+    unsafe {
+        thunk(i32::MAX, 0);
+    }
+}


### PR DESCRIPTION
This PR is an implementation of `async` witx functions for Wasmtime. This is a significantly different design than what's present today for sync bindings or sync-wasm-but-actually-invoked-`async` bindings. Instead the support for `async function` in witx will spawn a "reactor task" onto tokio which manages the `Store<T>` and similarly manages running callbacks. The "callback ABI" is all that's implemented here at this time.

This "reactor task" takes ownership of the `Store<T>` from the outside and the bindings structure no longer takes `&mut StoreContextMut` anywhere since the caller won't have it. Instead the bindings structure communicates with the reactor task via a channel, and everything otherwise happens asynchronously. Some properties of this implementation include:

* Great care is taken to handle "cancellation" correctly in Rust-futures-world where if the original request to execute wasm is dropped (the channel is disconnected) this will immediately abort any executing WebAssembly and propagate the cancellation to all callbacks as well. 
* If wasm is ever "interrupted" for one reason or another -- e.g. via a cancelled future or a trap -- then the entire reactor task is "torn down" which destroys the `Store<T>`. This cancels any other possible concurrent execution of wasm. This is intended to model `kill -9` in a sense but also reflect how after a trap it's not really feasible to resume wasm execution since it's all in an indeterminate state.
* Some properties of the witx async model are refined, such as:
  * If the completion callback is called and then a trap happens afterwards, that's translate as a trap
  * New "event" intrinsics were added to support cross-coroutine wakeups and the Rust guest is based on this
  * Coroutines are not considered "done" until all of their pending callbacks have been resolved.
* Support for "synchronous" witx functions remains with Wasmtime, even when `async` functions are present, but due to the nature of running code in a separate task this is still exposed to the host in an `async` function with asynchronous communication with the reactor task.
* There is a period of time that passed when the wasm calls a completion callback until the wasm has actually fully completed. This period of time is not exposed in the APIs generated for the Wasmtime host (or the JS host). Instead functions from wasm are simply exposed as `async function() -> T` effectively which means that if the completion callback is called significantly further before the coroutine finishes the caller of the API will not know of this.
* Currently the notion of "async" in the wasmtime code generator is a bit wonky. There's a 2x2 matrix here where one axis is whether the witx function is `async` or not, and the other axis is whether wasmtime is configured to invoke the function asynchronously or not (using Wasmtime's `async fn` support natively). One gap here of `async` witx function invoked synchronously in Wasmtime is not supported, and if configured that way the generated code either won't compile or won't work at runtime, I didn't test this too thoroughly.

This PR continues to have no support for streams. @aturon and I are still discussing a lot of implementation details and implications, so that'll all be a separate follow-up PR.