### PR TITLE
Avoid "stuttering" adding wasmtime imports to linker

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -958,9 +958,7 @@ impl Generator for Wasmtime {
         for (module, funcs) in mem::take(&mut self.imports) {
             let module_camel = module.to_camel_case();
             let is_async = !self.opts.async_.is_none();
-            self.push_str("\npub fn add_");
-            self.push_str(&module);
-            self.push_str("_to_linker<T, U>(linker: &mut wasmtime::Linker<T>");
+            self.push_str("\npub fn add_to_linker<T, U>(linker: &mut wasmtime::Linker<T>");
             self.push_str(", get: impl Fn(&mut T) -> ");
             if self.all_needed_handles.is_empty() {
                 self.push_str("&mut U");

--- a/tests/runtime/buffers/host.rs
+++ b/tests/runtime/buffers/host.rs
@@ -122,7 +122,7 @@ fn run(wasm: &str) -> Result<()> {
 
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| Exports::instantiate(store, module, linker, |cx| &mut cx.exports),
     )?;
 

--- a/tests/runtime/flavorful/host.rs
+++ b/tests/runtime/flavorful/host.rs
@@ -98,7 +98,7 @@ fn run(wasm: &str) -> Result<()> {
 
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| Exports::instantiate(store, module, linker, |cx| &mut cx.exports),
     )?;
 

--- a/tests/runtime/handles/host.rs
+++ b/tests/runtime/handles/host.rs
@@ -95,7 +95,7 @@ fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(
         wasm,
         |linker| {
-            imports::add_imports_to_linker(
+            imports::add_to_linker(
                 linker,
                 |cx: &mut crate::Context<(MyImports, imports::ImportsTables<MyImports>), _>| {
                     (&mut cx.imports.0, &mut cx.imports.1)

--- a/tests/runtime/invalid/host.rs
+++ b/tests/runtime/invalid/host.rs
@@ -44,7 +44,7 @@ fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(
         wasm,
         |linker| {
-            imports::add_imports_to_linker(
+            imports::add_to_linker(
                 linker,
                 |cx: &mut crate::Context<(MyImports, imports::ImportsTables<MyImports>), _>| {
                     (&mut cx.imports.0, &mut cx.imports.1)

--- a/tests/runtime/lists/host.rs
+++ b/tests/runtime/lists/host.rs
@@ -129,7 +129,7 @@ fn run(wasm: &str) -> Result<()> {
 
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| Exports::instantiate(store, module, linker, |cx| &mut cx.exports),
     )?;
 

--- a/tests/runtime/numbers/host.rs
+++ b/tests/runtime/numbers/host.rs
@@ -66,7 +66,7 @@ witx_bindgen_wasmtime::import!("./tests/runtime/numbers/exports.witx");
 fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| {
             exports::Exports::instantiate(store, module, linker, |cx| &mut cx.exports)
         },

--- a/tests/runtime/records/host.rs
+++ b/tests/runtime/records/host.rs
@@ -56,7 +56,7 @@ fn run(wasm: &str) -> Result<()> {
 
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| Exports::instantiate(store, module, linker, |cx| &mut cx.exports),
     )?;
 

--- a/tests/runtime/smoke/host.rs
+++ b/tests/runtime/smoke/host.rs
@@ -19,7 +19,7 @@ witx_bindgen_wasmtime::import!("./tests/runtime/smoke/exports.witx");
 fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| {
             exports::Exports::instantiate(store, module, linker, |cx| &mut cx.exports)
         },

--- a/tests/runtime/smw_functions/host.rs
+++ b/tests/runtime/smw_functions/host.rs
@@ -52,7 +52,7 @@ witx_bindgen_wasmtime::import!("tests/runtime/smw_functions/exports.witx");
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
         |store, module, linker| {
             exports::Exports::instantiate(store, module, linker, |cx| &mut cx.exports)
         },

--- a/tests/runtime/smw_lists/host.rs
+++ b/tests/runtime/smw_lists/host.rs
@@ -42,7 +42,7 @@ witx_bindgen_wasmtime::import!("tests/runtime/smw_lists/exports.witx");
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
         |store, module, linker| {
             exports::Exports::instantiate(store, module, linker, |cx| &mut cx.exports)
         },

--- a/tests/runtime/smw_strings/host.rs
+++ b/tests/runtime/smw_strings/host.rs
@@ -34,7 +34,7 @@ witx_bindgen_wasmtime::import!("tests/runtime/smw_strings/exports.witx");
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut Host { &mut cx.imports }),
         |store, module, linker| {
             exports::Exports::instantiate(store, module, linker, |cx| &mut cx.exports)
         },

--- a/tests/runtime/variants/host.rs
+++ b/tests/runtime/variants/host.rs
@@ -58,7 +58,7 @@ fn run(wasm: &str) -> Result<()> {
 
     let (exports, mut store) = crate::instantiate(
         wasm,
-        |linker| imports::add_imports_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
+        |linker| imports::add_to_linker(linker, |cx| -> &mut MyImports { &mut cx.imports }),
         |store, module, linker| Exports::instantiate(store, module, linker, |cx| &mut cx.exports),
     )?;
 


### PR DESCRIPTION
Functions are already namespaced in an appropriately named module so
there's no need to have the name of the witx module additionally in the
name of the function `add_to_linker`.