### PR TITLE
Generate a `name` section for spidermonkey wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2caacc74c68c74f0008c4055cdf509c43e623775eaf73323bb818dcf666ed9bd"
+checksum = "db0c351632e46cc06a58a696a6c11e4cf90cad4b9f8f07a0b59128d616c29bb0"
 dependencies = [
  "leb128",
 ]
@@ -2129,7 +2129,7 @@ dependencies = [
  "lazy_static",
  "structopt",
  "test-helpers",
- "wasm-encoder 0.6.0",
+ "wasm-encoder 0.8.0",
  "wasmparser 0.80.1",
  "witx-bindgen-gen-core",
 ]

--- a/crates/gen-spidermonkey/Cargo.toml
+++ b/crates/gen-spidermonkey/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 [dependencies]
 lazy_static = "1.4.0"
 structopt = { version = "0.3", optional = true }
-wasm-encoder = "0.6.0"
+wasm-encoder = "0.8.0"
 witx-bindgen-gen-core = { path = "../gen-core" }
 
 [dev-dependencies]

--- a/crates/gen-spidermonkey/src/data_segments.rs
+++ b/crates/gen-spidermonkey/src/data_segments.rs
@@ -31,7 +31,7 @@ impl DataSegments {
         let offset = self.reserve_space(u32::try_from(segment.len()).unwrap());
         self.data.active(
             self.memory,
-            wasm_encoder::Instruction::I32Const(offset as i32),
+            &wasm_encoder::Instruction::I32Const(offset as i32),
             segment,
         );
         offset


### PR DESCRIPTION
This commit updates the generated wasm module for spidermonkey modules
to have a `name` section which contains debugging information about
functions, locals, memories, etc. This is not currently complete in that
everything is named, but it at least adds a lot of names to the output
to make it a bit more readable. My hope is that this could be expanded
as necessary over time to name more items to assist in debugging the
generated code as necessary.