### PR TITLE
chore: edits to `WIT.md`

### DIFF
--- a/WIT.md
+++ b/WIT.md
@@ -1,7 +1,7 @@
 # The `*.wit` format
 
 This is intended to document the `*.wit` format as it exists today. The goal is
-to provide an overview to understand what features wit files give you and how
+to provide an overview to understand what features `wit` files give you and how
 they're structured. This isn't intended to be a formal grammar, although it's
 expected that one day we'll have a formal grammar for `*.wit` files.
 
@@ -14,15 +14,15 @@ the left.
 
 ## Lexical structure
 
-The wit format is a curly-braced-based format where whitespace is optional (but
+The `wit` format is a curly-braced-based format where whitespace is optional (but
 recommended). It is intended to be easily human readable and supports features
-like comments, multi-line comments, and custom identifiers. A wit document
+like comments, multi-line comments, and custom identifiers. A `wit` document
 is parsed as a unicode string, and when stored in a file is expected to be
-encoded as utf-8.
+encoded as UTF-8.
 
 The current structure of tokens are:
 
-```
+```wit
 token ::= whitespace
         | comment
         | operator
@@ -33,44 +33,44 @@ token ::= whitespace
 Whitespace and comments are ignored when parsing structures defined elsewhere
 here.
 
-#### Whitespace
+### Whitespace
 
 A `whitespace` token in `*.wit` is a space, a newline, a carriage return, or a
 tab character:
 
-```
+```wit
 whitespace ::= ' ' | '\n' | '\r' | '\t'
 ```
 
-#### Comments
+### Comments
 
 A `comment` token in `*.wit` is either a line comment preceded with `//` which
 ends at the next newline (`\n`) character or it's a block comment which starts
 with `/*` and ends with `*/`. Note that block comments are allowed to be nested
 and their delimiters must be balanced
 
-```
+```wit
 comment ::= '//' character-that-isnt-a-newline*
           | '/*' any-unicode-character* '*/'
 ```
 
-#### Operators
+### Operators
 
-There are some common operators in the lexical structure of wit used for
+There are some common operators in the lexical structure of `wit` used for
 various constructs. Note that delimiters such as `{`, `(`, and `[` must all be
 balanced.
 
-```
+```wit
 operator ::= '=' | ',' | ':' | ';' | '(' | ')' | '{' | '}' | '<' | '>' | '*' | '->'
 ```
 
-#### Keywords
+### Keywords
 
-Certain identifiers are reserved for use in wit documents and cannot be used
+Certain identifiers are reserved for use in `wit` documents and cannot be used
 bare as an identifier. These are used to help parse the format, and the list of
 keywords is still in flux at this time but the current set is:
 
-```
+```wit
 keyword ::= 'use'
           | 'type'
           | 'resource'
@@ -99,7 +99,7 @@ keyword ::= 'use'
           | 'async'
 ```
 
-#### Identifiers
+### Identifiers
 
 Identifiers are used for the names of functions, parameters, etc. Identifiers
 can either be specified raw as a sequence of characters or as a string literal.
@@ -107,7 +107,7 @@ As a string literal an identifier is allowed to be any valid unicode string,
 including those that might overlap otherwise with keywords. For example an
 identifier can't be `use` but it can be `"use"`:
 
-```
+```wit
 identifier ::= keylike+
              | string
 
@@ -121,7 +121,7 @@ keylike ::= '-'
 Strings are intended to be the same format as strings in the WebAssembly text
 format except that they're always valid unicode and don't have raw byte escapes:
 
-```
+```wit
 string ::= '"' stringchar* '"'
 
 stringchar ::= c       if c == \u{9} or (\u{20} <= c <= \u{10ffff} and c != \u{7f}
@@ -137,7 +137,7 @@ escape ::= '\\'
 
 ## Top-level items
 
-A wit document is a sequence of items specified at the top level. These items
+A `wit` document is a sequence of items specified at the top level. These items
 come one after another and it's recommended to separate them with newlines for
 readability but this isn't required.
 
@@ -146,7 +146,7 @@ readability but this isn't required.
 A `use` statement enables importing type or resource definitions from other
 wit documents. The structure of a use statement is:
 
-```
+```wit
 use * from other-file
 use { a, list, of, names } from another-file
 use { name as other-name } from yet-another-file
@@ -154,7 +154,7 @@ use { name as other-name } from yet-another-file
 
 Specifically the structure of this is:
 
-```
+```wit
 use-item ::= 'use' use-names 'from' id
 
 use-names ::= '*'
@@ -167,26 +167,28 @@ use-names-item ::= id
                  | id 'as' id
 ```
 
+Note: Here `use-names-list?` means at least one `use-name-list` term.
+
 ## Items: type
 
-There are a number of methods of defining types in a wit document, and all of
-the types that can be defined in wit are intended to map directly to types in
-th interface types specification.
+There are a number of methods of defining types in a `wit` document, and all of
+the types that can be defined in `wit` are intended to map directly to types in
+the [interface types specification](https://github.com/WebAssembly/interface-types).
 
 ### Item: `type` (alias)
 
-A `type` statement declares a new named type in the wit document. This name can
+A `type` statement declares a new named type in the `wit` document. This name can
 be later referred to when defining items using this type. This construct is
 similar to a type alias in other languages
 
-```
+```wit
 type my-awesome-u32 = u32
 type my-complicated-tuple = tuple<u32, s32, string>
 ```
 
 Specifically the structure of this is:
 
-```
+```wit
 type-item ::= 'type' id '=' ty
 ```
 
@@ -196,7 +198,7 @@ A `record` statement declares a new named structure with named fields. Records
 are similar to a `struct` in many languages. Instances of a `record` always have
 their fields defined.
 
-```
+```wit
 record pair {
     x: u32,
     y: u32,
@@ -211,7 +213,7 @@ record person {
 
 Specifically the structure of this is:
 
-```
+```wit
 record-item ::= 'record' id '{' record-fields '}'
 
 record-fields ::= record-field
@@ -224,10 +226,10 @@ record-field ::= id ':' ty
 
 A `flags` statement defines a new `record`-like structure where all the fields
 are booleans. The `flags` type is distinct from `record` in that it typically is
-represented as a bitflags representation in the canonical ABI. For the purposes
+represented as a bit flags representation in the canonical ABI. For the purposes
 of type-checking, however, it's simply syntactic sugar for a record-of-booleans.
 
-```
+```wit
 flags properties {
     lego,
     marvel-superhero,
@@ -245,7 +247,7 @@ flags properties {
 
 Specifically the structure of this is:
 
-```
+```wit
 flags-items ::= 'flags' id '{' flags-fields '}'
 
 flags-fields ::= id,
@@ -264,7 +266,7 @@ present when values have that particular case's tag.
 
 All `variant` type must have at least one case specified.
 
-```
+```wit
 variant filter {
     all,
     none,
@@ -274,7 +276,7 @@ variant filter {
 
 Specifically the structure of this is:
 
-```
+```wit
 variant-items ::= 'variant' id '{' variant-cases '}'
 
 variant-cases ::= variant-case,
@@ -291,7 +293,7 @@ An `enum` statement defines a new type which is semantically equivalent to a
 however, to possibly have a different representation in the language ABIs or
 have different bindings generated in for languages.
 
-```
+```wit
 enum color {
     red,
     green,
@@ -313,7 +315,7 @@ enum color {
 
 Specifically the structure of this is:
 
-```
+```wit
 enum-items ::= 'enum' id '{' enum-cases '}'
 
 enum-cases ::= id,
@@ -328,7 +330,7 @@ numerical. This is special-cased, however, to possibly have a different
 representation in the language ABIs or have different bindings generated in for
 languages.
 
-```
+```wit
 union configuration {
     string,
     list<string>,
@@ -344,7 +346,7 @@ union configuration {
 
 Specifically the structure of this is:
 
-```
+```wit
 union-items ::= 'union' id '{' union-cases '}'
 
 union-cases ::= ty,
@@ -357,7 +359,7 @@ Functions can also be defined in a `*.wit` document. Functions have a name,
 parameters, and results. Functions can optionally also be declared as `async`
 functions.
 
-```
+```wit
 thunk: function()
 fibonacci: function(n: u32) -> u32
 sleep: async function(ms: u64)
@@ -365,7 +367,7 @@ sleep: async function(ms: u64)
 
 Specifically functions have the structure:
 
-```
+```wit
 func-item ::= id ':' 'async'? 'function' '(' func-args ')' func-ret
 
 func-args ::= func-arg
@@ -389,7 +391,7 @@ Resources can also optionally have functions defined within them which adds an
 implicit "self" argument as the first argument to each function of the same type
 of the including resource, unless the function is flagged as `static`.
 
-```
+```wit
 resource file-descriptor
 
 resource request {
@@ -402,7 +404,7 @@ resource request {
 
 Specifically resources have the structure:
 
-```
+```wit
 resource-item ::= 'resource' id resource-contents
 
 resource-contents ::= nil
@@ -416,12 +418,12 @@ resource-def ::= 'static'? func-item
 
 ## Types
 
-As mentioned previously the intention of wit is to allow defining types
+As mentioned previously the intention of `wit` is to allow defining types
 corresponding to the interface types specification. Many of the top-level items
 above are introducing new named types but "anonymous" types are also supported,
 such as built-ins. For example:
 
-```
+```wit
 type number = u32
 type fallible-function-result = expected<u32, string>
 type headers = list<string>
@@ -429,7 +431,7 @@ type headers = list<string>
 
 Specifically the following types are available:
 
-```
+```wit
 ty ::= 'u8' | 'u16' | 'u32' | 'u64'
      | 's8' | 's16' | 's32' | 's64'
      | 'f32' | 'f64'
@@ -455,7 +457,6 @@ expected-ty ::= '_'
               | ty
 ```
 
-
 The `tuple` type is semantically equivalent to a `record` with numerical fields,
 but it frequently can have language-specific meaning so it's provided as a
 first-class type.
@@ -463,7 +464,7 @@ first-class type.
 Similarly the `option` and `expected` types are semantically equivalent to the
 variants:
 
-```
+```wit
 variant option {
     none,
     some(ty),
@@ -484,39 +485,41 @@ through a `use` statement or they can be defined locally.
 
 ## Identifiers
 
-Identifiers in wit can be defined with two different forms. The first is a bare
-inline identifier with alphanumeric ascii characters:
+Identifiers in `wit` can be defined with two different forms. The first is a bare
+inline identifier with alphanumeric ASCII characters:
 
-```
+```wit
 foo: function(bar: u32)
 ```
 
 but these identifiers are limited in their definition not only in the character
-set (only ascii alphanumerics) but also they can't collide with other keywords.
+set (only ASCII alphanumerics) but also they can't collide with other keywords.
 To work around this restriction identifiers can also be declared in quotes:
 
-```
+```wit
 "foo": function("bar": u32)
 
 "variant": function("enum": s32)
 
 "function with spaces in its name": function()
+
+"can also be valid unicode 🚀": function("⛽": i32)
 ```
 
 ## Name resolution
 
-A wit document is resolved after parsing to ensure that all names resolve
-correctly. For example this is not a valid wit document:
+A `wit` document is resolved after parsing to ensure that all names resolve
+correctly. For example this is not a valid `wit` document:
 
-```
+```wit
 type foo = bar  // ERROR: name `bar` not defined
 ```
 
 Type references primarily happen through the `id` production of `ty`.
 
-Additionally names in a wit document can only be defined once:
+Additionally names in a `wit` document can only be defined once:
 
-```
+```wit
 type foo = u32
 type foo = u64  // ERROR: name `foo` already defined
 ```
@@ -524,7 +527,7 @@ type foo = u64  // ERROR: name `foo` already defined
 Names do not be defined before they're used (unlike in C or C++), it's ok to
 define a type after it's used:
 
-```
+```wit
 type foo = bar
 
 record bar {
@@ -534,7 +537,7 @@ record bar {
 
 Types, however, cannot be recursive:
 
-```
+```wit
 type foo = foo  // ERROR: cannot refer to itself
 
 record bar1 {
@@ -546,7 +549,7 @@ record bar2 {
 }
 ```
 
-The intention of wit is that it maps down to interface types, so the goal of
+The intention of `wit` is that it maps down to interface types, so the goal of
 name resolution is to effectively create the type section of a wasm module using
 interface types. The restrictions about self-referential types and such come
 from how types can be defined in the interface types section. Additionally


### PR DESCRIPTION
This PR adds some edits for clarity and convention.  One point of confusion not addressed is the presence of two headings with `Identifier`.