### PR TITLE
Allow _ (unit type) in Unions

### DIFF
--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -594,12 +594,16 @@ impl<'a> TypeDef<'a> {
                 Token::LeftBrace,
                 Token::RightBrace,
                 |docs, tokens| {
-                    let ty = Type::parse(tokens)?;
+                    let ty = if tokens.eat(Token::Underscore)? {
+                        None
+                    } else {
+                        Some(Type::parse(tokens)?)
+                    };
                     i += 1;
                     Ok(Case {
                         docs,
                         name: (i - 1).to_string().into(),
-                        ty: Some(ty),
+                        ty,
                     })
                 },
             )?,

--- a/crates/parser/tests/ui/types.wit
+++ b/crates/parser/tests/ui/types.wit
@@ -50,6 +50,8 @@ type t46 = t44
 type t47 = "t44"
 type t48 = push-buffer<u8>
 type t49 = pull-buffer<u8>
+union t50 { _, u32 }
+union t51 { u32, _, f32 }
 
 // type order doesn't matter
 type foo = bar

--- a/crates/parser/tests/ui/types.wit.result
+++ b/crates/parser/tests/ui/types.wit.result
@@ -302,15 +302,15 @@
         "fields": [
           [
             "a",
-            "type-53"
+            "type-55"
           ],
           [
             "b",
-            "type-53"
+            "type-55"
           ],
           [
             "c",
-            "type-53"
+            "type-55"
           ]
         ]
       }
@@ -322,15 +322,15 @@
         "fields": [
           [
             "a",
-            "type-53"
+            "type-55"
           ],
           [
             "b",
-            "type-53"
+            "type-55"
           ],
           [
             "c",
-            "type-53"
+            "type-55"
           ]
         ]
       }
@@ -406,7 +406,7 @@
           ],
           [
             "b",
-            "type-54"
+            "type-56"
           ]
         ]
       }
@@ -438,7 +438,7 @@
           ],
           [
             "1",
-            "type-54"
+            "type-56"
           ]
         ]
       }
@@ -454,7 +454,7 @@
           ],
           [
             "1",
-            "type-54"
+            "type-56"
           ]
         ]
       }
@@ -523,7 +523,7 @@
     {
       "idx": 46,
       "name": "t45",
-      "list": "type-56"
+      "list": "type-58"
     },
     {
       "idx": 47,
@@ -547,16 +547,52 @@
     },
     {
       "idx": 51,
-      "name": "foo",
-      "primitive": "type-52"
+      "name": "t50",
+      "variant": {
+        "cases": [
+          [
+            "0",
+            null
+          ],
+          [
+            "1",
+            "u32"
+          ]
+        ]
+      }
     },
     {
       "idx": 52,
+      "name": "t51",
+      "variant": {
+        "cases": [
+          [
+            "0",
+            "u32"
+          ],
+          [
+            "1",
+            null
+          ],
+          [
+            "2",
+            "f32"
+          ]
+        ]
+      }
+    },
+    {
+      "idx": 53,
+      "name": "foo",
+      "primitive": "type-54"
+    },
+    {
+      "idx": 54,
       "name": "bar",
       "primitive": "u32"
     },
     {
-      "idx": 53,
+      "idx": 55,
       "variant": {
         "cases": [
           [
@@ -571,7 +607,7 @@
       }
     },
     {
-      "idx": 54,
+      "idx": 56,
       "variant": {
         "cases": [
           [
@@ -586,12 +622,12 @@
       }
     },
     {
-      "idx": 55,
+      "idx": 57,
       "list": "type-33"
     },
     {
-      "idx": 56,
-      "list": "type-55"
+      "idx": 58,
+      "list": "type-57"
     }
   ]
 }


### PR DESCRIPTION
Allow unions to have variants without a type.

This just requires changing the parser, since unions are just an alias
for variants with indexes as variant names, and variants don't need a type.

Notes:

* it wanted  to check that `_` is only present at most once, but there currently isn't any duplicate type checking for unions anyway so I just left it as is

* There are currently *a lot* of failing UI tests for the parser on main! None of those are affected
* The additional tests types in `types.wit` are at the bottom to keep the diff a bit smaller instead of renumbering