### PR TITLE
Implement `AsFd` etc. for handle types in the rust-wasm bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "4f8499797f7e264c83334d9fc98b2c9889ebe5839514a14d81769ca09d71fd1d"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "rustc_version",
  "winapi",
 ]
@@ -170,7 +170,7 @@ dependencies = [
  "errno",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "ipnet",
  "maybe-owned",
  "rustc_version",
@@ -198,7 +198,7 @@ checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "ipnet",
  "rustc_version",
  "rustix",
@@ -562,7 +562,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "rustix",
  "winapi",
 ]
@@ -746,7 +746,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a1d9a66d8b0312e3601a04a2dcf8f0ddd873319560ddeabe2110fa1e5af781a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "rustc_version",
  "winapi",
 ]
@@ -758,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
 dependencies = [
  "rustc_version",
+ "winapi",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806a2263a7ab56a48a20d88340e87a8e810b6f5adbbc1ac45ed57aaa33570343"
+dependencies = [
  "winapi",
 ]
 
@@ -1200,7 +1209,7 @@ checksum = "18c44018277ec7195538f5631b90def7ad975bb46370cb0f4eff4012de9333f8"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "itoa",
  "libc",
  "linux-raw-sys",
@@ -1358,7 +1367,7 @@ dependencies = [
  "bitflags",
  "cap-fs-ext",
  "cap-std",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "rustc_version",
  "rustix",
  "winapi",
@@ -1574,7 +1583,7 @@ dependencies = [
  "cap-std",
  "cap-time-ext",
  "fs-set-times",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "lazy_static",
  "rustix",
  "system-interface",
@@ -1972,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ecd175b4077107a91bb6bbb34aa9a691d8b45314791776f78b63a1cb8a08928"
 dependencies = [
  "bitflags",
- "io-lifetimes",
+ "io-lifetimes 0.3.3",
  "winapi",
 ]
 
@@ -2109,6 +2118,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitflags",
+ "io-lifetimes 0.4.3",
  "wit-bindgen-rust-impl",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806a2263a7ab56a48a20d88340e87a8e810b6f5adbbc1ac45ed57aaa33570343"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
 dependencies = [
  "winapi",
 ]
@@ -2118,7 +2118,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitflags",
- "io-lifetimes 0.4.3",
+ "io-lifetimes 0.4.4",
  "wit-bindgen-rust-impl",
 ]
 

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -544,11 +544,12 @@ impl Generator for RustWasm {
                 "{{
                     fn drop(&mut self) {{
                         unsafe {{
-                            drop({}_close(self.as_raw()));
+                            drop({}_close({}(self.as_raw())));
                         }}
                     }}
                 }}\n",
                 name,
+                name.to_camel_case(),
             ));
         } else {
             self.src.push_str(&format!(

--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -9,5 +9,8 @@ wit-bindgen-rust-impl = { path = "../rust-wasm-impl" }
 async-trait = "0.1.51"
 bitflags = "1.3"
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+io-lifetimes = { version = "0.4.3", default-features = false }
+
 [features]
 witx-compat = ['wit-bindgen-rust-impl/witx-compat']

--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1.51"
 bitflags = "1.3"
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-io-lifetimes = { version = "0.4.3", default-features = false }
+io-lifetimes = { version = "0.4.4", default-features = false }
 
 [features]
 witx-compat = ['wit-bindgen-rust-impl/witx-compat']

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub mod imports;
 #[doc(hidden)]
 pub use bitflags;
 
+// Re-export `io-lifetimes` so that we can reference it from macros.
+#[doc(hidden)]
+#[cfg(target_os = "wasi")]
+pub use io_lifetimes;
+
 /// A type for handles to resources that appear in exported functions.
 ///
 /// This type is used as `Handle<T>` for argument types and return values of

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -55,6 +55,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "io-lifetimes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806a2263a7ab56a48a20d88340e87a8e810b6f5adbbc1ac45ed57aaa33570343"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +242,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "wit-bindgen-gen-core"
 version = "0.1.0"
 dependencies = [
@@ -263,6 +294,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitflags",
+ "io-lifetimes",
  "wit-bindgen-rust-impl",
 ]
 

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "io-lifetimes"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806a2263a7ab56a48a20d88340e87a8e810b6f5adbbc1ac45ed57aaa33570343"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
 dependencies = [
  "winapi",
 ]


### PR DESCRIPTION
Implement `AsFd`/`FromFd`/`IntoFd` and `AsRawFd`/`FromRawFd`/`IntoRawFd`
traits for handle types in the rust-wasm bindings.

This makes it more convenient to implement types like `File` and
`TcpStream` as wrappers around handles, as they support the usual
I/O handle APIs, and can simply be constructed directly from `FromFd`
without having to use raw handles and the unsafe `from_raw_fd`.

These traits are part of the [I/O safety RFC], which are
[implemented in Rust nightly]. In order to avoid having wit-bindgen
depend on nightly, this PR uses the [io-lifetimes] crate, which
contains standalone definitions of the main types and traits. Once
I/O safety is stabilized, the code can be switched to use std.

[I/O safety RFC]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
[implemented in Rust nightly]: https://github.com/rust-lang/rust/issues/87074
[io-lifetimes]: https://crates.io/crates/io-lifetimes