### PR TITLE
gen-wasmtime: fix typo in generated code

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -1221,7 +1221,7 @@ impl Generator for Wasmtime {
             };
             self.push_str(&format!(
                 "
-                    /// Instantaites the provided `module` using the specified
+                    /// Instantiates the provided `module` using the specified
                     /// parameters, wrapping up the result in a structure that
                     /// translates between wasm and the host.
                     ///


### PR DESCRIPTION
Trivial. It's just been bugging me. 😅 