### PR TITLE
Rename errno "acces" to "access"

### DIFF
--- a/tests/codegen/wasi-next/wasi-types.wit
+++ b/tests/codegen/wasi-next/wasi-types.wit
@@ -39,7 +39,7 @@ enum errno {
   /// Argument list too long.
   toobig,
   /// Permission denied.
-  acces,
+  access,
   /// Address in use.
   addrinuse,
   /// Address not available.

--- a/tests/codegen/wasi_snapshot_preview1/typenames.witx
+++ b/tests/codegen/wasi_snapshot_preview1/typenames.witx
@@ -44,7 +44,7 @@
     ;;; Argument list too long.
     $2big
     ;;; Permission denied.
-    $acces
+    $access
     ;;; Address in use.
     $addrinuse
     ;;; Address not available.


### PR DESCRIPTION
Presumably the spelling of "access" as "acces" is a typo.
This PR replaces the instance of "acces" in `was-types.wit` and `typenames.witx` with "access"