### PR TITLE
Fix typed array canonical list lowering in JS bindgen

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -1734,7 +1734,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         ));
                         // TODO: this is the wrong endianness
                         self.src.js(&format!(
-                            "(new Uint8Array(memory.buffer, ptr{}, len{0} * {})).set(new Uint8Array(val{0}.buffer));\n",
+                            "(new Uint8Array(memory.buffer, ptr{0}, len{0} * {1})).set(new Uint8Array(val{0}.buffer, val{0}.byteOffset, len{0} * {1}));\n",
                             tmp, size,
                         ));
                     }

--- a/tests/runtime/lists/exports.wit
+++ b/tests/runtime/lists/exports.wit
@@ -9,4 +9,5 @@ list-result: function() -> list<u8>
 list-result2: function() -> string
 list-result3: function() -> list<string>
 
+list-roundtrip: function(a: list<u8>) -> list<u8>
 string-roundtrip: function(a: string) -> string

--- a/tests/runtime/lists/host.py
+++ b/tests/runtime/lists/host.py
@@ -28,6 +28,9 @@ class MyImports:
     def list_result3(self) -> List[str]:
         return ['hello,', 'world!']
 
+    def list_roundtrip(self, a: bytes) -> bytes:
+        return a
+
     def string_roundtrip(self, a: str) -> str:
         return a
 

--- a/tests/runtime/lists/host.rs
+++ b/tests/runtime/lists/host.rs
@@ -43,6 +43,10 @@ impl Imports for MyImports {
         vec!["hello,".to_string(), "world!".to_string()]
     }
 
+    fn list_roundtrip(&mut self, list: &[u8]) -> Vec<u8> {
+        list.to_vec()
+    }
+
     fn string_roundtrip(&mut self, s: &str) -> String {
         s.to_string()
     }

--- a/tests/runtime/lists/host.ts
+++ b/tests/runtime/lists/host.ts
@@ -25,6 +25,7 @@ async function run() {
     },
     listResult2() { return 'hello!'; },
     listResult3() { return ['hello,', 'world!']; },
+    listRoundtrip(x) { return x; },
     stringRoundtrip(x) { return x; },
 
     unalignedRoundtrip1(u16, u32, u64, flag32, flag64) {
@@ -119,6 +120,12 @@ async function run() {
   assert.deepStrictEqual(Array.from(wasm.listResult()), [1, 2, 3, 4, 5]);
   assert.deepStrictEqual(wasm.listResult2(), "hello!");
   assert.deepStrictEqual(wasm.listResult3(), ["hello,", "world!"]);
+  
+  const buffer = new ArrayBuffer(8);
+  (new Uint8Array(buffer)).set(new Uint8Array([1, 2, 3, 4]), 2);
+  // Create a view of the four bytes in the middle of the buffer
+  const view = new Uint8Array(buffer, 2, 4);
+  assert.deepStrictEqual(Array.from(wasm.listRoundtrip(view)), [1, 2, 3, 4]);
 
   assert.deepStrictEqual(wasm.stringRoundtrip("x"), "x");
   assert.deepStrictEqual(wasm.stringRoundtrip(""), "");

--- a/tests/runtime/lists/imports.wit
+++ b/tests/runtime/lists/imports.wit
@@ -30,6 +30,8 @@ list-minmax32: function(a: list<u32>, b: list<s32>) -> (list<u32>, list<s32>)
 list-minmax64: function(a: list<u64>, b: list<s64>) -> (list<u64>, list<s64>)
 list-minmax-float: function(a: list<f32>, b: list<f64>) -> (list<f32>, list<f64>)
 
+list-roundtrip: function(a: list<u8>) -> list<u8>
+
 string-roundtrip: function(a: string) -> string
 
 unaligned-roundtrip1: function(a: list<u16>, b: list<u32>, c: list<u64>, d: list<flag32>, e: list<flag64>)

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -283,6 +283,10 @@ void exports_list_result3(exports_list_string_t *ret0) {
   exports_string_dup(&ret0->ptr[1], "world!");
 }
 
+void exports_list_roundtrip(exports_list_u8_t *a, exports_list_u8_t *ret0) {
+  *ret0 = *a;
+}
+
 void exports_string_roundtrip(exports_string_t *a, exports_string_t *ret0) {
   *ret0 = *a;
 }

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -159,6 +159,10 @@ impl exports::Exports for Exports {
         vec!["hello,".to_string(), "world!".to_string()]
     }
 
+    fn list_roundtrip(x: Vec<u8>) -> Vec<u8> {
+        x.clone()
+    }
+
     fn string_roundtrip(x: String) -> String {
         x.clone()
     }


### PR DESCRIPTION
Hey there!

I was messing around with the JS output and noticed an issue with the way memory is copied when lowering lists of bytes. The argument is a typed array, but it copies the entire underlying buffer, which in some cases can be larger than the view of the typed array. This results in an error since we end up trying to write more data than what's expected. 

I fixed this by explicitly providing the byte offset and size.

Let me know if there's any other information I can provide or anything I can do to help get this merged.

Cheers!