### PR TITLE
feat(TS): make nullable fields use option `?`

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -189,7 +189,7 @@ impl Js {
                     TypeDefKind::Variant(v) => {
                         if self.is_nullable_option(iface, v) {
                             self.print_ty(iface, v.cases[1].ty.as_ref().unwrap());
-                            self.src.ts(" | null")
+                            self.src.ts(" | null");
                         } else if let Some(t) = v.as_option() {
                             self.needs_ty_option = true;
                             self.src.ts("Option<");

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -465,6 +465,28 @@ impl Interface {
             _ => false,
         }
     }
+    pub fn get_variant(&self, ty: &Type) -> Option<&Variant> {
+        if let Type::Id(id) = ty {
+            match &self.types[*id].kind {
+                TypeDefKind::Variant(v) => Some(v),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn get_nullable_option(&self, ty: &Type) -> Option<&Type> {
+        self.get_variant(ty).and_then(|v| v.as_option())
+    }
+
+    pub fn is_nullable_option(&self, variant: &Variant) -> bool {
+        variant.as_option().map_or(false, |ty| {
+            self.get_nullable_option(ty)
+                .map_or(true, |ty| self.get_nullable_option(ty).is_none())
+        })
+
+    }
 }
 
 fn load_fs(root: &Path, name: &str) -> Result<(PathBuf, String)> {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -475,17 +475,6 @@ impl Interface {
             None
         }
     }
-
-    pub fn get_nullable_option(&self, ty: &Type) -> Option<&Type> {
-        self.get_variant(ty).and_then(|v| v.as_option())
-    }
-
-    pub fn is_nullable_option(&self, variant: &Variant) -> bool {
-        variant.as_option().map_or(false, |ty| {
-            self.get_nullable_option(ty)
-                .map_or(true, |ty| self.get_nullable_option(ty).is_none())
-        })
-    }
 }
 
 fn load_fs(root: &Path, name: &str) -> Result<(PathBuf, String)> {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -485,7 +485,6 @@ impl Interface {
             self.get_nullable_option(ty)
                 .map_or(true, |ty| self.get_nullable_option(ty).is_none())
         })
-
     }
 }
 

--- a/tests/runtime/handles/host.ts
+++ b/tests/runtime/handles/host.ts
@@ -97,7 +97,7 @@ async function run() {
   c.drop();
   d.drop();
 
-  wasm.wasmState2ResultRecord().a.drop();
+  wasm.wasmState2ResultRecord().a?.drop();
   wasm.wasmState2ResultTuple()[0].drop();
   const opt = wasm.wasmState2ResultOption();
   if (opt === null)


### PR DESCRIPTION
Now fields and type aliases that are nullable are encoded as `T?` instead of `T | null`.

For fields (properties), this means `T | undefined` and for type aliases `T | null` as before.