### PR TITLE
fix(TS): use `/**` doc string in TS 

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -273,9 +273,9 @@ impl Js {
         };
         self.src.ts("/**\n");
         for line in docs.lines() {
-            self.src.ts(&format!("* {}\n", line));
+            self.src.ts(&format!(" * {}\n", line));
         }
-        self.src.ts("*/\n");
+        self.src.ts(" */\n");
     }
 
     fn ts_func(&mut self, iface: &Interface, func: &Function) {

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -271,9 +271,11 @@ impl Js {
             Some(docs) => docs,
             None => return,
         };
+        self.src.ts("/**\n");
         for line in docs.lines() {
-            self.src.ts(&format!("// {}\n", line));
+            self.src.ts(&format!("* {}\n", line));
         }
+        self.src.ts("*/\n");
     }
 
     fn ts_func(&mut self, iface: &Interface, func: &Function) {

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -843,19 +843,23 @@ impl Generator for Js {
             self.src.js(&format!("export class {} {{\n", module));
 
             self.src.ts("
-                // The WebAssembly instance that this class is operating with.
-                // This is only available after the `instantiate` method has
-                // been called.
+               /**
+                * The WebAssembly instance that this class is operating with.
+                * This is only available after the `instantiate` method has
+                * been called.
+                */
                 instance: WebAssembly.Instance;
             ");
 
             self.src.ts("
-                // Constructs a new instance with internal state necessary to
-                // manage a wasm instance.
-                //
-                // Note that this does not actually instantiate the WebAssembly
-                // instance or module, you'll need to call the `instantiate`
-                // method below to \"activate\" this class.
+               /**
+                * Constructs a new instance with internal state necessary to
+                * manage a wasm instance.
+                *
+                * Note that this does not actually instantiate the WebAssembly
+                * instance or module, you'll need to call the `instantiate`
+                * method below to \"activate\" this class.
+                */
                 constructor();
             ");
             if self.exported_resources.len() > 0 {
@@ -872,16 +876,18 @@ impl Generator for Js {
             }
 
             self.src.ts("
-                // This is a low-level method which can be used to add any
-                // intrinsics necessary for this instance to operate to an
-                // import object.
-                //
-                // The `import` object given here is expected to be used later
-                // to actually instantiate the module this class corresponds to.
-                // If the `instantiate` method below actually does the
-                // instantiation then there's no need to call this method, but
-                // if you're instantiating manually elsewhere then this can be
-                // used to prepare the import object for external instantiation.
+               /** 
+                * This is a low-level method which can be used to add any
+                * intrinsics necessary for this instance to operate to an
+                * import object.
+                *
+                * The `import` object given here is expected to be used later
+                * to actually instantiate the module this class corresponds to.
+                * If the `instantiate` method below actually does the
+                * instantiation then there's no need to call this method, but
+                * if you're instantiating manually elsewhere then this can be
+                * used to prepare the import object for external instantiation.
+                */
                 addToImports(imports: any): void;
             ");
             self.src.js("addToImports(imports) {\n");
@@ -928,34 +934,36 @@ impl Generator for Js {
 
             self.src.ts(&format!(
                 "
-                    // Initializes this object with the provided WebAssembly
-                    // module/instance.
-                    //
-                    // This is intended to be a flexible method of instantiating
-                    // and completion of the initialization of this class. This
-                    // method must be called before interacting with the
-                    // WebAssembly object.
-                    //
-                    // The first argument to this method is where to get the
-                    // wasm from. This can be a whole bunch of different types,
-                    // for example:
-                    //
-                    // * A precompiled `WebAssembly.Module`
-                    // * A typed array buffer containing the wasm bytecode.
-                    // * A `Promise` of a `Response` which is used with
-                    //   `instantiateStreaming`
-                    // * A `Response` itself used with `instantiateStreaming`.
-                    // * An already instantiated `WebAssembly.Instance`
-                    //
-                    // If necessary the module is compiled, and if necessary the
-                    // module is instantiated. Whether or not it's necessary
-                    // depends on the type of argument provided to
-                    // instantiation.
-                    //
-                    // If instantiation is performed then the `imports` object
-                    // passed here is the list of imports used to instantiate
-                    // the instance. This method may add its own intrinsics to
-                    // this `imports` object too.
+                   /**
+                    * Initializes this object with the provided WebAssembly
+                    * module/instance.
+                    *
+                    * This is intended to be a flexible method of instantiating
+                    * and completion of the initialization of this class. This
+                    * method must be called before interacting with the
+                    * WebAssembly object.
+                    *
+                    * The first argument to this method is where to get the
+                    * wasm from. This can be a whole bunch of different types,
+                    * for example:
+                    *
+                    * * A precompiled `WebAssembly.Module`
+                    * * A typed array buffer containing the wasm bytecode.
+                    * * A `Promise` of a `Response` which is used with
+                    *   `instantiateStreaming`
+                    * * A `Response` itself used with `instantiateStreaming`.
+                    * * An already instantiated `WebAssembly.Instance`
+                    *
+                    * If necessary the module is compiled, and if necessary the
+                    * module is instantiated. Whether or not it's necessary
+                    * depends on the type of argument provided to
+                    * instantiation.
+                    *
+                    * If instantiation is performed then the `imports` object
+                    * passed here is the list of imports used to instantiate
+                    * the instance. This method may add its own intrinsics to
+                    * this `imports` object too.
+                    */
                     instantiate(
                         module: WebAssembly.Module | BufferSource | Promise<Response> | Response | WebAssembly.Instance,
                         imports?: any,


### PR DESCRIPTION
This way the comments will be proper TS doc strings and show up in hover overs, etc.