### PR TITLE
dont depend on proc-macros unconditionally

### DIFF
--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = { version = "0.1.51", optional = true }
 bitflags = "1.3"
 
 [features]
+default = ['proc-macro']
 proc-macro = ['wit-bindgen-rust-impl']
 async = ['async-trait']
 witx-compat = ['proc-macro', 'wit-bindgen-rust-impl/witx-compat']

--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-wit-bindgen-rust-impl = { path = "../rust-wasm-impl" }
-async-trait = "0.1.51"
+wit-bindgen-rust-impl = { path = "../rust-wasm-impl", optional = true }
+async-trait = { version = "0.1.51", optional = true }
 bitflags = "1.3"
 
 [features]
-witx-compat = ['wit-bindgen-rust-impl/witx-compat']
+proc-macro = ['wit-bindgen-rust-impl']
+async = ['async-trait']
+witx-compat = ['proc-macro', 'wit-bindgen-rust-impl/witx-compat']

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -1,8 +1,10 @@
+#[cfg(feature = "async")]
 pub use async_trait::async_trait;
 use std::fmt;
 use std::marker;
 use std::mem;
 use std::ops::Deref;
+#[cfg(feature = "proc-macro")]
 pub use wit_bindgen_rust_impl::{export, import};
 
 pub mod exports;

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 futures-util = { version = "0.3.17", default-features = true }
-wit-bindgen-rust = { path = "../rust-wasm", features = ['witx-compat'] }
+wit-bindgen-rust = { path = "../rust-wasm", features = ['witx-compat', 'async'] }
 
 [features]
 unchecked = []


### PR DESCRIPTION
the use of proc-macro in the rust bindings crate was already seperate from the rest, exposed only through imports.
this makes said imports conditional, to allow for faster compile-times when they are unused (for example when using code generated from the CLI for a non-async wasm module).