### PR TITLE
Use shell expansion when reading paths from procedural macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ name = "wit-bindgen-rust-impl"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "shellexpand",
  "syn",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-rust-wasm",
@@ -2174,6 +2175,7 @@ name = "wit-bindgen-wasmtime-impl"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "shellexpand",
  "syn",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-wasmtime",

--- a/crates/rust-wasm-impl/Cargo.toml
+++ b/crates/rust-wasm-impl/Cargo.toml
@@ -11,6 +11,7 @@ test = false
 
 [dependencies]
 proc-macro2 = "1.0"
+shellexpand = "2.1.0"
 syn = "1.0"
 wit-bindgen-gen-core = { path = "../gen-core", version = "0.1" }
 wit-bindgen-gen-rust-wasm = { path = "../gen-rust-wasm", version = "0.1" }

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -26,6 +26,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "flags"
 version = "0.1.0"
 dependencies = [
@@ -37,6 +64,17 @@ name = "flags-main"
 version = "0.1.0"
 dependencies = [
  "wit-bindgen-rust",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -59,6 +97,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "lists"
@@ -145,6 +189,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "resources"
 version = "0.1.0"
 dependencies = [
@@ -164,6 +227,15 @@ name = "resources-main"
 version = "0.1.0"
 dependencies = [
  "wit-bindgen-rust",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]
@@ -257,6 +329,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "wit-bindgen-gen-core"
 version = "0.1.0"
 dependencies = [
@@ -295,6 +395,7 @@ name = "wit-bindgen-rust-impl"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "shellexpand",
  "syn",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-rust-wasm",

--- a/crates/wasmtime-impl/Cargo.toml
+++ b/crates/wasmtime-impl/Cargo.toml
@@ -11,6 +11,7 @@ test = false
 
 [dependencies]
 proc-macro2 = "1.0"
+shellexpand = "2.1.0"
 syn = "1.0"
 wit-bindgen-gen-core = { path = "../gen-core", version = "0.1" }
 wit-bindgen-gen-wasmtime = { path = "../gen-wasmtime", version = "0.1" }


### PR DESCRIPTION
This fixes #159 by expanding any environment variables in paths passed by the user.

Now, you should be able to give the macro an absolute path by writing something like this:

```rs
wit_bindgen_rust::import!("$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit");
```