### PR TITLE
Fix typo in WIT.md

### DIFF
--- a/WIT.md
+++ b/WIT.md
@@ -544,8 +544,8 @@ type foo = u32
 type foo = u64  // ERROR: name `foo` already defined
 ```
 
-Names do not be defined before they're used (unlike in C or C++), it's ok to
-define a type after it's used:
+Names do not need to be defined before they're used (unlike in C or C++),
+it's ok to define a type after it's used:
 
 ```wit
 type foo = bar


### PR DESCRIPTION
It seems like the sentence
> Names do not be defined before they're used (unlike in C or C++), it's ok to define a type after it's used:

was meant to read
> Names do not need to be defined before they're used (unlike in C or C++), it's ok to define a type after it's used:

(Sorry, I accidentally closed the PR and had to re-open it)