### PR TITLE
Implement wit2wasm and wasm2wit tools.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
-dependencies = [
- "gimli 0.25.0",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -43,15 +34,6 @@ checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -61,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -89,22 +71,22 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
- "addr2line 0.16.0",
+ "addr2line",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.26.2",
+ "object",
  "rustc-demangle",
 ]
 
@@ -140,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
@@ -215,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -230,24 +212,54 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
-name = "cpp_demangle"
-version = "0.3.3"
+name = "clap"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if",
 ]
@@ -263,24 +275,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71447555acc6c875c52c407d572fc1327dc5c34cba72b4b2e7ad048aa4e4fd19"
+checksum = "32f027f29ace03752bb83c112eb4f53744bc4baadf19955e67fcde1d71d2f39d"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9a10261891a7a919b0d4f6aa73582e88441d9a8f6173c88efbe4a5a362ea67"
+checksum = "6c10af69cbf4e228c11bdc26d8f9d5276773909152a769649a160571b282f92f"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.26.1",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -289,33 +301,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815755d76fcbcf6e17ab888545b28ab775f917cb12ce0797e60cd41a2288692c"
+checksum = "290ac14d2cef43cbf1b53ad5c1b34216c9e32e00fa9b6ac57b5e5a2064369e02"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea92f2a67335a2e4d3c9c65624c3b14ae287d595b0650822c41824febab66b"
+checksum = "beb9142d134a03d01e3995e6d8dd3aecf16312261d0cb0c5dcd73d5be2528c1c"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd25847875e388c500ad3624b4d2e14067955c93185194a7222246a25b91c975"
+checksum = "1268a50b7cbbfee8514d417fc031cedd9965b15fa9e5ed1d4bc16de86f76765e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308bcfb7eb47bdf5ff6e1ace262af4ed39ec19f204c751fffb037e0e82a0c8bf"
+checksum = "97ac0d440469e19ab12183e31a9e41b4efd8a4ca5fbde2a10c78c7bb857cc2a4"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -325,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cdc799aee673be2317e631d4569a1ba0a7e77a07a7ce45557086d2e02e9514"
+checksum = "794cd1a5694a01c68957f9cfdc5ac092cf8b4e9c2d1697c4a5100f90103e9e9e"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -336,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.81.0"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf8577386bb813bc513e524f665d62b44debaddf929308d0fa2b99c030e17c7"
+checksum = "f2ddd4ca6963f6e94d00e8935986411953581ac893587ab1f0eb4f0b5a40ae65"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -346,24 +358,24 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.82.0",
+ "wasmparser 0.82.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -382,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -395,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -467,12 +479,12 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -480,12 +492,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -504,11 +516,11 @@ dependencies = [
 
 [[package]]
 name = "errno-dragonfly"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
- "gcc",
+ "cc",
  "libc",
 ]
 
@@ -520,11 +532,11 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "file-per-thread-logger"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger 0.9.0",
  "log",
 ]
 
@@ -565,18 +577,16 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -584,38 +594,29 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -623,20 +624,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "gimli"
@@ -678,6 +673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,15 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab7905ea95c6d9af62940f9d7dd9596d54c334ae2c15300c482051292d5637f"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -736,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -757,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768dbad422f45f69c8f5ce59c0802e2681aa3e751c5db8217901607bb2bc24dd"
+checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 dependencies = [
  "libc",
  "winapi",
@@ -785,18 +777,12 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -821,21 +807,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leb128"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.40"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdc16c6ce4c85d9b46b4e66f2a814be5b3f034dbd5131c268a24ca26d970db8"
+checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "log"
@@ -869,9 +855,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -888,27 +874,18 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -924,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -935,19 +912,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.2"
+name = "os_str_bytes"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "petgraph"
@@ -961,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -973,9 +959,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_assertions"
@@ -983,7 +969,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
@@ -1014,31 +1000,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
+checksum = "6eca0fa5dd7c4c96e184cec588f0b1db1ee3165e678db21c09793105acb17e6f"
 dependencies = [
  "cc",
 ]
@@ -1055,30 +1029,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1098,15 +1065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1136,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -1207,14 +1165,14 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db890a96e64911e67fa84e58ce061a40a6a65c231e5fad20b190933f8991a27c"
+checksum = "a9466f25b92a648960ac1042fd3baa6b0bf285e60f754d7e5070770c813a177a"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "linux-raw-sys",
  "once_cell",
@@ -1223,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -1244,18 +1202,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1264,20 +1222,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1297,15 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1320,23 +1278,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.23"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1345,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1372,15 +1336,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1391,7 +1355,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "filetime",
- "heck",
+ "heck 0.3.3",
  "ignore",
  "proc-macro2",
  "quote",
@@ -1434,19 +1398,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.29"
+name = "textwrap"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1455,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -1488,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "log",
@@ -1501,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1512,18 +1482,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicase"
@@ -1545,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1569,9 +1539,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1592,9 +1562,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c807b3eaa1d21e864939768b2643b504ef2ba256ecec84d748bc1274c05f823"
+checksum = "1c8a21d19ad46499a6611da6d74636f19a6bebaaaa85254b2bec4392493abe2c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1616,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97893a7d96f65b8aeee25fda068c6c03e365890515dbdd4ac0d95bb2e03c2e"
+checksum = "73ee711ef917d4250d1b6d430d6b7f3a4820f52940fb59beb761297998ff7528"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1650,18 +1620,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.9.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=component-model#0dbb2da3c5b66f249ba05a1c6a9bdf1b2cd0b43e"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmlink"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "lazy_static",
  "petgraph",
  "pretty_assertions",
  "wasm-encoder 0.4.1",
  "wasmparser 0.78.2",
  "wasmprinter",
- "wat",
+ "wat 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wit-parser",
 ]
 
@@ -1674,7 +1652,7 @@ dependencies = [
  "log",
  "structopt",
  "wasmlink",
- "wat",
+ "wat 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wit-parser",
 ]
 
@@ -1686,9 +1664,9 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"
-version = "0.80.1"
+version = "0.80.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92b6dcaa5af4b2a176b29be3bf1402fab9e69d313141185099c7d1684f2dca"
+checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "wasmparser"
@@ -1697,20 +1675,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0559cc0f1779240d6f894933498877ea94f693d84f3ee39c9a9932c6c312bd70"
 
 [[package]]
-name = "wasmprinter"
-version = "0.2.29"
+name = "wasmparser"
+version = "0.82.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=component-model#0dbb2da3c5b66f249ba05a1c6a9bdf1b2cd0b43e"
+
+[[package]]
+name = "wasmparser"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62f18810edc34db799bcb3d555835b2eecc9b6b221f8ee74fdb5aae0bffa176"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f973822fb3ca7e03ab421910274514b405df19a3d53acb131ae4df3a2fc4eb58"
 dependencies = [
  "anyhow",
- "wasmparser 0.80.1",
+ "wasmparser 0.83.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794a893696a3bc8d5eb8f5fb30c5d1bace6552a2fc13eb84caffc258434502f"
+checksum = "4882e78d9daceeaff656d82869f298fd472ea8d8ccf96fbd310da5c1687773ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1721,7 +1710,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object 0.27.1",
+ "object",
  "once_cell",
  "paste",
  "psm",
@@ -1729,22 +1718,22 @@ dependencies = [
  "region",
  "serde",
  "target-lexicon",
- "wasmparser 0.82.0",
+ "wasmparser 0.82.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-runtime",
- "wat",
+ "wat 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d612196f85f5db5111c6d053667d3dee34ef6493295a51d6a6aef48a525258ef"
+checksum = "cf5b9af2d970624455f9ea109acc60cc477afe097f86c190eb519a8b7d6646cd"
 dependencies = [
  "anyhow",
  "base64",
@@ -1762,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032f983a46b06a4f472c0c825fcf6819489df1f2f0a268653b46d948b955aaeb"
+checksum = "1ed6ff21d2dbfe568af483f0c508e049fc6a497c73635e2c50c9b1baf3a93ed8"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1772,41 +1761,41 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli 0.26.1",
+ "gimli",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.82.0",
+ "wasmparser 0.82.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02f9ee24c14f45c9ec988b3afeed00c756fc107c379d993248595e610d71601"
+checksum = "860936d38df423b4291b3e31bc28d4895e2208f9daba351c2397d18a0a10e0bf"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli 0.26.1",
+ "gimli",
  "indexmap",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.82.0",
+ "wasmparser 0.82.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2155b2e18b86977e89d8bc4ebb40b4e9d164919022dee5a8f3d8de72a5f294ff"
+checksum = "67e285306aa274d85a22753bef826226e1cc473bac0b541523f46dccf80751cc"
 dependencies = [
  "cc",
  "rustix",
@@ -1815,18 +1804,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae414b81367a4f39c688b22f3cd2127ef1452416c1d7f83862a0ba0e1faef33"
+checksum = "e794310a0df5266c7ac73e8211a024a49e3860ac0ca2af5db8527be942ad063e"
 dependencies = [
- "addr2line 0.17.0",
+ "addr2line",
  "anyhow",
  "bincode",
  "cfg-if",
  "cpp_demangle",
- "gimli 0.26.1",
+ "gimli",
  "log",
- "object 0.27.1",
+ "object",
  "region",
  "rustc-demangle",
  "rustix",
@@ -1840,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649e06a8c331f99e11acd72425b91dd478234bc4911bad794255bb2b95172c3e"
+checksum = "90ffe5cb3db705ea43fcf37475a79891a3ada754c1cbe333540879649de943d5"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1866,21 +1855,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62289c2b4917e9ca778be49e4c606346aeaccb06591ec76ace4c85562c851812"
+checksum = "70a5b60d70c1927c5a403f7c751de179414b6b91da75b2312c3ae78196cf9dc3"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.82.0",
+ "wasmparser 0.82.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d8329c83173f6fd7a0f8157adaf258393754f3e600a2138808af4c6a969e83"
+checksum = "23fa6fbbad7e6f7dfe5fc0127ecd4bca409e3dcb51596b10ccf4949ac450d4c9"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -1909,27 +1898,47 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebc29df4629f497e0893aacd40f13a4a56b85ef6eb4ab6d603f07244f1a7bf2"
+checksum = "e9bbbd53432b267421186feee3e52436531fa69a7cfee9403f5204352df3dd05"
 dependencies = [
  "leb128",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "wast"
+version = "39.0.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=component-model#0dbb2da3c5b66f249ba05a1c6a9bdf1b2cd0b43e"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
+checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
 dependencies = [
- "wast 38.0.0",
+ "wast 39.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.41"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=component-model#0dbb2da3c5b66f249ba05a1c6a9bdf1b2cd0b43e"
+dependencies = [
+ "wast 39.0.0 (git+https://github.com/bytecodealliance/wasm-tools?branch=component-model)",
 ]
 
 [[package]]
 name = "wiggle"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ea9f3e555a9bc4796ff6c2ddaf11fbde4f70f697590d0029dc9c3404e60df3"
+checksum = "11fb3417e7e14c88f2d9ee6c3746ba6b71f4000f7f4d1450b219a278f39d31e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1942,12 +1951,12 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46668e5b1852991e1764bb4aa45584760e564efebb39ecbc95c803204e662aa"
+checksum = "d0c36b9602eda8612e2338c4f39728046819b3bc2ed71a474c5c108f5b54e1f9"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "shellexpand",
@@ -1957,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592d4c346c35bed7717240306cd946b0066000fb9578a12f8b81d76708561f26"
+checksum = "abd843bbf81370dba59cb869cb50d8e369e82b809f84b6a8db23d6b2394e50e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2045,7 +2054,7 @@ dependencies = [
 name = "wit-bindgen-gen-c"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "structopt",
  "test-helpers",
  "wit-bindgen-gen-core",
@@ -2063,7 +2072,7 @@ dependencies = [
 name = "wit-bindgen-gen-js"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "structopt",
  "test-helpers",
  "wit-bindgen-gen-core",
@@ -2073,7 +2082,7 @@ dependencies = [
 name = "wit-bindgen-gen-markdown"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "pulldown-cmark",
  "structopt",
  "wit-bindgen-gen-core",
@@ -2083,7 +2092,7 @@ dependencies = [
 name = "wit-bindgen-gen-rust"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "wit-bindgen-gen-core",
 ]
 
@@ -2091,7 +2100,7 @@ dependencies = [
 name = "wit-bindgen-gen-rust-wasm"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "structopt",
  "test-helpers",
  "wit-bindgen-gen-core",
@@ -2103,12 +2112,12 @@ dependencies = [
 name = "wit-bindgen-gen-spidermonkey"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "lazy_static",
  "structopt",
  "test-helpers",
  "wasm-encoder 0.8.0",
- "wasmparser 0.80.1",
+ "wasmparser 0.80.2",
  "wit-bindgen-gen-core",
 ]
 
@@ -2117,7 +2126,7 @@ name = "wit-bindgen-gen-wasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "structopt",
  "test-helpers",
  "wasmtime",
@@ -2131,7 +2140,7 @@ dependencies = [
 name = "wit-bindgen-gen-wasmtime-py"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "structopt",
  "test-helpers",
  "wit-bindgen-gen-core",
@@ -2177,6 +2186,20 @@ dependencies = [
  "syn",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-wasmtime",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 3.1.5",
+ "env_logger 0.9.0",
+ "log",
+ "wasm-encoder 0.9.0",
+ "wasmparser 0.82.0 (git+https://github.com/bytecodealliance/wasm-tools?branch=component-model)",
+ "wat 1.0.41 (git+https://github.com/bytecodealliance/wasm-tools?branch=component-model)",
+ "wit-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/test-rust-wasm",
   "crates/wit-bindgen-demo",
   "crates/wasmlink-cli",
+  "crates/wit-component",
   "crates/test-modules",
 ]
 resolver = "2"

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -9,6 +9,8 @@ use std::fmt;
 mod lex;
 mod resolve;
 
+pub use lex::validate_id;
+
 pub struct Ast<'a> {
     pub items: Vec<Item<'a>>,
 }

--- a/crates/parser/src/ast/lex.rs
+++ b/crates/parser/src/ast/lex.rs
@@ -450,7 +450,7 @@ fn is_keylike_continue(ch: char) -> bool {
     UnicodeXID::is_xid_continue(ch) || ch == '-'
 }
 
-fn validate_id(start: usize, id: &str) -> Result<(), Error> {
+pub fn validate_id(start: usize, id: &str) -> Result<(), Error> {
     // Ids must be in stream-safe NFC.
     if !unicode_normalization::is_nfc_stream_safe(&id) {
         return Err(Error::IdNotSSNFC(start));

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -10,7 +10,13 @@ mod ast;
 mod sizealign;
 pub use sizealign::*;
 
-#[derive(Debug)]
+/// Checks if the given string is a legal identifier in wit.
+pub fn validate_id(s: &str) -> Result<()> {
+    ast::validate_id(0, s)?;
+    Ok(())
+}
+
+#[derive(Debug, Default)]
 pub struct Interface {
     pub name: String,
     pub types: Arena<TypeDef>,
@@ -181,6 +187,13 @@ impl Variant {
 
     pub fn is_enum(&self) -> bool {
         self.cases.iter().all(|c| c.ty.is_none())
+    }
+
+    pub fn is_union(&self) -> bool {
+        self.cases
+            .iter()
+            .enumerate()
+            .all(|(i, c)| c.name.parse().ok() == Some(i) && c.ty.is_some())
     }
 
     pub fn as_option(&self) -> Option<&Type> {

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "wit-component"
+version = "0.1.0"
+authors = ["Peter Huene <peter@huene.dev>"]
+edition = "2021"
+
+[[bin]]
+name = "wit2wasm"
+path = "src/bin/wit2wasm.rs"
+required-features = ["cli"]
+
+[[bin]]
+name = "wasm2wit"
+path = "src/bin/wasm2wit.rs"
+required-features = ["cli"]
+
+[dependencies]
+wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools", branch = "component-model" }
+wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools", branch = "component-model" }
+wat = { git = "https://github.com/bytecodealliance/wasm-tools", branch = "component-model" }
+wit-parser = { path = "../parser" }
+anyhow = "1.0.55"
+clap = { version = "3.1.0", features = ["derive"], optional = true }
+env_logger = { version = "0.9.0", optional = true }
+log = { version = "0.4.14", optional = true }
+
+[features]
+default = ["cli"]
+cli = ["clap", "env_logger", "log"]

--- a/crates/wit-component/README.md
+++ b/crates/wit-component/README.md
@@ -1,0 +1,26 @@
+<div align="center">
+  <h1><code>wit-component</code></h1>
+
+  <p>
+    <strong>WebAssembly component tooling based on the component model proposal and <em>wit-bindgen</em>.</strong>
+  </p>
+
+  <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
+
+  <p>
+    <a href="https://github.com/bytecodealliance/wit-bindgen/actions?query=workflow%3ACI"><img src="https://github.com/bytecodealliance/wit-bindgen/workflows/CI/badge.svg" alt="build status" /></a>
+    <img src="https://img.shields.io/badge/rustc-stable+-green.svg" alt="supported rustc stable" />
+  </p>
+</div>
+
+# `wit-component`
+
+`wit-component` is a crate and a set of CLI tools for creating and interacting with WebAssembly components based on the [component model proposal](https://github.com/WebAssembly/component-model/).
+
+## Tools
+
+* `wit2wasm` - encodes an interface definition (in `wit`) as an "interface-only" WebAssembly component.
+  A `.wasm` component file will be generated that stores a full description of the original interface.
+
+* `wasm2wit` - decodes an "interface-only" WebAssembly component to an interface definition (in `wit`).
+  A `.wit` file will be generated that represents the interface described by the component.

--- a/crates/wit-component/src/bin/wasm2wit.rs
+++ b/crates/wit-component/src/bin/wasm2wit.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use wit_component::cli::WasmToWitApp;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_target(false)
+        .init();
+
+    if let Err(e) = WasmToWitApp::parse().execute() {
+        log::error!("{:?}", e);
+        std::process::exit(1);
+    }
+}

--- a/crates/wit-component/src/bin/wit2wasm.rs
+++ b/crates/wit-component/src/bin/wit2wasm.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use wit_component::cli::WitToWasmApp;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_target(false)
+        .init();
+
+    if let Err(e) = WitToWasmApp::parse().execute() {
+        log::error!("{:?}", e);
+        std::process::exit(1);
+    }
+}

--- a/crates/wit-component/src/cli.rs
+++ b/crates/wit-component/src/cli.rs
@@ -1,0 +1,87 @@
+//! The WebAssembly component tool command line interface.
+
+#![deny(missing_docs)]
+
+use crate::{decode_interface_component, encode_interface_component, InterfacePrinter};
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+
+/// WebAssembly interface encoder.
+///
+/// Encodes a WebAssembly interface as a WebAssembly component.
+#[derive(Debug, Parser)]
+#[clap(name = "wit2wasm", version = env!("CARGO_PKG_VERSION"))]
+pub struct WitToWasmApp {
+    /// The path of the output WebAssembly component.
+    #[clap(long, short = 'o', value_name = "OUTPUT", parse(from_os_str))]
+    pub output: Option<PathBuf>,
+
+    /// The name of the interface to encode (defaults to interface file name).
+    #[clap(long, short = 'n', value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// The path to the WebAssembly interface file to encode.
+    #[clap(index = 1, value_name = "INTERFACE", parse(from_os_str))]
+    pub interface: PathBuf,
+}
+
+impl WitToWasmApp {
+    /// Executes the application.
+    pub fn execute(self) -> Result<()> {
+        let name = self
+            .name
+            .as_deref()
+            .unwrap_or_else(|| self.interface.file_stem().unwrap().to_str().unwrap());
+
+        let output = self.output.unwrap_or_else(|| {
+            let mut stem: PathBuf = self.interface.file_stem().unwrap().into();
+            stem.set_extension("wasm");
+            stem
+        });
+
+        std::fs::write(&output, encode_interface_component(name, &self.interface)?)
+            .with_context(|| format!("failed to write output file `{}`", output.display()))?;
+
+        println!("encoded interface as component `{}`", output.display());
+
+        Ok(())
+    }
+}
+
+/// WebAssembly interface decoder.
+///
+/// Decodes a WebAssembly interface from a WebAssembly component.
+#[derive(Debug, Parser)]
+#[clap(name = "wit2wasm", version = env!("CARGO_PKG_VERSION"))]
+pub struct WasmToWitApp {
+    /// The path of the output WebAssembly interface file.
+    #[clap(long, short = 'o', value_name = "OUTPUT", parse(from_os_str))]
+    pub output: Option<PathBuf>,
+
+    /// The path to the WebAssembly component to decode.
+    #[clap(index = 1, value_name = "COMPONENT", parse(from_os_str))]
+    pub component: PathBuf,
+}
+
+impl WasmToWitApp {
+    /// Executes the application.
+    pub fn execute(self) -> Result<()> {
+        let output = self.output.unwrap_or_else(|| {
+            let mut stem: PathBuf = self.component.file_stem().unwrap().into();
+            stem.set_extension("wit");
+            stem
+        });
+
+        let interface = decode_interface_component(&self.component)?;
+
+        let mut printer = InterfacePrinter::default();
+
+        std::fs::write(&output, printer.print(&interface)?)
+            .with_context(|| format!("failed to write output file `{}`", output.display()))?;
+
+        println!("decoded interface to `{}`", output.display());
+
+        Ok(())
+    }
+}

--- a/crates/wit-component/src/cli.rs
+++ b/crates/wit-component/src/cli.rs
@@ -83,8 +83,9 @@ impl WasmToWitApp {
         let bytes = wat::parse_file(&self.component)
             .with_context(|| format!("failed to parse component `{}`", self.component.display()))?;
 
-        let interface = decode_interface_component(&bytes)
-            .with_context(|| format!("failed to decode component`{}`", self.component.display()))?;
+        let interface = decode_interface_component(&bytes).with_context(|| {
+            format!("failed to decode component `{}`", self.component.display())
+        })?;
 
         let mut printer = InterfacePrinter::default();
 

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -1,0 +1,573 @@
+use anyhow::{anyhow, bail, Context, Result};
+use std::collections::HashMap;
+use wasmparser::{
+    Chunk, ComponentExport, ComponentExportKind, ComponentFuncType, ComponentImport,
+    ComponentTypeDef, Encoding, InstanceType, InterfaceType, InterfaceTypeRef, Parser, Payload,
+    PrimitiveInterfaceType, Validator, WasmFeatures,
+};
+use wit_parser::{
+    abi::Abi, validate_id, Case, Docs, Field, Function, FunctionKind, Int, Interface, Record,
+    RecordKind, Type, TypeDef, TypeDefKind, TypeId, Variant,
+};
+
+/// Represents information about a decoded WebAssembly component.
+#[derive(Default)]
+pub struct ComponentInfo<'a> {
+    /// The types defined in the component.
+    pub types: Vec<ComponentTypeDef<'a>>,
+    /// The instance types imported by the component.
+    pub imports: Vec<ComponentImport<'a>>,
+    /// The instance types exported by the component.
+    pub exports: Vec<ComponentExport<'a>>,
+}
+
+impl<'a> ComponentInfo<'a> {
+    /// Creates a new component info by parsing the given WebAssembly component bytes.
+    pub fn new(mut bytes: &'a [u8]) -> Result<Self> {
+        let mut parser = Parser::new(0);
+        let mut validator = Validator::new();
+        let mut types = Vec::new();
+        let mut imports = Vec::new();
+        let mut exports = Vec::new();
+
+        validator.wasm_features(WasmFeatures {
+            component_model: true,
+            ..Default::default()
+        });
+
+        loop {
+            match parser.parse(bytes, true)? {
+                Chunk::Parsed { payload, consumed } => {
+                    bytes = &bytes[consumed..];
+                    match payload {
+                        Payload::Version {
+                            num,
+                            encoding,
+                            range,
+                        } => {
+                            if encoding != Encoding::Component {
+                                bail!("file is not a WebAssembly component");
+                            }
+
+                            validator.version(num, encoding, &range)?;
+                        }
+
+                        Payload::TypeSection(_) => unreachable!(),
+                        Payload::ImportSection(_) => unreachable!(),
+                        Payload::FunctionSection(_) => unreachable!(),
+                        Payload::TableSection(_) => unreachable!(),
+                        Payload::MemorySection(_) => unreachable!(),
+                        Payload::TagSection(_) => unreachable!(),
+                        Payload::GlobalSection(_) => unreachable!(),
+                        Payload::ExportSection(_) => unreachable!(),
+                        Payload::StartSection { .. } => unreachable!(),
+                        Payload::ElementSection(_) => unreachable!(),
+                        Payload::DataCountSection { .. } => unreachable!(),
+                        Payload::DataSection(_) => unreachable!(),
+                        Payload::CodeSectionStart { .. } => unreachable!(),
+                        Payload::CodeSectionEntry(_) => unreachable!(),
+
+                        Payload::ComponentTypeSection(s) => {
+                            validator.component_type_section(&s)?;
+
+                            types.reserve(s.get_count() as usize);
+                            for ty in s {
+                                types.push(ty?);
+                            }
+                        }
+                        Payload::ComponentImportSection(s) => {
+                            validator.component_import_section(&s)?;
+
+                            for import in s {
+                                let import = import?;
+                                if let ComponentTypeDef::Instance(_) = &types[import.ty as usize] {
+                                    imports.push(import);
+                                }
+                            }
+                        }
+                        Payload::ComponentFunctionSection(s) => {
+                            validator.component_function_section(&s)?;
+                        }
+                        Payload::ModuleSection { range, .. } => {
+                            validator.module_section(&range)?;
+                        }
+                        Payload::ComponentSection { range, .. } => {
+                            validator.component_section(&range)?;
+                        }
+                        Payload::InstanceSection(s) => {
+                            validator.instance_section(&s)?;
+                        }
+                        Payload::ComponentExportSection(s) => {
+                            validator.component_export_section(&s)?;
+
+                            for export in s {
+                                let export = export?;
+                                match export.kind {
+                                    ComponentExportKind::Type(index) => {
+                                        if let ComponentTypeDef::Instance(_) =
+                                            &types[index as usize]
+                                        {
+                                            exports.push(export);
+                                        }
+                                    }
+                                    ComponentExportKind::Instance(_) => {
+                                        todo!()
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        Payload::ComponentStartSection(s) => {
+                            validator.component_start_section(&s)?;
+                        }
+                        Payload::AliasSection(s) => {
+                            validator.alias_section(&s)?;
+                        }
+                        Payload::CustomSection { .. } => {
+                            // Skip custom sections
+                        }
+                        Payload::UnknownSection { id, range, .. } => {
+                            validator.unknown_section(id, &range)?;
+                        }
+                        Payload::End(offset) => {
+                            validator.end(offset)?;
+                            break;
+                        }
+                    }
+                }
+                Chunk::NeedMoreData(_) => unreachable!(),
+            }
+        }
+
+        Ok(Self {
+            types,
+            imports,
+            exports,
+        })
+    }
+}
+
+/// Represents an interface decoder for WebAssembly components.
+pub struct InterfaceDecoder<'a> {
+    info: &'a ComponentInfo<'a>,
+    name_map: HashMap<u32, &'a str>,
+    exported_funcs: Vec<u32>,
+    interface: Interface,
+    type_map: HashMap<u32, Type>,
+    bool_ty: Option<TypeId>,
+    string_ty: Option<TypeId>,
+}
+
+impl<'a> InterfaceDecoder<'a> {
+    /// Creates a new interface decoder for the given type information,
+    /// interface name, and instance type index.
+    pub fn new(info: &'a ComponentInfo<'a>, name: &str, ty: u32) -> Result<Self> {
+        let defs = match info
+            .types
+            .get(ty as usize)
+            .ok_or_else(|| anyhow!("instance type index {} out of bounds", ty))?
+        {
+            ComponentTypeDef::Instance(defs) => defs,
+            _ => bail!("type index {} is not an instance type", ty),
+        };
+
+        let mut index_map = HashMap::new();
+        let mut type_count = 0;
+        let mut name_map = HashMap::new();
+        let mut exported_funcs = Vec::new();
+
+        for ty in defs.iter() {
+            match ty {
+                InstanceType::Type(_) => {
+                    bail!("unexpected local type in instance type definition");
+                }
+                InstanceType::OuterType { count, index } => {
+                    if *count != 1 {
+                        bail!("unexpected count for outer type alias in instance type definition");
+                    }
+                    index_map.insert(type_count, *index);
+                    type_count += 1;
+                }
+                InstanceType::Export { name, ty } => {
+                    let index = index_map[ty];
+                    let ty = &info.types[index as usize];
+                    match ty {
+                        ComponentTypeDef::Function(_) | ComponentTypeDef::Interface(_) => {
+                            name_map.insert(index, *name);
+                        }
+                        _ => {}
+                    }
+
+                    if let ComponentTypeDef::Function(_) = ty {
+                        exported_funcs.push(index);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            info,
+            name_map,
+            exported_funcs,
+            interface: Interface {
+                name: name.to_string(),
+                ..Default::default()
+            },
+            type_map: HashMap::new(),
+            bool_ty: None,
+            string_ty: None,
+        })
+    }
+
+    /// Consumes the decoder and returns the interface representation.
+    pub fn finish(mut self) -> Result<Interface> {
+        let funcs = std::mem::take(&mut self.exported_funcs);
+        for index in funcs {
+            let ty = match &self.info.types[index as usize] {
+                ComponentTypeDef::Function(ty) => ty,
+                _ => unreachable!(),
+            };
+
+            let name = self.name_map[&index].to_string();
+            self.add_function(name, ty)?;
+        }
+
+        Ok(self.interface)
+    }
+
+    fn add_function(&mut self, name: String, ty: &ComponentFuncType) -> Result<()> {
+        validate_id(&name)
+            .with_context(|| format!("function name `{}` is not a valid identifier", name))?;
+
+        let mut params = Vec::new();
+        for (name, ty) in ty.params.iter() {
+            params.push((name.unwrap().to_string(), self.decode_type(ty)?));
+        }
+
+        let mut results = Vec::new();
+        if let InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit) = &ty.result {
+        } else {
+            results.push(("".to_string(), self.decode_type(&ty.result)?));
+        }
+
+        self.interface.functions.push(Function {
+            abi: Abi::Canonical,
+            is_async: false,
+            docs: Docs::default(),
+            name,
+            kind: FunctionKind::Freestanding,
+            params,
+            results,
+        });
+
+        Ok(())
+    }
+
+    fn decode_type(&mut self, ty: &InterfaceTypeRef) -> Result<Type> {
+        Ok(match ty {
+            InterfaceTypeRef::Primitive(ty) => self.decode_primitive(*ty)?,
+            InterfaceTypeRef::Type(index) => {
+                if let Some(ty) = self.type_map.get(index) {
+                    return Ok(*ty);
+                }
+
+                let name = self.name_map.get(index).map(ToString::to_string);
+
+                if let Some(name) = name.as_deref() {
+                    validate_id(name).with_context(|| {
+                        format!("type name `{}` is not a valid identifier", name)
+                    })?;
+                }
+
+                let ty = match &self.info.types[*index as usize] {
+                    ComponentTypeDef::Interface(ty) => match ty {
+                        InterfaceType::Primitive(ty) => self.decode_named_primitive(name, ty)?,
+                        InterfaceType::Record(fields) => self.decode_record(name, fields)?,
+                        InterfaceType::Variant(cases) => self.decode_variant(name, cases)?,
+                        InterfaceType::List(ty) => {
+                            let inner = self.decode_type(ty)?;
+                            Type::Id(self.alloc_type(name, TypeDefKind::List(inner)))
+                        }
+                        InterfaceType::Tuple(tys) => self.decode_tuple(name, tys)?,
+                        InterfaceType::Flags(names) => self.decode_flags(name, names)?,
+                        InterfaceType::Enum(names) => self.decode_enum(name, names)?,
+                        InterfaceType::Union(tys) => self.decode_union(name, tys)?,
+                        InterfaceType::Option(ty) => self.decode_option(name, ty)?,
+                        InterfaceType::Expected { ok, error } => {
+                            self.decode_expected(name, ok, error)?
+                        }
+                    },
+                    _ => unreachable!(),
+                };
+
+                self.type_map.insert(*index, ty);
+                ty
+            }
+        })
+    }
+
+    fn decode_named_primitive(
+        &mut self,
+        name: Option<String>,
+        ty: &PrimitiveInterfaceType,
+    ) -> Result<Type> {
+        let mut ty = self.decode_primitive(*ty)?;
+        if let Some(name) = name {
+            validate_id(&name)
+                .with_context(|| format!("type name `{}` is not a valid identifier", name))?;
+
+            ty = Type::Id(self.alloc_type(Some(name), TypeDefKind::Type(ty)));
+        }
+
+        Ok(ty)
+    }
+
+    fn decode_primitive(&mut self, ty: PrimitiveInterfaceType) -> Result<Type> {
+        Ok(match ty {
+            PrimitiveInterfaceType::Unit => bail!("unexpected unit type in interface function"),
+            PrimitiveInterfaceType::Bool => self.bool(),
+            PrimitiveInterfaceType::S8 => Type::S8,
+            PrimitiveInterfaceType::U8 => Type::U8,
+            PrimitiveInterfaceType::S16 => Type::S16,
+            PrimitiveInterfaceType::U16 => Type::U16,
+            PrimitiveInterfaceType::S32 => Type::S32,
+            PrimitiveInterfaceType::U32 => Type::U32,
+            PrimitiveInterfaceType::S64 => Type::S64,
+            PrimitiveInterfaceType::U64 => Type::U64,
+            PrimitiveInterfaceType::Float32 => Type::F32,
+            PrimitiveInterfaceType::Float64 => Type::F64,
+            PrimitiveInterfaceType::Char => Type::Char,
+            PrimitiveInterfaceType::String => self.string(),
+        })
+    }
+
+    fn decode_record(
+        &mut self,
+        name: Option<String>,
+        fields: &[(&str, InterfaceTypeRef)],
+    ) -> Result<Type> {
+        if name.is_none() {
+            bail!("interface has an unnamed record type");
+        }
+
+        let record = Record {
+            fields: fields
+                .iter()
+                .map(|(name, ty)| {
+                    Ok(Field {
+                        docs: Docs::default(),
+                        name: name.to_string(),
+                        ty: self.decode_type(ty)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            kind: RecordKind::Other,
+        };
+
+        Ok(Type::Id(self.alloc_type(name, TypeDefKind::Record(record))))
+    }
+
+    fn decode_variant(
+        &mut self,
+        name: Option<String>,
+        cases: &[wasmparser::VariantCase],
+    ) -> Result<Type> {
+        if name.is_none() {
+            bail!("interface has an unnamed variant type");
+        }
+
+        let variant = Variant {
+            cases: cases
+                .iter()
+                .map(|case| {
+                    Ok(Case {
+                        docs: Docs::default(),
+                        name: case.name.to_string(),
+                        ty: match case.ty {
+                            InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit) => None,
+                            _ => Some(self.decode_type(&case.ty)?),
+                        },
+                    })
+                })
+                .collect::<Result<_>>()?,
+            tag: Variant::infer_tag(cases.len()),
+        };
+
+        Ok(Type::Id(
+            self.alloc_type(name, TypeDefKind::Variant(variant)),
+        ))
+    }
+
+    fn decode_tuple(&mut self, name: Option<String>, tys: &[InterfaceTypeRef]) -> Result<Type> {
+        let record = Record {
+            fields: tys
+                .iter()
+                .enumerate()
+                .map(|(i, ty)| {
+                    Ok(Field {
+                        docs: Docs::default(),
+                        name: i.to_string(),
+                        ty: self.decode_type(ty)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            kind: RecordKind::Tuple,
+        };
+
+        Ok(Type::Id(self.alloc_type(name, TypeDefKind::Record(record))))
+    }
+
+    fn decode_flags(&mut self, name: Option<String>, names: &[&str]) -> Result<Type> {
+        let record = Record {
+            fields: names
+                .iter()
+                .map(|name| {
+                    Ok(Field {
+                        docs: Docs::default(),
+                        name: name.to_string(),
+                        ty: self.decode_primitive(PrimitiveInterfaceType::Bool)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            kind: RecordKind::Flags(None),
+        };
+
+        Ok(Type::Id(self.alloc_type(name, TypeDefKind::Record(record))))
+    }
+
+    fn decode_enum(&mut self, name: Option<String>, names: &[&str]) -> Result<Type> {
+        let variant = Variant {
+            cases: names
+                .iter()
+                .map(|name| {
+                    Ok(Case {
+                        docs: Docs::default(),
+                        name: name.to_string(),
+                        ty: None,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            tag: Variant::infer_tag(names.len()),
+        };
+
+        Ok(Type::Id(
+            self.alloc_type(name, TypeDefKind::Variant(variant)),
+        ))
+    }
+
+    fn decode_union(&mut self, name: Option<String>, tys: &[InterfaceTypeRef]) -> Result<Type> {
+        let variant = Variant {
+            cases: tys
+                .iter()
+                .enumerate()
+                .map(|(i, ty)| {
+                    Ok(Case {
+                        docs: Docs::default(),
+                        name: i.to_string(),
+                        ty: Some(self.decode_type(ty)?),
+                    })
+                })
+                .collect::<Result<_>>()?,
+            tag: Variant::infer_tag(tys.len()),
+        };
+
+        Ok(Type::Id(
+            self.alloc_type(name, TypeDefKind::Variant(variant)),
+        ))
+    }
+
+    fn decode_option(&mut self, name: Option<String>, ty: &InterfaceTypeRef) -> Result<Type> {
+        let variant = Variant {
+            cases: vec![
+                Case {
+                    docs: Docs::default(),
+                    name: "none".to_string(),
+                    ty: None,
+                },
+                Case {
+                    docs: Docs::default(),
+                    name: "some".to_string(),
+                    ty: Some(self.decode_type(ty)?),
+                },
+            ],
+            tag: Variant::infer_tag(2),
+        };
+
+        Ok(Type::Id(
+            self.alloc_type(name, TypeDefKind::Variant(variant)),
+        ))
+    }
+
+    fn decode_expected(
+        &mut self,
+        name: Option<String>,
+        ok: &InterfaceTypeRef,
+        error: &InterfaceTypeRef,
+    ) -> Result<Type> {
+        let variant = Variant {
+            cases: vec![
+                Case {
+                    docs: Docs::default(),
+                    name: "ok".to_string(),
+                    ty: match ok {
+                        InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit) => None,
+                        _ => Some(self.decode_type(ok)?),
+                    },
+                },
+                Case {
+                    docs: Docs::default(),
+                    name: "err".to_string(),
+                    ty: match error {
+                        InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit) => None,
+                        _ => Some(self.decode_type(error)?),
+                    },
+                },
+            ],
+            tag: Variant::infer_tag(2),
+        };
+
+        Ok(Type::Id(
+            self.alloc_type(name, TypeDefKind::Variant(variant)),
+        ))
+    }
+
+    fn alloc_type(&mut self, name: Option<String>, kind: TypeDefKind) -> TypeId {
+        self.interface.types.alloc(TypeDef {
+            docs: Docs::default(),
+            kind,
+            name,
+            foreign_module: None,
+        })
+    }
+
+    fn bool(&mut self) -> Type {
+        if self.bool_ty.is_none() {
+            self.bool_ty = Some(self.alloc_type(
+                None,
+                TypeDefKind::Variant(Variant {
+                    cases: vec![
+                        Case {
+                            docs: Docs::default(),
+                            name: "false".to_string(),
+                            ty: None,
+                        },
+                        Case {
+                            docs: Docs::default(),
+                            name: "true".to_string(),
+                            ty: None,
+                        },
+                    ],
+                    tag: Int::U8,
+                }),
+            ));
+        }
+        Type::Id(self.bool_ty.unwrap())
+    }
+
+    fn string(&mut self) -> Type {
+        if self.string_ty.is_none() {
+            self.string_ty = Some(self.alloc_type(None, TypeDefKind::List(Type::Char)));
+        }
+        Type::Id(self.string_ty.unwrap())
+    }
+}

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1,0 +1,636 @@
+use anyhow::{bail, Result};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    hash::{Hash, Hasher},
+};
+use wasm_encoder::{
+    ComponentExport, ComponentExportSection, ComponentTypeSection, InstanceType, InterfaceTypeRef,
+    PrimitiveInterfaceType,
+};
+use wit_parser::{
+    abi::Abi, Docs, Field, Function, FunctionKind, Interface, Record, RecordKind, Type, TypeDef,
+    TypeDefKind, Variant,
+};
+
+struct TypeKey<'a> {
+    interface: &'a Interface,
+    ty: Type,
+}
+
+impl Hash for TypeKey<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.ty {
+            Type::Id(id) => {
+                TypeDefKey::borrow(self.interface, &self.interface.types[id]).hash(state)
+            }
+            _ => self.ty.hash(state),
+        }
+    }
+}
+
+impl PartialEq for TypeKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.ty, other.ty) {
+            (Type::Id(id), Type::Id(other_id)) => {
+                TypeDefKey::borrow(self.interface, &self.interface.types[id])
+                    == TypeDefKey::borrow(other.interface, &other.interface.types[other_id])
+            }
+            _ => self.ty.eq(&other.ty),
+        }
+    }
+}
+
+impl Eq for TypeKey<'_> {}
+
+/// Represents a key type for interface type definitions.
+pub struct TypeDefKey<'a> {
+    interface: &'a Interface,
+    borrow: Option<&'a TypeDef>,
+    owned: Option<TypeDef>,
+}
+
+impl<'a> TypeDefKey<'a> {
+    fn borrow(interface: &'a Interface, def: &'a TypeDef) -> Self {
+        Self {
+            interface,
+            borrow: Some(def),
+            owned: None,
+        }
+    }
+
+    fn owned(interface: &'a Interface, def: TypeDef) -> Self {
+        Self {
+            interface,
+            borrow: None,
+            owned: Some(def),
+        }
+    }
+
+    fn def(&self) -> &TypeDef {
+        if let Some(kind) = self.borrow {
+            kind
+        } else {
+            self.owned.as_ref().unwrap()
+        }
+    }
+}
+
+impl PartialEq for TypeDefKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        let def = self.def();
+        let other_def = other.def();
+        def.name == other_def.name
+            && match (&def.kind, &other_def.kind) {
+                (TypeDefKind::Record(r1), TypeDefKind::Record(r2)) => {
+                    if r1.fields.len() != r2.fields.len() {
+                        return false;
+                    }
+
+                    r1.fields.iter().zip(r2.fields.iter()).all(|(f1, f2)| {
+                        f1.name == f2.name
+                            && TypeKey {
+                                interface: self.interface,
+                                ty: f1.ty,
+                            }
+                            .eq(&TypeKey {
+                                interface: other.interface,
+                                ty: f2.ty,
+                            })
+                    })
+                }
+                (TypeDefKind::Variant(v1), TypeDefKind::Variant(v2)) => {
+                    if v1.cases.len() != v2.cases.len() {
+                        return false;
+                    }
+
+                    v1.cases.iter().zip(v2.cases.iter()).all(|(c1, c2)| {
+                        c1.name == c2.name
+                            && c1
+                                .ty
+                                .map(|ty| TypeKey {
+                                    interface: self.interface,
+                                    ty,
+                                })
+                                .eq(&c2.ty.map(|ty| TypeKey {
+                                    interface: other.interface,
+                                    ty,
+                                }))
+                    })
+                }
+                (TypeDefKind::List(t1), TypeDefKind::List(t2))
+                | (TypeDefKind::Type(t1), TypeDefKind::Type(t2)) => TypeKey {
+                    interface: self.interface,
+                    ty: *t1,
+                }
+                .eq(&TypeKey {
+                    interface: other.interface,
+                    ty: *t2,
+                }),
+                _ => false,
+            }
+    }
+}
+
+impl Eq for TypeDefKey<'_> {}
+
+impl Hash for TypeDefKey<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let def = self.def();
+        def.name.hash(state);
+        match &def.kind {
+            TypeDefKind::Record(r) => {
+                state.write_u8(0);
+                for f in &r.fields {
+                    f.name.hash(state);
+                    TypeKey {
+                        interface: self.interface,
+                        ty: f.ty,
+                    }
+                    .hash(state);
+                }
+            }
+            TypeDefKind::Variant(v) => {
+                state.write_u8(1);
+                for c in &v.cases {
+                    c.name.hash(state);
+                    c.ty.map(|ty| TypeKey {
+                        interface: self.interface,
+                        ty,
+                    })
+                    .hash(state);
+                }
+            }
+            TypeDefKind::List(ty) => {
+                state.write_u8(2);
+                TypeKey {
+                    interface: self.interface,
+                    ty: *ty,
+                }
+                .hash(state);
+            }
+            TypeDefKind::Type(ty) => {
+                state.write_u8(3);
+                TypeKey {
+                    interface: self.interface,
+                    ty: *ty,
+                }
+                .hash(state);
+            }
+            TypeDefKind::Pointer(_)
+            | TypeDefKind::ConstPointer(_)
+            | TypeDefKind::PushBuffer(_)
+            | TypeDefKind::PullBuffer(_) => unreachable!(),
+        }
+    }
+}
+
+/// Represents a key type for interface function definitions.
+pub struct FunctionKey<'a> {
+    interface: &'a Interface,
+    func: &'a Function,
+}
+
+impl PartialEq for FunctionKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.func.params.len() != other.func.params.len()
+            || self.func.results.len() != other.func.results.len()
+        {
+            return false;
+        }
+
+        self.func
+            .params
+            .iter()
+            .zip(other.func.params.iter())
+            .all(|((n1, t1), (n2, t2))| {
+                n1 == n2
+                    && TypeKey {
+                        interface: self.interface,
+                        ty: *t1,
+                    }
+                    .eq(&TypeKey {
+                        interface: other.interface,
+                        ty: *t2,
+                    })
+            })
+            && self
+                .func
+                .results
+                .iter()
+                .zip(other.func.results.iter())
+                .all(|((_, t1), (_, t2))| {
+                    // Return value names aren't encoded, so ignore them
+                    TypeKey {
+                        interface: self.interface,
+                        ty: *t1,
+                    }
+                    .eq(&TypeKey {
+                        interface: other.interface,
+                        ty: *t2,
+                    })
+                })
+    }
+}
+
+impl Eq for FunctionKey<'_> {}
+
+impl Hash for FunctionKey<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.func.params.len().hash(state);
+        for (name, ty) in &self.func.params {
+            name.hash(state);
+            TypeKey {
+                interface: self.interface,
+                ty: *ty,
+            }
+            .hash(state);
+        }
+        self.func.results.len().hash(state);
+        for (_, ty) in &self.func.results {
+            // Result names aren't encoded, so ignore them
+            TypeKey {
+                interface: self.interface,
+                ty: *ty,
+            }
+            .hash(state);
+        }
+    }
+}
+
+#[derive(Default)]
+struct InterfaceEncoderState<'a> {
+    ty: InstanceType,
+    aliases: HashMap<u32, u32>,
+    exports: HashMap<&'a str, u32>,
+}
+
+/// An encoder of WebAssembly interfaces AST representations.
+pub struct InterfaceEncoder<'a> {
+    interface: &'a Interface,
+    name: &'a str,
+    types: &'a mut ComponentTypeSection,
+    exports: &'a mut ComponentExportSection,
+    type_map: &'a mut HashMap<TypeDefKey<'a>, u32>,
+    func_type_map: &'a mut HashMap<FunctionKey<'a>, u32>,
+    state: InterfaceEncoderState<'a>,
+}
+
+impl<'a> InterfaceEncoder<'a> {
+    /// Creates a new `InterfaceEncoder` for the given interface.
+    ///
+    /// The interface will be encoded in the given sections.
+    pub fn new(
+        interface: &'a Interface,
+        name: &'a str,
+        types: &'a mut ComponentTypeSection,
+        exports: &'a mut ComponentExportSection,
+        type_map: &'a mut HashMap<TypeDefKey<'a>, u32>,
+        func_type_map: &'a mut HashMap<FunctionKey<'a>, u32>,
+    ) -> Result<Self> {
+        if interface.resources.len() != 0 {
+            bail!("the use of resources in interfaces is not currently not supported");
+        }
+
+        Ok(InterfaceEncoder {
+            interface,
+            name,
+            types,
+            exports,
+            type_map,
+            func_type_map,
+            state: InterfaceEncoderState::default(),
+        })
+    }
+
+    /// Encodes the interface into the internal sections.
+    pub fn encode(&mut self) -> Result<()> {
+        for func in &self.interface.functions {
+            assert!(!func.name.is_empty());
+
+            if !matches!(func.kind, FunctionKind::Freestanding) {
+                bail!(
+                    "unsupported function `{}`: only free-standing functions are currently supported",
+                    func.name
+                );
+            }
+
+            if !matches!(func.abi, Abi::Canonical) {
+                bail!(
+                    "unsupported function `{}`: only canonical functions are supported",
+                    func.name
+                );
+            }
+
+            if func.is_async {
+                bail!(
+                    "unsupported function `{}`: only synchronous functions are currently supported",
+                    func.name
+                );
+            }
+
+            let index = match self.func_type_map.get(&FunctionKey {
+                interface: self.interface,
+                func,
+            }) {
+                Some(index) => *index,
+                None => {
+                    let index = self.encode_func_type(func)?;
+                    self.func_type_map.insert(
+                        FunctionKey {
+                            interface: self.interface,
+                            func,
+                        },
+                        index,
+                    );
+                    index
+                }
+            };
+
+            self.export_type(&func.name, index)?;
+
+            // TODO: stick interface documentation in a custom section?
+        }
+
+        let state = std::mem::take(&mut self.state);
+        let index = self.types.len();
+        self.types.instance(&state.ty);
+        self.exports.export(self.name, ComponentExport::Type(index));
+        Ok(())
+    }
+
+    fn export_type(&mut self, name: &'a str, index: u32) -> Result<()> {
+        match self.state.exports.entry(name) {
+            Entry::Occupied(e) => {
+                if *e.get() != index {
+                    bail!("duplicate export `{}`", name)
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(index);
+                let index = self.alias_type(index);
+                self.state.ty.export(name, index);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn alias_type(&mut self, index: u32) -> u32 {
+        match self.state.aliases.entry(index) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let alias = self.state.ty.type_count();
+                e.insert(alias);
+                self.state.ty.alias_outer_type(1, index);
+                alias
+            }
+        }
+    }
+
+    fn encode_record(&mut self, record: &Record) -> Result<InterfaceTypeRef> {
+        Ok(match record.kind {
+            RecordKind::Other => {
+                let fields = record
+                    .fields
+                    .iter()
+                    .map(|f| Ok((f.name.as_str(), self.encode_type(&f.ty)?)))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let index = self.types.len();
+                let encoder = self.types.interface_type();
+                encoder.record(fields);
+                InterfaceTypeRef::Type(index)
+            }
+            RecordKind::Flags(_) => {
+                let index = self.types.len();
+                let encoder = self.types.interface_type();
+                encoder.flags(record.fields.iter().map(|f| f.name.as_str()));
+                InterfaceTypeRef::Type(index)
+            }
+            RecordKind::Tuple => {
+                let tys = record
+                    .fields
+                    .iter()
+                    .map(|f| self.encode_type(&f.ty))
+                    .collect::<Result<Vec<_>>>()?;
+                let index = self.types.len();
+                let encoder = self.types.interface_type();
+                encoder.tuple(tys);
+                InterfaceTypeRef::Type(index)
+            }
+        })
+    }
+
+    fn encode_variant(&mut self, variant: &Variant) -> Result<InterfaceTypeRef> {
+        if variant.is_bool() {
+            return Ok(InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Bool));
+        }
+
+        if let Some(ty) = variant.as_option() {
+            let ty = self.encode_type(ty)?;
+            let index = self.types.len();
+            let encoder = self.types.interface_type();
+            encoder.option(ty);
+            return Ok(InterfaceTypeRef::Type(index));
+        }
+
+        if let Some((ok, error)) = variant.as_expected() {
+            let ok = ok
+                .map(|ty| self.encode_type(ty))
+                .transpose()?
+                .unwrap_or(InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit));
+            let error = error
+                .map(|ty| self.encode_type(ty))
+                .transpose()?
+                .unwrap_or(InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit));
+            let index = self.types.len();
+            let encoder = self.types.interface_type();
+            encoder.expected(ok, error);
+            return Ok(InterfaceTypeRef::Type(index));
+        }
+
+        if variant.is_enum() {
+            let index = self.types.len();
+            let encoder = self.types.interface_type();
+            encoder.enum_type(variant.cases.iter().map(|c| c.name.as_str()));
+            return Ok(InterfaceTypeRef::Type(index));
+        }
+
+        if variant.is_union() {
+            let tys = variant
+                .cases
+                .iter()
+                .map(|c| self.encode_type(c.ty.as_ref().unwrap()))
+                .collect::<Result<Vec<_>>>()?;
+
+            let index = self.types.len();
+            let encoder = self.types.interface_type();
+            encoder.union(tys);
+            return Ok(InterfaceTypeRef::Type(index));
+        }
+
+        let cases = variant
+            .cases
+            .iter()
+            .map(|c| {
+                Ok((
+                    c.name.as_str(),
+                    match c.ty.as_ref() {
+                        Some(ty) => self.encode_type(ty)?,
+                        None => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit),
+                    },
+                    None, // TODO: support defaulting case values in the future
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let index = self.types.len();
+        let encoder = self.types.interface_type();
+        encoder.variant(cases);
+        Ok(InterfaceTypeRef::Type(index))
+    }
+
+    fn encode_type(&mut self, ty: &Type) -> Result<InterfaceTypeRef> {
+        Ok(match ty {
+            Type::U8 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::U8),
+            Type::U16 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::U16),
+            Type::U32 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::U32),
+            Type::U64 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::U64),
+            Type::S8 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::S8),
+            Type::S16 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::S16),
+            Type::S32 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::S32),
+            Type::S64 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::S64),
+            Type::F32 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Float32),
+            Type::F64 => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Float64),
+            Type::Char => InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Char),
+            Type::Id(id) => {
+                let ty = &self.interface.types[*id];
+                let key = TypeDefKey::borrow(self.interface, &self.interface.types[*id]);
+                let encoded = if let Some(index) = self.type_map.get(&key) {
+                    InterfaceTypeRef::Type(*index)
+                } else {
+                    let mut encoded = match &ty.kind {
+                        TypeDefKind::Record(r) => self.encode_record(r)?,
+                        TypeDefKind::Variant(v) => self.encode_variant(v)?,
+                        TypeDefKind::List(ty) => {
+                            if matches!(ty, Type::Char) {
+                                InterfaceTypeRef::Primitive(PrimitiveInterfaceType::String)
+                            } else {
+                                let ty = self.encode_type(ty)?;
+                                let index = self.types.len();
+                                let encoder = self.types.interface_type();
+                                encoder.list(ty);
+                                InterfaceTypeRef::Type(index)
+                            }
+                        }
+                        TypeDefKind::Type(ty) => self.encode_type(ty)?,
+                        TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => {
+                            bail!("the use of pointers in interfaces is not supported")
+                        }
+                        TypeDefKind::PushBuffer(_) | TypeDefKind::PullBuffer(_) => {
+                            bail!("the use of buffers in interfaces is not currently supported")
+                        }
+                    };
+
+                    if ty.name.is_some() {
+                        if let InterfaceTypeRef::Primitive(ty) = encoded {
+                            // Named primitive types need entries in the type section
+                            let index = self.types.len();
+                            self.types.interface_type().primitive(ty);
+                            encoded = InterfaceTypeRef::Type(index);
+                        }
+                    }
+
+                    if let InterfaceTypeRef::Type(index) = encoded {
+                        self.type_map.insert(key, index);
+                    }
+
+                    encoded
+                };
+
+                if let Some(name) = ty.name.as_deref() {
+                    if let InterfaceTypeRef::Type(index) = encoded {
+                        self.export_type(name, index)?;
+                    }
+                }
+
+                encoded
+            }
+            Type::Handle(_) => {
+                bail!("the use of handle types in interfaces is not currently supported")
+            }
+            Type::CChar => {
+                bail!("the use of C characters in interfaces is not currently supported")
+            }
+            Type::Usize => bail!("the use of usize in interfaces is not currently supported"),
+        })
+    }
+
+    fn encode_func_type(&mut self, func: &Function) -> Result<u32> {
+        // Encode all referenced parameter types from this function.
+        let params: Vec<_> = func
+            .params
+            .iter()
+            .map(|(name, ty)| Ok((Some(name.as_str()), self.encode_type(ty)?)))
+            .collect::<Result<_>>()?;
+
+        let result = if func.results.is_empty() {
+            InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit)
+        } else if func.results.len() == 1 {
+            let (name, ty) = &func.results[0];
+            if !name.is_empty() {
+                bail!(
+                    "unsupported function `{}`: a single return value cannot be named",
+                    func.name
+                );
+            }
+            self.encode_type(ty)?
+        } else {
+            // Encode a tuple for the return value
+            let fields = func
+                .results
+                .iter()
+                .enumerate()
+                .map(|(i, (_, ty))| {
+                    Ok(Field {
+                        docs: Docs::default(),
+                        name: i.to_string(),
+                        ty: *ty,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let def = TypeDef {
+                docs: Docs::default(),
+                name: None,
+                kind: TypeDefKind::Record(Record {
+                    fields,
+                    kind: RecordKind::Tuple,
+                }),
+                foreign_module: None,
+            };
+
+            InterfaceTypeRef::Type(
+                match self.type_map.get(&TypeDefKey::borrow(self.interface, &def)) {
+                    Some(index) => *index,
+                    None => match &def.kind {
+                        TypeDefKind::Record(r) => match self.encode_record(r)? {
+                            InterfaceTypeRef::Type(ty) => {
+                                self.type_map
+                                    .insert(TypeDefKey::owned(self.interface, def), ty);
+                                ty
+                            }
+                            _ => unreachable!(),
+                        },
+                        _ => unreachable!(),
+                    },
+                },
+            )
+        };
+
+        // Encode the function type
+        let index = self.types.len();
+        self.types.function(params, result);
+        Ok(index)
+    }
+}

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -1,0 +1,102 @@
+//! The WebAssembly component tooling.
+
+#![deny(missing_docs)]
+
+use crate::encoding::InterfaceEncoder;
+use anyhow::{bail, Context, Result};
+use std::{collections::HashMap, path::Path};
+use wasm_encoder::{Component, ComponentExportSection, ComponentTypeSection};
+use wasmparser::{ComponentExportKind, ComponentTypeDef, Validator, WasmFeatures};
+use wit_parser::Interface;
+
+#[cfg(feature = "cli")]
+pub mod cli;
+mod decoding;
+mod encoding;
+mod printing;
+
+pub use printing::*;
+
+fn read_interface(path: impl AsRef<Path>) -> Result<Interface> {
+    let path = path.as_ref();
+
+    if !path.is_file() {
+        bail!("interface file `{}` does not exist", path.display(),);
+    }
+
+    Interface::parse_file(&path)
+        .with_context(|| format!("failed to parse interface file `{}`", path.display()))
+}
+
+/// Encodes an "interface-only" component from an interface definition file.
+///
+/// The resulting component file will only describe the types of the given interface.
+pub fn encode_interface_component(name: &str, interface: impl AsRef<Path>) -> Result<Vec<u8>> {
+    let interface = read_interface(interface)?;
+
+    let mut types = ComponentTypeSection::new();
+    let mut exports = ComponentExportSection::new();
+    let mut type_map = HashMap::new();
+    let mut func_type_map = HashMap::new();
+
+    let mut encoder = InterfaceEncoder::new(
+        &interface,
+        name,
+        &mut types,
+        &mut exports,
+        &mut type_map,
+        &mut func_type_map,
+    )?;
+    encoder.encode()?;
+
+    let mut component = Component::new();
+    component.section(&types);
+    component.section(&exports);
+    let output = component.finish();
+
+    let mut validator = Validator::new();
+    validator.wasm_features(WasmFeatures {
+        component_model: true,
+        ..Default::default()
+    });
+
+    validator
+        .validate_all(&output)
+        .context("failed to validate component output")?;
+
+    Ok(output)
+}
+
+/// Gets the imported and exported interfaces of a component.
+pub fn decode_interface_component(component: impl AsRef<Path>) -> Result<Interface> {
+    let component = component.as_ref();
+    if !component.is_file() {
+        bail!(
+            "component `{}` does not exist as a file",
+            component.display()
+        );
+    }
+
+    let bytes = wat::parse_file(component)
+        .with_context(|| format!("failed to parse component `{}`", component.display()))?;
+
+    let info = decoding::ComponentInfo::new(&bytes)?;
+    if !info.imports.is_empty() || info.exports.len() != 1 {
+        bail!(
+            "component `{}` is not an interface-only component",
+            component.display()
+        );
+    }
+
+    let export = &info.exports[0];
+
+    Ok(match export.kind {
+        ComponentExportKind::Type(ty) => match &info.types[ty as usize] {
+            ComponentTypeDef::Instance(_) => {
+                decoding::InterfaceDecoder::new(&info, export.name, ty)?.finish()?
+            }
+            _ => bail!("expected an instance type export"),
+        },
+        _ => bail!("expected a type export"),
+    })
+}

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -68,24 +68,10 @@ pub fn encode_interface_component(name: &str, interface: impl AsRef<Path>) -> Re
 }
 
 /// Gets the imported and exported interfaces of a component.
-pub fn decode_interface_component(component: impl AsRef<Path>) -> Result<Interface> {
-    let component = component.as_ref();
-    if !component.is_file() {
-        bail!(
-            "component `{}` does not exist as a file",
-            component.display()
-        );
-    }
-
-    let bytes = wat::parse_file(component)
-        .with_context(|| format!("failed to parse component `{}`", component.display()))?;
-
-    let info = decoding::ComponentInfo::new(&bytes)?;
+pub fn decode_interface_component(bytes: &[u8]) -> Result<Interface> {
+    let info = decoding::ComponentInfo::new(bytes)?;
     if !info.imports.is_empty() || info.exports.len() != 1 {
-        bail!(
-            "component `{}` is not an interface-only component",
-            component.display()
-        );
+        bail!("component is not an interface-only component");
     }
 
     let export = &info.exports[0];

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -67,7 +67,7 @@ pub fn encode_interface_component(name: &str, interface: impl AsRef<Path>) -> Re
     Ok(output)
 }
 
-/// Gets the imported and exported interfaces of a component.
+/// Decode an "interface-only" component to a wit `Interface`.
 pub fn decode_interface_component(bytes: &[u8]) -> Result<Interface> {
     let info = decoding::ComponentInfo::new(bytes)?;
     if !info.imports.is_empty() || info.exports.len() != 1 {

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -214,6 +214,20 @@ impl InterfacePrinter {
             return Ok(());
         }
 
+        if record.is_flags() {
+            match name {
+                Some(name) => {
+                    writeln!(&mut self.output, "flags {} {{", name)?;
+                    for field in &record.fields {
+                        writeln!(&mut self.output, "  {},", field.name)?;
+                    }
+                    self.output.push_str("}\n\n");
+                }
+                None => bail!("interface has unnamed flags type"),
+            }
+            return Ok(());
+        }
+
         match name {
             Some(name) => {
                 writeln!(&mut self.output, "record {} {{", name)?;

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -1,0 +1,305 @@
+use anyhow::{bail, Result};
+use std::collections::HashSet;
+use std::fmt::Write;
+use wit_parser::{Interface, Record, Type, TypeDefKind, TypeId, Variant};
+
+/// A utility for printing WebAssembly interface definitions to a string.
+#[derive(Default)]
+pub struct InterfacePrinter {
+    output: String,
+    declared: HashSet<TypeId>,
+}
+
+impl InterfacePrinter {
+    /// Print the given WebAssembly interface to a string.
+    pub fn print(&mut self, interface: &Interface) -> Result<String> {
+        for func in &interface.functions {
+            for (_, ty) in func.params.iter().chain(func.results.iter()) {
+                self.declare_type(interface, ty)?;
+            }
+        }
+
+        for func in &interface.functions {
+            write!(&mut self.output, "{}: function(", func.name)?;
+            for (i, (name, ty)) in func.params.iter().enumerate() {
+                if i > 0 {
+                    self.output.push_str(", ");
+                }
+                write!(&mut self.output, "{}: ", name)?;
+                self.print_type_name(interface, ty)?;
+            }
+            self.output.push(')');
+
+            if !func.results.is_empty() {
+                self.output.push_str(" -> ");
+                for (_, ty) in &func.results {
+                    self.print_type_name(interface, ty)?;
+                }
+            }
+
+            self.output.push_str("\n\n");
+        }
+
+        self.declared.clear();
+        Ok(std::mem::take(&mut self.output))
+    }
+
+    fn print_type_name(&mut self, interface: &Interface, ty: &Type) -> Result<()> {
+        match ty {
+            Type::U8 => self.output.push_str("u8"),
+            Type::U16 => self.output.push_str("u16"),
+            Type::U32 => self.output.push_str("u32"),
+            Type::U64 => self.output.push_str("u64"),
+            Type::S8 => self.output.push_str("s8"),
+            Type::S16 => self.output.push_str("s16"),
+            Type::S32 => self.output.push_str("s32"),
+            Type::S64 => self.output.push_str("s64"),
+            Type::F32 => self.output.push_str("f32"),
+            Type::F64 => self.output.push_str("f64"),
+            Type::Char => self.output.push_str("char"),
+
+            Type::Id(id) => {
+                let ty = &interface.types[*id];
+                if let Some(name) = &ty.name {
+                    self.output.push_str(name);
+                    return Ok(());
+                }
+
+                match &ty.kind {
+                    TypeDefKind::Record(r) => {
+                        self.print_record_type(interface, r)?;
+                    }
+                    TypeDefKind::Variant(v) => {
+                        self.print_variant_type(interface, v)?;
+                    }
+                    TypeDefKind::List(ty) => {
+                        if let Type::Char = ty {
+                            self.output.push_str("string");
+                        } else {
+                            self.output.push_str("list<");
+                            self.print_type_name(interface, ty)?;
+                            self.output.push('>');
+                        }
+                    }
+                    TypeDefKind::Type(ty) => self.print_type_name(interface, ty)?,
+
+                    TypeDefKind::Pointer(_)
+                    | TypeDefKind::ConstPointer(_)
+                    | TypeDefKind::PushBuffer(_)
+                    | TypeDefKind::PullBuffer(_) => bail!("interface has unsupported type"),
+                }
+            }
+
+            Type::CChar | Type::Usize | Type::Handle(_) => bail!("interface has unsupported type"),
+        }
+
+        Ok(())
+    }
+
+    fn print_record_type(&mut self, interface: &Interface, record: &Record) -> Result<()> {
+        if !record.is_tuple() {
+            bail!("interface has an unnamed record type");
+        }
+
+        self.output.push_str("tuple<");
+        for (i, field) in record.fields.iter().enumerate() {
+            if i > 0 {
+                self.output.push_str(", ");
+            }
+            self.print_type_name(interface, &field.ty)?;
+        }
+        self.output.push('>');
+
+        Ok(())
+    }
+
+    fn print_variant_type(&mut self, interface: &Interface, variant: &Variant) -> Result<()> {
+        if variant.is_bool() {
+            self.output.push_str("bool");
+            return Ok(());
+        }
+
+        if let Some(ty) = variant.as_option() {
+            self.output.push_str("option<");
+            self.print_type_name(interface, ty)?;
+            self.output.push('>');
+            return Ok(());
+        }
+
+        if let Some((ok, err)) = variant.as_expected() {
+            self.output.push_str("expected<");
+            match ok {
+                Some(ty) => self.print_type_name(interface, ty)?,
+                None => self.output.push('_'),
+            }
+            self.output.push_str(", ");
+            match err {
+                Some(ty) => self.print_type_name(interface, ty)?,
+                None => self.output.push('_'),
+            }
+            self.output.push('>');
+            return Ok(());
+        }
+
+        bail!("interface has an unnamed variant type");
+    }
+
+    fn declare_type(&mut self, interface: &Interface, ty: &Type) -> Result<()> {
+        match ty {
+            Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::S8
+            | Type::S16
+            | Type::S32
+            | Type::S64
+            | Type::F32
+            | Type::F64
+            | Type::Char => return Ok(()),
+
+            Type::Id(id) => {
+                if !self.declared.insert(*id) {
+                    return Ok(());
+                }
+
+                let ty = &interface.types[*id];
+                match &ty.kind {
+                    TypeDefKind::Record(r) => {
+                        self.declare_record(interface, ty.name.as_deref(), r)?
+                    }
+                    TypeDefKind::Variant(v) => {
+                        self.declare_variant(interface, ty.name.as_deref(), v)?
+                    }
+                    TypeDefKind::List(inner) => {
+                        self.declare_list(interface, ty.name.as_deref(), inner)?
+                    }
+                    TypeDefKind::Type(inner) => match ty.name.as_deref() {
+                        Some(name) => {
+                            write!(&mut self.output, "type {} = ", name)?;
+                            self.print_type_name(interface, inner)?;
+                            self.output.push_str("\n\n");
+                        }
+                        None => bail!("unnamed type in interface"),
+                    },
+
+                    TypeDefKind::Pointer(_)
+                    | TypeDefKind::ConstPointer(_)
+                    | TypeDefKind::PushBuffer(_)
+                    | TypeDefKind::PullBuffer(_) => bail!("interface has unsupported type"),
+                }
+            }
+
+            Type::CChar | Type::Usize | Type::Handle(_) => bail!("interface has unsupported type"),
+        }
+        Ok(())
+    }
+
+    fn declare_record(
+        &mut self,
+        interface: &Interface,
+        name: Option<&str>,
+        record: &Record,
+    ) -> Result<()> {
+        for field in record.fields.iter() {
+            self.declare_type(interface, &field.ty)?;
+        }
+
+        if record.is_tuple() {
+            if let Some(name) = name {
+                write!(&mut self.output, "type {} = ", name)?;
+                self.print_record_type(interface, record)?;
+                self.output.push_str("\n\n");
+            }
+            return Ok(());
+        }
+
+        match name {
+            Some(name) => {
+                writeln!(&mut self.output, "record {} {{", name)?;
+                for field in &record.fields {
+                    write!(&mut self.output, "  {}: ", field.name)?;
+                    self.declare_type(interface, &field.ty)?;
+                    self.print_type_name(interface, &field.ty)?;
+                    self.output.push_str(",\n");
+                }
+                self.output.push_str("}\n\n");
+                Ok(())
+            }
+            None => bail!("interface has unnamed record type"),
+        }
+    }
+
+    fn declare_variant(
+        &mut self,
+        interface: &Interface,
+        name: Option<&str>,
+        variant: &Variant,
+    ) -> Result<()> {
+        for case in variant.cases.iter() {
+            if let Some(ty) = &case.ty {
+                self.declare_type(interface, ty)?;
+            }
+        }
+
+        if variant.is_bool() || variant.as_option().is_some() || variant.as_expected().is_some() {
+            if let Some(name) = name {
+                write!(&mut self.output, "type {} = ", name)?;
+                self.print_variant_type(interface, variant)?;
+                self.output.push_str("\n\n");
+            }
+            return Ok(());
+        }
+
+        match name {
+            Some(name) => {
+                if variant.is_enum() {
+                    writeln!(&mut self.output, "enum {} {{", name)?;
+                    for case in &variant.cases {
+                        writeln!(&mut self.output, "  {},", case.name)?;
+                    }
+                    self.output.push_str("}\n\n");
+                    return Ok(());
+                }
+
+                if variant.is_union() {
+                    writeln!(&mut self.output, "union {} {{", name)?;
+                    for case in &variant.cases {
+                        self.output.push_str("  ");
+                        self.print_type_name(interface, case.ty.as_ref().unwrap())?;
+                        self.output.push_str(",\n");
+                    }
+                    self.output.push_str("}\n\n");
+                    return Ok(());
+                }
+
+                writeln!(&mut self.output, "variant {} {{", name)?;
+                for case in &variant.cases {
+                    write!(&mut self.output, "  {}", case.name)?;
+                    if let Some(ty) = &case.ty {
+                        self.output.push('(');
+                        self.print_type_name(interface, ty)?;
+                        self.output.push(')');
+                    }
+                    self.output.push_str(",\n");
+                }
+                self.output.push_str("}\n\n");
+                Ok(())
+            }
+            None => bail!("interface has unnamed variant type"),
+        }
+    }
+
+    fn declare_list(&mut self, interface: &Interface, name: Option<&str>, ty: &Type) -> Result<()> {
+        self.declare_type(interface, ty)?;
+
+        if let Some(name) = name {
+            write!(&mut self.output, "type {} = list<", name)?;
+            self.print_type_name(interface, ty)?;
+            self.output.push_str(">\n\n");
+            return Ok(());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/wit-component/tests/roundtrip.rs
+++ b/crates/wit-component/tests/roundtrip.rs
@@ -1,0 +1,28 @@
+//! Testing the round tripping of interfaces to component encodings and back.
+
+use anyhow::Result;
+use std::fs;
+use wit_component::{decode_interface_component, encode_interface_component, InterfacePrinter};
+
+#[test]
+fn roundtrip_interfaces() -> Result<()> {
+    for file in fs::read_dir("tests/wit")? {
+        let file = file?;
+        let bytes = encode_interface_component("test", file.path())?;
+        let interface = decode_interface_component(&bytes)?;
+
+        let mut printer = InterfacePrinter::default();
+        let output = printer.print(&interface)?;
+
+        if std::env::var_os("BLESS").is_some() {
+            fs::write(file.path(), output)?;
+        } else {
+            assert_eq!(
+                output,
+                fs::read_to_string(file.path())?.replace("\r\n", "\n")
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/wit-component/tests/wit/flags.wit
+++ b/crates/wit-component/tests/wit/flags.wit
@@ -1,0 +1,162 @@
+flags flag1 {
+  b0,
+}
+
+flags flag2 {
+  b0,
+  b1,
+}
+
+flags flag4 {
+  b0,
+  b1,
+  b2,
+  b3,
+}
+
+flags flag8 {
+  b0,
+  b1,
+  b2,
+  b3,
+  b4,
+  b5,
+  b6,
+  b7,
+}
+
+flags flag16 {
+  b0,
+  b1,
+  b2,
+  b3,
+  b4,
+  b5,
+  b6,
+  b7,
+  b8,
+  b9,
+  b10,
+  b11,
+  b12,
+  b13,
+  b14,
+  b15,
+}
+
+flags flag32 {
+  b0,
+  b1,
+  b2,
+  b3,
+  b4,
+  b5,
+  b6,
+  b7,
+  b8,
+  b9,
+  b10,
+  b11,
+  b12,
+  b13,
+  b14,
+  b15,
+  b16,
+  b17,
+  b18,
+  b19,
+  b20,
+  b21,
+  b22,
+  b23,
+  b24,
+  b25,
+  b26,
+  b27,
+  b28,
+  b29,
+  b30,
+  b31,
+}
+
+flags flag64 {
+  b0,
+  b1,
+  b2,
+  b3,
+  b4,
+  b5,
+  b6,
+  b7,
+  b8,
+  b9,
+  b10,
+  b11,
+  b12,
+  b13,
+  b14,
+  b15,
+  b16,
+  b17,
+  b18,
+  b19,
+  b20,
+  b21,
+  b22,
+  b23,
+  b24,
+  b25,
+  b26,
+  b27,
+  b28,
+  b29,
+  b30,
+  b31,
+  b32,
+  b33,
+  b34,
+  b35,
+  b36,
+  b37,
+  b38,
+  b39,
+  b40,
+  b41,
+  b42,
+  b43,
+  b44,
+  b45,
+  b46,
+  b47,
+  b48,
+  b49,
+  b50,
+  b51,
+  b52,
+  b53,
+  b54,
+  b55,
+  b56,
+  b57,
+  b58,
+  b59,
+  b60,
+  b61,
+  b62,
+  b63,
+}
+
+roundtrip-flag1: function(x: flag1) -> flag1
+
+roundtrip-flag2: function(x: flag2) -> flag2
+
+roundtrip-flag4: function(x: flag4) -> flag4
+
+roundtrip-flag8: function(x: flag8) -> flag8
+
+roundtrip-flag16: function(x: flag16) -> flag16
+
+roundtrip-flag32: function(x: flag32) -> flag32
+
+roundtrip-flag64: function(x: flag64) -> flag64
+

--- a/crates/wit-component/tests/wit/floats.wit
+++ b/crates/wit-component/tests/wit/floats.wit
@@ -1,0 +1,8 @@
+f32-param: function(x: f32)
+
+f64-param: function(x: f64)
+
+f32-result: function() -> f32
+
+f64-result: function() -> f64
+

--- a/crates/wit-component/tests/wit/integers.wit
+++ b/crates/wit-component/tests/wit/integers.wit
@@ -1,0 +1,38 @@
+a1: function(x: u8)
+
+a2: function(x: s8)
+
+a3: function(x: u16)
+
+a4: function(x: s16)
+
+a5: function(x: u32)
+
+a6: function(x: s32)
+
+a7: function(x: u64)
+
+a8: function(x: s64)
+
+a9: function(p1: u8, p2: s8, p3: u16, p4: s16, p5: u32, p6: s32, p7: u64, p8: s64)
+
+r1: function() -> u8
+
+r2: function() -> s8
+
+r3: function() -> u16
+
+r4: function() -> s16
+
+r5: function() -> u32
+
+r6: function() -> s32
+
+r7: function() -> u64
+
+r8: function() -> s64
+
+pair-ret: function() -> tuple<s64, u8>
+
+multi-ret: function() -> tuple<s64, u8>
+

--- a/crates/wit-component/tests/wit/lists.wit
+++ b/crates/wit-component/tests/wit/lists.wit
@@ -1,0 +1,89 @@
+record other-record {
+  a1: u32,
+  a2: u64,
+  a3: s32,
+  a4: s64,
+  b: string,
+  c: list<u8>,
+}
+
+record some-record {
+  x: string,
+  y: other-record,
+  c1: u32,
+  c2: u64,
+  c3: s32,
+  c4: s64,
+}
+
+variant other-variant {
+  a,
+  b(u32),
+  c(string),
+}
+
+variant some-variant {
+  a(string),
+  b,
+  c(u32),
+  d(list<other-variant>),
+}
+
+type load-store-all-sizes = list<tuple<string, u8, s8, u16, s16, u32, s32, u64, s64, f32, f64, char>>
+
+list-u8-param: function(x: list<u8>)
+
+list-u16-param: function(x: list<u16>)
+
+list-u32-param: function(x: list<u32>)
+
+list-u64-param: function(x: list<u64>)
+
+list-s8-param: function(x: list<s8>)
+
+list-s16-param: function(x: list<s16>)
+
+list-s32-param: function(x: list<s32>)
+
+list-s64-param: function(x: list<s64>)
+
+list-f32-param: function(x: list<f32>)
+
+list-f64-param: function(x: list<f64>)
+
+list-u8-ret: function() -> list<u8>
+
+list-u16-ret: function() -> list<u16>
+
+list-u32-ret: function() -> list<u32>
+
+list-u64-ret: function() -> list<u64>
+
+list-s8-ret: function() -> list<s8>
+
+list-s16-ret: function() -> list<s16>
+
+list-s32-ret: function() -> list<s32>
+
+list-s64-ret: function() -> list<s64>
+
+list-f32-ret: function() -> list<f32>
+
+list-f64-ret: function() -> list<f64>
+
+tuple-list: function(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>
+
+string-list-arg: function(a: list<string>)
+
+string-list-ret: function() -> list<string>
+
+tuple-string-list: function(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>
+
+string-list: function(x: list<string>) -> list<string>
+
+record-list: function(x: list<some-record>) -> list<other-record>
+
+variant-list: function(x: list<some-variant>) -> list<other-variant>
+
+load-store-everything: function(a: load-store-all-sizes) -> load-store-all-sizes
+

--- a/crates/wit-component/tests/wit/records.wit
+++ b/crates/wit-component/tests/wit/records.wit
@@ -1,0 +1,54 @@
+record empty {
+}
+
+record scalars {
+  a: u32,
+  b: u32,
+}
+
+flags really-flags {
+  a,
+  b,
+  c,
+  d,
+  e,
+  f,
+  g,
+  h,
+  i,
+}
+
+record aggregates {
+  a: scalars,
+  b: u32,
+  c: empty,
+  d: string,
+  e: really-flags,
+}
+
+type int-typedef = s32
+
+type tuple-typedef2 = tuple<int-typedef>
+
+tuple-arg: function(x: tuple<char, u32>)
+
+tuple-result: function() -> tuple<char, u32>
+
+empty-arg: function(x: empty)
+
+empty-result: function() -> empty
+
+scalar-arg: function(x: scalars)
+
+scalar-result: function() -> scalars
+
+flags-arg: function(x: really-flags)
+
+flags-result: function() -> really-flags
+
+aggregate-arg: function(x: aggregates)
+
+aggregate-result: function() -> aggregates
+
+typedef-inout: function(e: tuple-typedef2) -> s32
+

--- a/crates/wit-component/tests/wit/variants.wit
+++ b/crates/wit-component/tests/wit/variants.wit
@@ -1,0 +1,97 @@
+enum e1 {
+  a,
+}
+
+union u1 {
+  u32,
+  f32,
+}
+
+record empty {
+}
+
+variant v1 {
+  a,
+  b(u1),
+  c(e1),
+  d(string),
+  e(empty),
+  f,
+  g(u32),
+}
+
+variant casts1 {
+  a(s32),
+  b(f32),
+}
+
+variant casts2 {
+  a(f64),
+  b(f32),
+}
+
+variant casts3 {
+  a(f64),
+  b(u64),
+}
+
+variant casts4 {
+  a(u32),
+  b(s64),
+}
+
+variant casts5 {
+  a(f32),
+  b(s64),
+}
+
+variant casts6 {
+  a(tuple<f32, u32>),
+  b(tuple<u32, u32>),
+}
+
+enum my-errno {
+  bad1,
+  bad2,
+}
+
+e1-arg: function(x: e1)
+
+e1-result: function() -> e1
+
+u1-arg: function(x: u1)
+
+u1-result: function() -> u1
+
+v1-arg: function(x: v1)
+
+v1-result: function() -> v1
+
+bool-arg: function(x: bool)
+
+bool-result: function() -> bool
+
+option-arg: function(a: option<bool>, b: option<tuple<>>, c: option<u32>, d: option<e1>, e: option<f32>, f: option<u1>, g: option<option<bool>>)
+
+option-result: function() -> tuple<option<bool>, option<tuple<>>, option<u32>, option<e1>, option<f32>, option<u1>, option<option<bool>>>
+
+casts: function(a: casts1, b: casts2, c: casts3, d: casts4, e: casts5, f: casts6) -> tuple<casts1, casts2, casts3, casts4, casts5, casts6>
+
+expected-arg: function(a: expected<_, _>, b: expected<_, e1>, c: expected<e1, _>, d: expected<tuple<>, tuple<>>, e: expected<u32, v1>, f: expected<string, list<u8>>)
+
+expected-result: function() -> tuple<expected<_, _>, expected<_, e1>, expected<e1, _>, expected<tuple<>, tuple<>>, expected<u32, v1>, expected<string, list<u8>>>
+
+return-expected-sugar: function() -> expected<s32, my-errno>
+
+return-expected-sugar2: function() -> expected<_, my-errno>
+
+return-expected-sugar3: function() -> expected<my-errno, my-errno>
+
+return-expected-sugar4: function() -> expected<tuple<s32, u32>, my-errno>
+
+return-option-sugar: function() -> option<s32>
+
+return-option-sugar2: function() -> option<my-errno>
+
+expected-simple: function() -> expected<u32, s32>
+


### PR DESCRIPTION
This PR implements simple CLI tools for encoding a single wit file to a
WebAssembly component (`wit2wasm`) or decoding a WebAssembly component to a wit
file (`wasm2wit`).

The latter tool right now only works with the output of `wit2wasm` and may
eventually be made more generic to spit out a wit representation for
all imported/exported interfaces of a WebAssembly component.