### PR TITLE
chore: [wasmlink] Update wasmencoder to v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,15 +1603,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b4949d4f2b25a4b208317dcf86aacef9e7a5884e48dfc45d4aeb91808d6f86"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0c351632e46cc06a58a696a6c11e4cf90cad4b9f8f07a0b59128d616c29bb0"
@@ -1628,6 +1619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9d9bf45fc46f71c407837c9b30b1e874197f2dc357588430b21e5017d290ab"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmlink"
 version = "0.1.0"
 dependencies = [
@@ -1636,7 +1636,7 @@ dependencies = [
  "lazy_static",
  "petgraph",
  "pretty_assertions",
- "wasm-encoder 0.4.1",
+ "wasm-encoder 0.10.0",
  "wasmparser 0.78.2",
  "wasmprinter",
  "wat 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/wasmlink/Cargo.toml
+++ b/crates/wasmlink/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0.40"
 heck = "0.3.3"
 lazy_static = "1.4.0"
 petgraph = "0.5.1"
-wasm-encoder = "0.4.1"
+wasm-encoder = "0.10.0"
 wasmparser = "0.78.1"
 wit-parser = { path = "../parser" }
 

--- a/crates/wasmlink/src/adapter.rs
+++ b/crates/wasmlink/src/adapter.rs
@@ -142,16 +142,16 @@ impl<'a> ModuleAdapter<'a> {
                 let mut func = wasm_encoder::Function::new(std::iter::empty());
 
                 for i in 0..info.import_type.params.len() as u32 {
-                    func.instruction(wasm_encoder::Instruction::LocalGet(i));
+                    func.instruction(&wasm_encoder::Instruction::LocalGet(i));
                 }
 
-                func.instruction(wasm_encoder::Instruction::I32Const(func_index as i32));
-                func.instruction(wasm_encoder::Instruction::CallIndirect {
+                func.instruction(&wasm_encoder::Instruction::I32Const(func_index as i32));
+                func.instruction(&wasm_encoder::Instruction::CallIndirect {
                     ty: *type_index,
                     table: 0,
                 });
 
-                func.instruction(wasm_encoder::Instruction::End);
+                func.instruction(&wasm_encoder::Instruction::End);
 
                 code.function(&func);
             }
@@ -170,10 +170,8 @@ impl<'a> ModuleAdapter<'a> {
 
         tables.table(wasm_encoder::TableType {
             element_type: wasm_encoder::ValType::FuncRef,
-            limits: wasm_encoder::Limits {
-                min: table_len,
-                max: Some(table_len),
-            },
+            minimum: table_len,
+            maximum: Some(table_len),
         });
 
         exports.export(FUNCTION_TABLE_NAME, wasm_encoder::Export::Table(0));
@@ -300,7 +298,9 @@ impl<'a> ModuleAdapter<'a> {
                 PARENT_MODULE_NAME,
                 Some(MEMORY_EXPORT_NAME),
                 wasm_encoder::EntityType::Memory(wasm_encoder::MemoryType {
-                    limits: wasm_encoder::Limits { min: 0, max: None },
+                    maximum: None,
+                    minimum: 0,
+                    memory64: false,
                 }),
             );
 

--- a/crates/wasmlink/src/linker.rs
+++ b/crates/wasmlink/src/linker.rs
@@ -366,7 +366,7 @@ impl<'a> LinkedModule<'a> {
         for (table_index, elements) in &self.segments {
             section.active(
                 Some(*table_index),
-                wasm_encoder::Instruction::I32Const(0),
+                &wasm_encoder::Instruction::I32Const(0),
                 wasm_encoder::ValType::FuncRef,
                 wasm_encoder::Elements::Expressions(elements),
             );


### PR DESCRIPTION
@peterhuene as discussed via Zulip, this is part 1/n towards porting my changes to temporarily support dynamic linking modules, until the component model changes land completely. I'm aiming to make incremental patches rather than a big one to make it easier to review. 

This update will make it easier to keep track of the index space of each
section while constructing modules by relying on the provided `len`
method of each section rather than having to maintain internal data
structure for this purpose.