### PR TITLE
Fix borrowchecker errors in Wasmtime list lowering

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -1998,7 +1998,10 @@ impl Bindgen for FunctionBindgen<'_> {
                 }
             }
 
-            Instruction::IterElem { .. } => results.push("e".to_string()),
+            Instruction::IterElem { .. } => {
+                self.caller_memory_available = false; // invalidated by for loop
+                results.push("e".to_string())
+            }
 
             Instruction::IterBasePointer => results.push("base".to_string()),
 

--- a/tests/codegen/lists.wit
+++ b/tests/codegen/lists.wit
@@ -29,6 +29,7 @@ string-list: function(x: list<string>) -> list<string>
 record some-record {
   x: string,
   y: other-record,
+  z: list<other-record>,
   c1: u32,
   c2: u64,
   c3: s32,
@@ -43,6 +44,7 @@ record other-record {
   c: list<u8>,
 }
 record-list: function(x: list<some-record>) -> list<other-record>
+record-list-reverse: function(x: list<other-record>) -> list<some-record>
 
 variant some-variant {
   a(string),


### PR DESCRIPTION
Fixes code generation for Wasmtime list lowering.

List lowering happens in a for loop and thus opens a new scope, which
invalidates previous caller_memory bindings.

A new binding was previously not enforced, resulting in borrow checker errors in
the generated code if the items in a list required allocation.

The `lists.wit` test is modified to contain previously problematic definitions.

Fixes #187
