### PR TITLE
Remove the leading $ from the install instructions so it doesn't get copied via the copy button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ At this time a CLI tool is provided mostly for debugging and exploratory
 purposes. It can be installed with:
 
 ```
-$ cargo install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli
+cargo install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli
 ```
 
 This tool is not necessarily intended to be integrated into toolchains. For


### PR DESCRIPTION
I was working through Radu Matei's excellent [tutorial](https://radu-matei.com/blog/intro-wasm-components/) on wasm components and went to install `wit-bindgen`.  I used the automatic copy button to copy the `cargo install` but because the text included the prompt `$`, the copy wasn't correct.  Removing the leading `$` so the command can be directly copied and pasted.

Small problem, small fix.