### PR TITLE
wit-bindgen-rust: enable standalone code generation.

### DIFF
--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -1419,7 +1419,7 @@ impl Bindgen for FunctionBindgen<'_> {
         self.blocks.push((src.into(), mem::take(operands)));
     }
 
-    fn return_pointer(&mut self, size: usize, align: usize) -> String {
+    fn return_pointer(&mut self, _iface: &Interface, size: usize, align: usize) -> String {
         self.gen.return_pointer_area_size = self.gen.return_pointer_area_size.max(size);
         self.gen.return_pointer_area_align = self.gen.return_pointer_area_align.max(align);
         let ptr = self.locals.tmp("ptr");

--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -87,9 +87,15 @@ pub trait Generator {
     fn type_alias(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs);
     fn type_list(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs);
     fn type_builtin(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs);
-    // fn const_(&mut self, iface: &Interface, name: &str, ty: &str, val: u64, docs: &Docs);
+
+    fn preprocess_functions(&mut self, iface: &Interface, dir: Direction) {
+        drop((iface, dir));
+    }
     fn import(&mut self, iface: &Interface, func: &Function);
     fn export(&mut self, iface: &Interface, func: &Function);
+    fn finish_functions(&mut self, iface: &Interface, dir: Direction) {
+        drop((iface, dir));
+    }
 
     fn finish_one(&mut self, iface: &Interface, files: &mut Files);
 
@@ -127,9 +133,7 @@ pub trait Generator {
             self.type_resource(iface, id);
         }
 
-        // for c in module.constants() {
-        //     self.const_(&c.name, &c.ty, c.value, &c.docs);
-        // }
+        self.preprocess_functions(iface, dir);
 
         for f in iface.functions.iter() {
             match dir {
@@ -137,6 +141,8 @@ pub trait Generator {
                 Direction::Export => self.export(iface, &f),
             }
         }
+
+        self.finish_functions(iface, dir);
 
         self.finish_one(iface, files)
     }

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -1265,7 +1265,7 @@ impl Bindgen for FunctionBindgen<'_> {
         self.blocks.push((src.into(), mem::take(operands)));
     }
 
-    fn return_pointer(&mut self, _size: usize, _align: usize) -> String {
+    fn return_pointer(&mut self, _iface: &Interface, _size: usize, _align: usize) -> String {
         unimplemented!()
     }
 
@@ -2112,7 +2112,7 @@ impl Bindgen for FunctionBindgen<'_> {
             Instruction::IterBasePointer => results.push("base".to_string()),
 
             Instruction::CallWasm {
-                module: _,
+                iface: _,
                 name,
                 sig,
             } => {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -46,12 +46,15 @@ pub struct Opts {
     #[cfg_attr(feature = "structopt", structopt(skip))]
     pub symbol_namespace: String,
 
-    /// The alias to use for the `wit_bindgen_rust` crate.
+    /// If true, the code generation is intended for standalone crates.
     ///
-    /// This allows code generators to alias the `wit_bindgen_rust` crate
-    /// to a re-export in another crate.
+    /// Standalone mode generates bindings without a wrapping module.
+    ///
+    /// For exported interfaces, an `export!` macro is also generated
+    /// that can be used to export an implementation from a different
+    /// crate.
     #[cfg_attr(feature = "structopt", structopt(skip))]
-    pub crate_alias: Option<String>,
+    pub standalone: bool,
 }
 
 #[derive(Default)]
@@ -79,6 +82,10 @@ impl RustWasm {
             Direction::Export => AbiVariant::GuestExport,
             Direction::Import => AbiVariant::GuestImport,
         }
+    }
+
+    fn ret_area_name(iface: &Interface) -> String {
+        format!("{}_RET_AREA", iface.name.to_shouty_snake_case())
     }
 }
 
@@ -150,12 +157,10 @@ impl Generator for RustWasm {
         self.in_import = variant == AbiVariant::GuestImport;
         self.types.analyze(iface);
         self.trait_name = iface.name.to_camel_case();
-        self.src
-            .push_str(&format!("mod {} {{\n", iface.name.to_snake_case()));
 
-        if let Some(alias) = &self.opts.crate_alias {
+        if !self.opts.standalone {
             self.src
-                .push_str(&format!("use {} as wit_bindgen_rust;\n", alias));
+                .push_str(&format!("mod {} {{\n", iface.name.to_snake_case()));
         }
 
         self.sizes.fill(iface);
@@ -456,6 +461,16 @@ impl Generator for RustWasm {
         self.src.push_str(";\n");
     }
 
+    fn preprocess_functions(&mut self, _iface: &Interface, dir: Direction) {
+        if self.opts.standalone && dir == Direction::Export {
+            self.src.push_str(
+                "/// Declares the export of the interface for the given type.\n\
+                 #[macro_export]\n\
+                 macro_rules! export(($t:ident) => {\n",
+            );
+        }
+    }
+
     fn import(&mut self, iface: &Interface, func: &Function) {
         let mut sig = FnSig::default();
         let param_mode = TypeMode::AllBorrowed("'_");
@@ -508,14 +523,25 @@ impl Generator for RustWasm {
     }
 
     fn export(&mut self, iface: &Interface, func: &Function) {
-        let rust_name = func.name.to_snake_case();
+        let iface_name = iface.name.to_snake_case();
 
         self.src.push_str("#[export_name = \"");
-        self.src.push_str(&self.opts.symbol_namespace);
-        self.src.push_str(&func.name);
+        match &iface.module {
+            Some(module) => {
+                self.src.push_str(module);
+                self.src.push_str("#");
+                self.src.push_str(&func.name);
+            }
+            None => {
+                self.src.push_str(&self.opts.symbol_namespace);
+                self.src.push_str(&func.name);
+            }
+        }
         self.src.push_str("\"]\n");
         self.src.push_str("unsafe extern \"C\" fn __wit_bindgen_");
-        self.src.push_str(&rust_name);
+        self.src.push_str(&iface_name);
+        self.src.push_str("_");
+        self.src.push_str(&func.name.to_snake_case());
         self.src.push_str("(");
         let sig = iface.wasm_signature(AbiVariant::GuestExport, func);
         let mut params = Vec::new();
@@ -537,7 +563,17 @@ impl Generator for RustWasm {
             }
             _ => unimplemented!(),
         }
-        self.src.push_str("{\n");
+
+        self.push_str("{\n");
+
+        if self.opts.standalone {
+            // Force the macro code to reference wit_bindgen_rust for standalone crates.
+            // Also ensure any referenced types are also used from the external crate.
+            self.src
+                .push_str("#[allow(unused_imports)]\nuse wit_bindgen_rust;\nuse ");
+            self.src.push_str(&iface_name);
+            self.src.push_str("::*;\n");
+        }
 
         if func.is_async {
             self.src.push_str("let future = async move {\n");
@@ -595,6 +631,26 @@ impl Generator for RustWasm {
         dst.push(mem::replace(&mut self.src, prev).into());
     }
 
+    fn finish_functions(&mut self, iface: &Interface, dir: Direction) {
+        if self.return_pointer_area_align > 0 {
+            self.src.push_str(&format!(
+                "
+                    #[repr(align({align}))]
+                    struct RetArea([u8; {size}]);
+                    static mut {name}: RetArea = RetArea([0; {size}]);
+                ",
+                name = Self::ret_area_name(iface),
+                align = self.return_pointer_area_align,
+                size = self.return_pointer_area_size,
+            ));
+        }
+
+        // For standalone generation, close the export! macro
+        if self.opts.standalone && dir == Direction::Export {
+            self.src.push_str("});\n");
+        }
+    }
+
     fn finish_one(&mut self, iface: &Interface, files: &mut Files) {
         let mut src = mem::take(&mut self.src);
 
@@ -628,20 +684,10 @@ impl Generator for RustWasm {
             }
         }
 
-        if self.return_pointer_area_align > 0 {
-            src.push_str(&format!(
-                "
-                    #[repr(align({align}))]
-                    struct RetArea([u8; {size}]);
-                    static mut RET_AREA: RetArea = RetArea([0; {size}]);
-                ",
-                align = self.return_pointer_area_align,
-                size = self.return_pointer_area_size,
-            ));
-        }
-
         // Close the opening `mod`.
-        src.push_str("}\n");
+        if !self.opts.standalone {
+            src.push_str("}\n");
+        }
 
         if self.opts.rustfmt {
             let mut child = Command::new("rustfmt")
@@ -710,11 +756,13 @@ impl FunctionBindgen<'_> {
 
     fn declare_import(
         &mut self,
-        module: &str,
+        iface: &Interface,
         name: &str,
         params: &[WasmType],
         results: &[WasmType],
     ) -> String {
+        let module = iface.module.as_deref().unwrap_or(&iface.name);
+
         // Define the actual function we're calling inline
         self.push_str("#[link(wasm_import_module = \"");
         self.push_str(module);
@@ -808,13 +856,15 @@ impl Bindgen for FunctionBindgen<'_> {
         }
     }
 
-    fn return_pointer(&mut self, size: usize, align: usize) -> String {
+    fn return_pointer(&mut self, iface: &Interface, size: usize, align: usize) -> String {
         self.gen.return_pointer_area_size = self.gen.return_pointer_area_size.max(size);
         self.gen.return_pointer_area_align = self.gen.return_pointer_area_align.max(align);
         let tmp = self.tmp();
+
         self.push_str(&format!(
-            "let ptr{} = RET_AREA.0.as_mut_ptr() as i32;\n",
-            tmp
+            "let ptr{} = {}.0.as_mut_ptr() as i32;\n",
+            tmp,
+            RustWasm::ret_area_name(iface),
         ));
         format!("ptr{}", tmp)
     }
@@ -1397,8 +1447,8 @@ impl Bindgen for FunctionBindgen<'_> {
 
             Instruction::IterBasePointer => results.push("base".to_string()),
 
-            Instruction::CallWasm { module, name, sig } => {
-                let func = self.declare_import(module, name, &sig.params, &sig.results);
+            Instruction::CallWasm { iface, name, sig } => {
+                let func = self.declare_import(iface, name, &sig.params, &sig.results);
 
                 // ... then call the function with all our operands
                 if sig.results.len() > 0 {
@@ -1412,7 +1462,7 @@ impl Bindgen for FunctionBindgen<'_> {
             }
 
             Instruction::CallWasmAsyncImport {
-                module,
+                iface,
                 name,
                 params: wasm_params,
                 results: wasm_results,
@@ -1455,7 +1505,7 @@ impl Bindgen for FunctionBindgen<'_> {
                 // the canonical ABI `operands` we were provided, and the last
                 // two arguments are our completion callback and the context for
                 // the callback, our `tx` sender.
-                let func = self.declare_import(module, name, wasm_params, &[]);
+                let func = self.declare_import(iface, name, wasm_params, &[]);
                 self.push_str(&func);
                 self.push_str("(");
                 for op in operands {
@@ -1489,11 +1539,20 @@ impl Bindgen for FunctionBindgen<'_> {
                 results.push("result".to_string());
                 match &func.kind {
                     FunctionKind::Freestanding => {
-                        self.push_str(&format!(
-                            "<super::{m} as {m}>::{}",
-                            func.name.to_snake_case(),
-                            m = module.to_camel_case()
-                        ));
+                        if self.gen.opts.standalone {
+                            // For standalone mode, use the macro identifier
+                            self.push_str(&format!(
+                                "<$t as {t}>::{}",
+                                func.name.to_snake_case(),
+                                t = module.to_camel_case(),
+                            ));
+                        } else {
+                            self.push_str(&format!(
+                                "<super::{m} as {m}>::{}",
+                                func.name.to_snake_case(),
+                                m = module.to_camel_case()
+                            ));
+                        }
                     }
                     FunctionKind::Static { resource, name }
                     | FunctionKind::Method { resource, name } => {

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -1983,7 +1983,7 @@ impl abi::Bindgen for Bindgen<'_, '_> {
                 name: _,
                 ty: _,
             } => todo!(),
-            abi::Instruction::CallWasm { module, name, sig } => {
+            abi::Instruction::CallWasm { iface, name, sig } => {
                 // Push the Wasm arguments.
                 //
                 // []
@@ -1996,7 +1996,7 @@ impl abi::Bindgen for Bindgen<'_, '_> {
                 let func_index = self
                     .gen
                     .import_fn_name_to_index
-                    .get(*module)
+                    .get(&iface.name)
                     .unwrap()
                     .get(*name)
                     .unwrap()
@@ -2200,7 +2200,7 @@ impl abi::Bindgen for Bindgen<'_, '_> {
         }
     }
 
-    fn return_pointer(&mut self, size: usize, align: usize) -> Self::Operand {
+    fn return_pointer(&mut self, _iface: &Interface, size: usize, align: usize) -> Self::Operand {
         self.gen.return_pointer_area_size = self.gen.return_pointer_area_size.max(size);
         self.gen.return_pointer_area_align = self.gen.return_pointer_area_align.max(align);
         let local = self.new_local(wasm_encoder::ValType::I32);

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -1047,7 +1047,7 @@ impl Bindgen for FunctionBindgen<'_> {
         self.blocks.push((src.into(), mem::take(operands)));
     }
 
-    fn return_pointer(&mut self, _size: usize, _align: usize) -> String {
+    fn return_pointer(&mut self, _iface: &Interface, _size: usize, _align: usize) -> String {
         unimplemented!()
     }
 
@@ -1913,7 +1913,7 @@ impl Bindgen for FunctionBindgen<'_> {
             //        results.push(format!("{}", handle));
             //    }
             Instruction::CallWasm {
-                module: _,
+                iface: _,
                 name,
                 sig,
             } => {

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -1418,7 +1418,7 @@ impl Bindgen for FunctionBindgen<'_> {
         self.caller_memory_available = false;
     }
 
-    fn return_pointer(&mut self, _size: usize, _align: usize) -> String {
+    fn return_pointer(&mut self, _iface: &Interface, _size: usize, _align: usize) -> String {
         unimplemented!()
     }
 
@@ -2012,7 +2012,7 @@ impl Bindgen for FunctionBindgen<'_> {
             Instruction::IterBasePointer => results.push("base".to_string()),
 
             Instruction::CallWasm {
-                module: _,
+                iface: _,
                 name,
                 sig,
             } => {

--- a/crates/parser/src/abi.rs
+++ b/crates/parser/src/abi.rs
@@ -640,7 +640,7 @@ def_instruction! {
         /// functions, instead `CallWasmAsyncImport` and `CallWasmAsyncExport`
         /// are used.
         CallWasm {
-            module: &'a str,
+            iface: &'a Interface,
             name: &'a str,
             sig: &'a WasmSignature,
         } : [sig.params.len()] => [sig.results.len()],
@@ -660,7 +660,7 @@ def_instruction! {
         /// It's up to the bindings generator to figure out how to make this
         /// look synchronous despite it being callback-based in the middle.
         CallWasmAsyncImport {
-            module: &'a str,
+            iface: &'a Interface,
             name: &'a str,
             params: &'a [WasmType],
             results: &'a [WasmType],
@@ -841,8 +841,10 @@ pub trait Bindgen {
         results: &mut Vec<Self::Operand>,
     );
 
-    /// TODO
-    fn return_pointer(&mut self, size: usize, align: usize) -> Self::Operand;
+    /// Gets a operand reference to the return pointer area.
+    ///
+    /// The provided size and alignment is for the function's return type.
+    fn return_pointer(&mut self, iface: &Interface, size: usize, align: usize) -> Self::Operand;
 
     /// Enters a new block of code to generate code for.
     ///
@@ -1138,7 +1140,9 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     let ptr = match self.variant {
                         // When a wasm module calls an import it will provide
                         // static space that isn't dynamically allocated.
-                        AbiVariant::GuestImport => self.bindgen.return_pointer(size, align),
+                        AbiVariant::GuestImport => {
+                            self.bindgen.return_pointer(self.iface, size, align)
+                        }
                         // When calling a wasm module from the outside, though,
                         // malloc needs to be called.
                         AbiVariant::GuestExport => {
@@ -1175,7 +1179,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         AbiVariant::GuestImport => {
                             assert_eq!(self.stack.len(), sig.params.len() - 2);
                             self.emit(&Instruction::CallWasmAsyncImport {
-                                module: &self.iface.name,
+                                iface: self.iface,
                                 name: &func.name,
                                 params: &sig.params,
                                 results: &results,
@@ -1199,7 +1203,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     if self.variant == AbiVariant::GuestImport && sig.retptr {
                         let size = self.bindgen.sizes().size(&func.result);
                         let align = self.bindgen.sizes().align(&func.result);
-                        let ptr = self.bindgen.return_pointer(size, align);
+                        let ptr = self.bindgen.return_pointer(self.iface, size, align);
                         self.return_pointer = Some(ptr.clone());
                         self.stack.push(ptr);
                     }
@@ -1208,7 +1212,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     // actual wasm function.
                     assert_eq!(self.stack.len(), sig.params.len());
                     self.emit(&Instruction::CallWasm {
-                        module: &self.iface.name,
+                        iface: self.iface,
                         name: &func.name,
                         sig: &sig,
                     });
@@ -1329,7 +1333,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         AbiVariant::GuestExport => {
                             let size = self.bindgen.sizes().size(&func.result);
                             let align = self.bindgen.sizes().align(&func.result);
-                            let ptr = self.bindgen.return_pointer(size, align);
+                            let ptr = self.bindgen.return_pointer(self.iface, size, align);
                             self.write_to_memory(&func.result, ptr.clone(), 0);
 
                             // Get the caller's context index.
@@ -1372,7 +1376,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                             AbiVariant::GuestExport => {
                                 let size = self.bindgen.sizes().size(&func.result);
                                 let align = self.bindgen.sizes().align(&func.result);
-                                let ptr = self.bindgen.return_pointer(size, align);
+                                let ptr = self.bindgen.return_pointer(self.iface, size, align);
                                 self.write_to_memory(&func.result, ptr.clone(), 0);
                                 self.stack.push(ptr);
                             }

--- a/crates/parser/src/ast/resolve.rs
+++ b/crates/parser/src/ast/resolve.rs
@@ -77,6 +77,7 @@ impl Resolver {
 
         Ok(Interface {
             name: name.to_string(),
+            module: None,
             types: mem::take(&mut self.types),
             type_lookup: mem::take(&mut self.type_lookup),
             resources: mem::take(&mut self.resources),

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -19,6 +19,14 @@ pub fn validate_id(s: &str) -> Result<()> {
 #[derive(Debug, Default)]
 pub struct Interface {
     pub name: String,
+    /// The module name to use for bindings generation.
+    ///
+    /// If `None`, then the interface name will be used.
+    ///
+    /// If `Some`, then this value is used to format an export
+    /// name of `<module>#<name>` for exports or an import module
+    /// name of `<module>` for imports.
+    pub module: Option<String>,
     pub types: Arena<TypeDef>,
     pub type_lookup: HashMap<String, TypeId>,
     pub resources: Arena<Resource>,

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -130,7 +130,7 @@ pub mod rt {
         memory: &Memory,
         base: i32,
         len: i32,
-        align: i32,
+        _align: i32,
     ) -> Result<Vec<T>, Trap> {
         let size = (len as u32)
             .checked_mul(mem::size_of::<T>() as u32)


### PR DESCRIPTION
This PR enables a "standalone" mode to the Rust bindings generator.

The general idea is that this mode may be used to generate bindings that can be
built as separate crates and depended upon like normal Rust crates.

For both import and export bindings, this means not nesting the bindings inside
of a module.

For export bindings, this means generating a macro that consuming crates can
use to export an interface for a given type. Additionally, this allows users to
export multiple interfaces from the same type (e.g. a single `Component` struct).

An optional `module` field was added to `Interface` to also allow users some
control over the exported and imported symbol names. When specified, it is used
as the module name for import bindings. For export bindings, it is used as part
of a formatted export name of `<module>#<function>`; this format is what is
currently expected of `wit-component` for exported (non-default) interfaces.