### PR TITLE
Remove `RustGenerator::print_pointer`

### DIFF
--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -123,32 +123,6 @@ impl RustGenerator for RustWasm {
         &mut self.types
     }
 
-    fn print_pointer(&mut self, iface: &Interface, const_: bool, ty: &Type) {
-        self.push_str("*");
-        if const_ {
-            self.push_str("const ");
-        } else {
-            self.push_str("mut ");
-        }
-        let manually_drop = match ty {
-            Type::Id(id) => match &iface.types[*id].kind {
-                TypeDefKind::Record(_) => true,
-                TypeDefKind::List(_) | TypeDefKind::Variant(_) | TypeDefKind::Type(_) => {
-                    panic!("unsupported pointer type")
-                }
-            },
-            Type::Handle(_) => true,
-            _ => false,
-        };
-        if manually_drop {
-            self.push_str("core::mem::ManuallyDrop<");
-        }
-        self.print_ty(iface, ty, TypeMode::Owned);
-        if manually_drop {
-            self.push_str(">");
-        }
-    }
-
     fn print_borrowed_slice(
         &mut self,
         iface: &Interface,

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -14,7 +14,6 @@ pub trait RustGenerator {
     fn push_str(&mut self, s: &str);
     fn info(&self, ty: TypeId) -> TypeInfo;
     fn types_mut(&mut self) -> &mut Types;
-    fn print_pointer(&mut self, iface: &Interface, const_: bool, ty: &Type);
     fn print_borrowed_slice(
         &mut self,
         iface: &Interface,

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -266,10 +266,6 @@ impl RustGenerator for Wasmtime {
         &mut self.types
     }
 
-    fn print_pointer(&mut self, _iface: &Interface, _const_: bool, _ty: &Type) {
-        self.push_str("u32");
-    }
-
     fn print_borrowed_slice(
         &mut self,
         iface: &Interface,


### PR DESCRIPTION
Not actually needed for anything after #195