### PR TITLE
Feature gate `wit-bindgen-rust` dependencies.

### DIFF
--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-wit-bindgen-rust-impl = { path = "../rust-wasm-impl" }
-async-trait = "0.1.51"
+wit-bindgen-rust-impl = { path = "../rust-wasm-impl", optional = true }
+async-trait = { version = "0.1.51", optional = true }
 bitflags = "1.3"
+
+[features]
+default = ["macros", "async"]
+macros = ["wit-bindgen-rust-impl"]
+async = ["async-trait"]

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -1,10 +1,14 @@
-pub use async_trait::async_trait;
 use std::fmt;
 use std::marker;
 use std::mem;
 use std::ops::Deref;
+
+#[cfg(feature = "macros")]
 pub use wit_bindgen_rust_impl::{export, import};
 
+#[cfg(feature = "async")]
+pub use async_trait::async_trait;
+#[cfg(feature = "async")]
 mod futures;
 
 // Re-export `bitflags` so that we can reference it from macros.
@@ -126,6 +130,7 @@ pub unsafe trait LocalHandle: HandleType {
 pub mod rt {
     use std::alloc::{self, Layout};
 
+    #[cfg(feature = "async")]
     pub use crate::futures::*;
 
     #[no_mangle]


### PR DESCRIPTION
This PR feature gates most of the dependencies for `wit-bindgen-rust`.

The intention behind this change is to make it so that we can optionally
build `wit-bindgen-rust` as only the runtime support and effectively
disable code generation support.

The async support is also gated so that it can, potentially, be selectively
enabled depending upon the presence of async functions in interface
definitions.

With these changes, systems that generate the bindings ahead-of-time can
effectively take a dependency on `wit-bindgen-rust` only for implementing
runtime support; this helps minimize the build dependencies when code
generation isn't needed.