### PR TITLE
Fix missing items in C header files

### DIFF
--- a/tests/codegen/small-anonymous.wit
+++ b/tests/codegen/small-anonymous.wit
@@ -1,0 +1,6 @@
+enum error {
+  success,
+  failure,
+}
+
+option-test: function() -> expected<option<string>, error>


### PR DESCRIPTION
This fixes an issue where some structures of "anonymous" types such as
results/etc would accidentally only place types in the C implementation
files instead of the header files where they were needed.

Closes #194