### PR TITLE
Split out the `flags` type from `record`

### DIFF
--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -55,6 +55,7 @@ pub trait Generator {
         record: &Record,
         docs: &Docs,
     );
+    fn type_flags(&mut self, iface: &Interface, id: TypeId, name: &str, flags: &Flags, docs: &Docs);
     fn type_variant(
         &mut self,
         iface: &Interface,
@@ -88,6 +89,7 @@ pub trait Generator {
             };
             match &ty.kind {
                 TypeDefKind::Record(record) => self.type_record(iface, id, name, record, &ty.docs),
+                TypeDefKind::Flags(flags) => self.type_flags(iface, id, name, flags, &ty.docs),
                 TypeDefKind::Variant(variant) => {
                     self.type_variant(iface, id, name, variant, &ty.docs)
                 }
@@ -188,6 +190,7 @@ impl Types {
                     info |= self.type_info(iface, &field.ty);
                 }
             }
+            TypeDefKind::Flags(_) => {}
             TypeDefKind::Variant(v) => {
                 for case in v.cases.iter() {
                     if let Some(ty) = &case.ty {
@@ -225,6 +228,7 @@ impl Types {
                     self.set_param_result_ty(iface, &field.ty, param, result)
                 }
             }
+            TypeDefKind::Flags(_) => {}
             TypeDefKind::Variant(v) => {
                 for case in v.cases.iter() {
                     if let Some(ty) = &case.ty {

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -171,6 +171,7 @@ impl Js {
                     TypeDefKind::Type(t) => self.print_ty(iface, t),
                     TypeDefKind::Record(r) if r.is_tuple() => self.print_tuple(iface, r),
                     TypeDefKind::Record(_) => panic!("anonymous record"),
+                    TypeDefKind::Flags(_) => panic!("anonymous flags"),
                     TypeDefKind::Variant(v) => {
                         if self.is_nullable_option(iface, v) {
                             self.print_ty(iface, v.cases[1].ty.as_ref().unwrap());
@@ -336,37 +337,6 @@ impl Generator for Js {
                 .ts(&format!("export type {} = ", name.to_camel_case()));
             self.print_tuple(iface, record);
             self.src.ts(";\n");
-        } else if record.is_flags() {
-            let repr = iface
-                .flags_repr(record)
-                .expect("unsupported number of flags");
-            let suffix = if repr == Int::U64 {
-                self.src
-                    .ts(&format!("export type {} = bigint;\n", name.to_camel_case()));
-                "n"
-            } else {
-                self.src
-                    .ts(&format!("export type {} = number;\n", name.to_camel_case()));
-                ""
-            };
-            let name = name.to_shouty_snake_case();
-            for (i, field) in record.fields.iter().enumerate() {
-                let field = field.name.to_shouty_snake_case();
-                self.src.js(&format!(
-                    "export const {}_{} = {}{};\n",
-                    name,
-                    field,
-                    1u64 << i,
-                    suffix,
-                ));
-                self.src.ts(&format!(
-                    "export const {}_{} = {}{};\n",
-                    name,
-                    field,
-                    1u64 << i,
-                    suffix,
-                ));
-            }
         } else {
             self.src
                 .ts(&format!("export interface {} {{\n", name.to_camel_case()));
@@ -381,6 +351,34 @@ impl Generator for Js {
                 self.src.ts(",\n");
             }
             self.src.ts("}\n");
+        }
+    }
+
+    fn type_flags(
+        &mut self,
+        _iface: &Interface,
+        _id: TypeId,
+        name: &str,
+        flags: &Flags,
+        docs: &Docs,
+    ) {
+        self.docs(docs);
+        let repr = js_flags_repr(flags);
+        let ty = repr.ty();
+        let suffix = repr.suffix();
+        self.src
+            .ts(&format!("export type {} = {ty};\n", name.to_camel_case()));
+        let name = name.to_shouty_snake_case();
+        for (i, flag) in flags.flags.iter().enumerate() {
+            let flag = flag.name.to_shouty_snake_case();
+            self.src.js(&format!(
+                "export const {name}_{flag} = {}{suffix};\n",
+                1u128 << i,
+            ));
+            self.src.ts(&format!(
+                "export const {name}_{flag} = {}{suffix};\n",
+                1u128 << i,
+            ));
         }
     }
 
@@ -1412,20 +1410,56 @@ impl Bindgen for FunctionBindgen<'_> {
                 }
             }
 
-            Instruction::FlagsLower { record, .. } | Instruction::FlagsLift { record, .. } => {
-                match record.num_i32s() {
-                    0 | 1 => {
-                        let validate = self.gen.intrinsic(Intrinsic::ValidateFlags);
-                        let mask = (1u64 << record.fields.len()) - 1;
-                        results.push(format!("{}({}, {})", validate, operands[0], mask));
+            Instruction::FlagsLower { flags, .. } => {
+                let repr = js_flags_repr(flags);
+                let validate = match repr {
+                    JsFlagsRepr::Number => self.gen.intrinsic(Intrinsic::ValidateFlags),
+                    JsFlagsRepr::Bigint => self.gen.intrinsic(Intrinsic::ValidateFlags64),
+                };
+                let op0 = &operands[0];
+                let len = flags.flags.len();
+                let n = repr.suffix();
+                let tmp = self.tmp();
+                let mask = (1u128 << len) - 1;
+                self.src.js(&format!(
+                    "const flags{tmp} = {validate}({op0}, {mask}{n});\n"
+                ));
+                match repr {
+                    JsFlagsRepr::Number => {
+                        results.push(format!("flags{}", tmp));
                     }
-                    _ => panic!("unsupported bitflags"),
+                    JsFlagsRepr::Bigint => {
+                        for i in 0..flags.repr().count() {
+                            let i = 32 * i;
+                            results.push(format!("Number((flags{tmp} >> {i}n) & 0xffffffffn)",));
+                        }
+                    }
                 }
             }
-            Instruction::FlagsLower64 { record, .. } | Instruction::FlagsLift64 { record, .. } => {
-                let validate = self.gen.intrinsic(Intrinsic::ValidateFlags64);
-                let mask = (1u128 << record.fields.len()) - 1;
-                results.push(format!("{}({}, {}n)", validate, operands[0], mask));
+
+            Instruction::FlagsLift { flags, .. } => {
+                let repr = js_flags_repr(flags);
+                let n = repr.suffix();
+                let tmp = self.tmp();
+                let operand = match repr {
+                    JsFlagsRepr::Number => operands[0].clone(),
+                    JsFlagsRepr::Bigint => {
+                        self.src.js(&format!("let flags{tmp} = 0n;\n"));
+                        for (i, op) in operands.iter().enumerate() {
+                            let i = 32 * i;
+                            self.src
+                                .js(&format!("flags{tmp} |= BigInt({op}) << {i}n;\n",));
+                        }
+                        format!("flags{tmp}")
+                    }
+                };
+                let validate = match repr {
+                    JsFlagsRepr::Number => self.gen.intrinsic(Intrinsic::ValidateFlags),
+                    JsFlagsRepr::Bigint => self.gen.intrinsic(Intrinsic::ValidateFlags64),
+                };
+                let len = flags.flags.len();
+                let mask = (1u128 << len) - 1;
+                results.push(format!("{validate}({operand}, {mask}{n})"));
             }
 
             Instruction::VariantPayloadName => results.push("e".to_string()),
@@ -2236,5 +2270,32 @@ impl Source {
     }
     fn ts(&mut self, s: &str) {
         self.ts.push_str(s);
+    }
+}
+
+enum JsFlagsRepr {
+    Number,
+    Bigint,
+}
+
+impl JsFlagsRepr {
+    fn ty(&self) -> &'static str {
+        match self {
+            JsFlagsRepr::Number => "number",
+            JsFlagsRepr::Bigint => "bigint",
+        }
+    }
+    fn suffix(&self) -> &'static str {
+        match self {
+            JsFlagsRepr::Number => "",
+            JsFlagsRepr::Bigint => "n",
+        }
+    }
+}
+
+fn js_flags_repr(f: &Flags) -> JsFlagsRepr {
+    match f.repr() {
+        FlagsRepr::U8 | FlagsRepr::U16 | FlagsRepr::U32(1) => JsFlagsRepr::Number,
+        FlagsRepr::U32(_) => JsFlagsRepr::Bigint,
     }
 }

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -79,6 +79,7 @@ impl Markdown {
                         }
                         self.src.push_str(")");
                     }
+                    TypeDefKind::Flags(_) => unreachable!(),
                     TypeDefKind::Variant(v) => {
                         if let Some(t) = v.as_option() {
                             self.src.push_str("option<");
@@ -162,7 +163,7 @@ impl Generator for Markdown {
         self.src.push_str("record\n\n");
         self.print_type_info(id, docs);
         self.src.push_str("\n### Record Fields\n\n");
-        for (i, field) in record.fields.iter().enumerate() {
+        for field in record.fields.iter() {
             self.src.push_str(&format!(
                 "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
                 r = name.to_snake_case(),
@@ -178,9 +179,38 @@ impl Generator for Markdown {
             self.src.push_str("\n\n");
             self.docs(&field.docs);
             self.src.deindent(1);
-            if record.is_flags() {
-                self.src.push_str(&format!("Bit: {}\n", i));
-            }
+            self.src.push_str("\n");
+        }
+    }
+
+    fn type_flags(
+        &mut self,
+        _iface: &Interface,
+        id: TypeId,
+        name: &str,
+        flags: &Flags,
+        docs: &Docs,
+    ) {
+        self.print_type_header(name);
+        self.src.push_str("record\n\n");
+        self.print_type_info(id, docs);
+        self.src.push_str("\n### Record Fields\n\n");
+        for (i, flag) in flags.flags.iter().enumerate() {
+            self.src.push_str(&format!(
+                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
+                r = name.to_snake_case(),
+                f = flag.name.to_snake_case(),
+                name = flag.name,
+            ));
+            self.hrefs.insert(
+                format!("{}::{}", name, flag.name),
+                format!("#{}.{}", name.to_snake_case(), flag.name.to_snake_case()),
+            );
+            self.src.indent(1);
+            self.src.push_str("\n\n");
+            self.docs(&flag.docs);
+            self.src.deindent(1);
+            self.src.push_str(&format!("Bit: {}\n", i));
             self.src.push_str("\n");
         }
     }

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -16,7 +16,7 @@ use wasm_encoder::Instruction;
 use wit_bindgen_gen_core::{
     wit_parser::{
         abi::{self, AbiVariant, WasmSignature, WasmType},
-        Docs, Function, Interface, Record, ResourceId, SizeAlign, Type, TypeId, Variant,
+        Docs, Flags, Function, Interface, Record, ResourceId, SizeAlign, Type, TypeId, Variant,
     },
     Direction, Files, Generator,
 };
@@ -951,6 +951,18 @@ impl Generator for SpiderMonkeyWasm<'_> {
         todo!()
     }
 
+    fn type_flags(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        flags: &Flags,
+        docs: &Docs,
+    ) {
+        let _ = (iface, id, name, flags, docs);
+        todo!()
+    }
+
     fn type_variant(
         &mut self,
         iface: &Interface,
@@ -1878,22 +1890,12 @@ impl abi::Bindgen for Bindgen<'_, '_> {
                 ty: _,
             } => todo!(),
             abi::Instruction::FlagsLower {
-                record: _,
-                name: _,
-                ty: _,
-            } => todo!(),
-            abi::Instruction::FlagsLower64 {
-                record: _,
+                flags: _,
                 name: _,
                 ty: _,
             } => todo!(),
             abi::Instruction::FlagsLift {
-                record: _,
-                name: _,
-                ty: _,
-            } => todo!(),
-            abi::Instruction::FlagsLift64 {
-                record: _,
+                flags: _,
                 name: _,
                 ty: _,
             } => todo!(),

--- a/crates/parser/tests/all.rs
+++ b/crates/parser/tests/all.rs
@@ -191,6 +191,9 @@ fn to_json(i: &Interface) -> String {
         Record {
             fields: Vec<(String, String)>,
         },
+        Flags {
+            flags: Vec<String>,
+        },
         Variant {
             cases: Vec<(String, Option<String>)>,
         },
@@ -267,6 +270,9 @@ fn to_json(i: &Interface) -> String {
                     .iter()
                     .map(|f| (f.name.clone(), translate_type(&f.ty)))
                     .collect(),
+            },
+            TypeDefKind::Flags(r) => Type::Flags {
+                flags: r.flags.iter().map(|f| f.name.clone()).collect(),
             },
             TypeDefKind::Variant(v) => Type::Variant {
                 cases: v

--- a/crates/parser/tests/ui/types.wit.result
+++ b/crates/parser/tests/ui/types.wit.result
@@ -291,47 +291,29 @@
     {
       "idx": 31,
       "name": "t30",
-      "record": {
-        "fields": []
+      "flags": {
+        "flags": []
       }
     },
     {
       "idx": 32,
       "name": "t31",
-      "record": {
-        "fields": [
-          [
-            "a",
-            "bool"
-          ],
-          [
-            "b",
-            "bool"
-          ],
-          [
-            "c",
-            "bool"
-          ]
+      "flags": {
+        "flags": [
+          "a",
+          "b",
+          "c"
         ]
       }
     },
     {
       "idx": 33,
       "name": "t32",
-      "record": {
-        "fields": [
-          [
-            "a",
-            "bool"
-          ],
-          [
-            "b",
-            "bool"
-          ],
-          [
-            "c",
-            "bool"
-          ]
+      "flags": {
+        "flags": [
+          "a",
+          "b",
+          "c"
         ]
       }
     },

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -179,6 +179,7 @@ pub fn codegen_rust_wasm_export(input: TokenStream) -> TokenStream {
                 let t = quote_ty(param, iface, t);
                 quote::quote! { Vec<#t> }
             }
+            TypeDefKind::Flags(_) => panic!("unknown flags"),
             TypeDefKind::Record(r) => {
                 let fields = r.fields.iter().map(|f| quote_ty(param, iface, &f.ty));
                 quote::quote! { (#(#fields,)*) }

--- a/crates/test-modules/modules/crates/records/records.wit
+++ b/crates/test-modules/modules/crates/records/records.wit
@@ -14,16 +14,16 @@ record scalars {
 scalar-arg: function(x: scalars)
 scalar-result: function() -> scalars
 
-record really-flags {
-    a: bool,
-    b: bool,
-    c: bool,
-    d: bool,
-    e: bool,
-    f: bool,
-    g: bool,
-    h: bool,
-    i: bool,
+flags really-flags {
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+    g,
+    h,
+    i,
 }
 
 flags-arg: function(x: really-flags)

--- a/crates/wasmlink/src/adapter/call.rs
+++ b/crates/wasmlink/src/adapter/call.rs
@@ -451,17 +451,12 @@ impl<'a> CallAdapter<'a> {
                         operands: element_operands,
                     });
                 }
+                TypeDefKind::Flags(r) => {
+                    for _ in 0..r.repr().count() {
+                        params.next().unwrap();
+                    }
+                }
                 TypeDefKind::Record(r) => match r.kind {
-                    RecordKind::Flags(_) => match interface.flags_repr(r) {
-                        Some(_) => {
-                            params.next().unwrap();
-                        }
-                        None => {
-                            for _ in 0..r.num_i32s() {
-                                params.next().unwrap();
-                            }
-                        }
-                    },
                     RecordKind::Tuple | RecordKind::Other => {
                         for f in &r.fields {
                             Self::push_operands(
@@ -612,8 +607,8 @@ impl<'a> CallAdapter<'a> {
                         operands: element_operands,
                     });
                 }
+                TypeDefKind::Flags(_) => {}
                 TypeDefKind::Record(r) => match r.kind {
-                    RecordKind::Flags(_) => {}
                     RecordKind::Tuple | RecordKind::Other => {
                         let offsets = sizes.field_offsets(r);
 

--- a/crates/wasmlink/src/module.rs
+++ b/crates/wasmlink/src/module.rs
@@ -48,6 +48,7 @@ fn has_list(interface: &WitInterface, ty: &WitType) -> bool {
         Type::Id(id) => match &interface.types[*id].kind {
             TypeDefKind::List(_) => true,
             TypeDefKind::Type(t) => has_list(interface, t),
+            TypeDefKind::Flags(_) => false,
             TypeDefKind::Record(r) => r.fields.iter().any(|f| has_list(interface, &f.ty)),
             TypeDefKind::Variant(v) => v.cases.iter().any(|c| {
                 c.ty.as_ref()

--- a/crates/wasmlink/tests/flags.baseline
+++ b/crates/wasmlink/tests/flags.baseline
@@ -1,9 +1,10 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i64) (result i64)))
+  (type (;1;) (func (param i32 i32 i32)))
+  (import "$parent" "memory" (memory (;0;) 0))
   (module (;0;)
     (type (;0;) (func (param i32) (result i32)))
-    (type (;1;) (func (param i64) (result i64)))
+    (type (;1;) (func (param i32 i32) (result i32)))
     (func (;0;) (type 0) (param i32) (result i32)
       unreachable)
     (func (;1;) (type 0) (param i32) (result i32)
@@ -16,8 +17,10 @@
       unreachable)
     (func (;5;) (type 0) (param i32) (result i32)
       unreachable)
-    (func (;6;) (type 1) (param i64) (result i64)
+    (func (;6;) (type 1) (param i32 i32) (result i32)
       unreachable)
+    (memory (;0;) 1)
+    (export "memory" (memory 0))
     (export "roundtrip-flag1" (func 0))
     (export "roundtrip-flag2" (func 1))
     (export "roundtrip-flag4" (func 2))
@@ -25,15 +28,16 @@
     (export "roundtrip-flag16" (func 4))
     (export "roundtrip-flag32" (func 5))
     (export "roundtrip-flag64" (func 6)))
-  (instance (;0;)
+  (instance (;1;)
     (instantiate 0))
-  (alias 0 "roundtrip-flag1" (func (;0;)))
-  (alias 0 "roundtrip-flag2" (func (;1;)))
-  (alias 0 "roundtrip-flag4" (func (;2;)))
-  (alias 0 "roundtrip-flag8" (func (;3;)))
-  (alias 0 "roundtrip-flag16" (func (;4;)))
-  (alias 0 "roundtrip-flag32" (func (;5;)))
-  (alias 0 "roundtrip-flag64" (func (;6;)))
+  (alias 1 "memory" (memory (;1;)))
+  (alias 1 "roundtrip-flag1" (func (;0;)))
+  (alias 1 "roundtrip-flag2" (func (;1;)))
+  (alias 1 "roundtrip-flag4" (func (;2;)))
+  (alias 1 "roundtrip-flag8" (func (;3;)))
+  (alias 1 "roundtrip-flag16" (func (;4;)))
+  (alias 1 "roundtrip-flag32" (func (;5;)))
+  (alias 1 "roundtrip-flag64" (func (;6;)))
   (func (;7;) (type 0) (param i32) (result i32)
     local.get 0
     call 0)
@@ -52,9 +56,17 @@
   (func (;12;) (type 0) (param i32) (result i32)
     local.get 0
     call 5)
-  (func (;13;) (type 1) (param i64) (result i64)
+  (func (;13;) (type 1) (param i32 i32 i32)
+    (local i32)
     local.get 0
-    call 6)
+    local.get 1
+    call 6
+    local.set 3
+    local.get 2
+    local.get 3
+    i32.const 8
+    memory.copy 0 1)
+  (export "memory" (memory 1))
   (export "roundtrip-flag1" (func 7))
   (export "roundtrip-flag2" (func 8))
   (export "roundtrip-flag4" (func 9))

--- a/crates/wasmlink/tests/flags.wat
+++ b/crates/wasmlink/tests/flags.wat
@@ -1,4 +1,5 @@
 (module
+    (memory (export "memory") 1)
     (func (export "roundtrip-flag1") (param i32) (result i32)
         unreachable
     )

--- a/crates/wasmlink/tests/flags.wat
+++ b/crates/wasmlink/tests/flags.wat
@@ -17,7 +17,7 @@
     (func (export "roundtrip-flag32") (param i32) (result i32)
         unreachable
     )
-    (func (export "roundtrip-flag64") (param i64) (result i64)
+    (func (export "roundtrip-flag64") (param i32 i32) (result i32)
         unreachable
     )
 )

--- a/crates/wasmlink/tests/records.wit
+++ b/crates/wasmlink/tests/records.wit
@@ -14,16 +14,16 @@ record scalars {
 scalar-arg: function(x: scalars)
 scalar-result: function() -> scalars
 
-record really-flags {
-    a: bool,
-    b: bool,
-    c: bool,
-    d: bool,
-    e: bool,
-    f: bool,
-    g: bool,
-    h: bool,
-    i: bool,
+flags really-flags {
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+    g,
+    h,
+    i,
 }
 
 flags-arg: function(x: really-flags)

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -73,13 +73,16 @@ pub mod rt {
         Trap::new(msg)
     }
 
-    pub fn validate_flags<U>(
-        bits: i64,
-        all: i64,
+    pub fn validate_flags<T, U>(
+        bits: T,
+        all: T,
         name: &str,
-        mk: impl FnOnce(i64) -> U,
-    ) -> Result<U, Trap> {
-        if bits & !all != 0 {
+        mk: impl FnOnce(T) -> U,
+    ) -> Result<U, Trap>
+    where
+        T: std::ops::Not<Output = T> + std::ops::BitAnd<Output = T> + From<u8> + PartialEq + Copy,
+    {
+        if bits & !all != 0u8.into() {
             let msg = format!("invalid flags specified for `{}`", name);
             Err(Trap::new(msg))
         } else {

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -5,8 +5,8 @@ use wasmparser::{
     Validator, WasmFeatures,
 };
 use wit_parser::{
-    validate_id, Case, Docs, Field, Function, FunctionKind, Interface, Record, RecordKind, Type,
-    TypeDef, TypeDefKind, TypeId, Variant,
+    validate_id, Case, Docs, Field, Flag, Flags, Function, FunctionKind, Interface, Record,
+    RecordKind, Type, TypeDef, TypeDefKind, TypeId, Variant,
 };
 
 /// Represents information about a decoded WebAssembly component.
@@ -446,8 +446,8 @@ impl<'a> InterfaceDecoder<'a> {
         let flags_name =
             flags_name.ok_or_else(|| anyhow!("interface has an unnamed flags type"))?;
 
-        let record = Record {
-            fields: names
+        let flags = Flags {
+            flags: names
                 .map(|name| {
                     validate_id(name).with_context(|| {
                         format!(
@@ -456,18 +456,16 @@ impl<'a> InterfaceDecoder<'a> {
                         )
                     })?;
 
-                    Ok(Field {
+                    Ok(Flag {
                         docs: Docs::default(),
                         name: name.clone(),
-                        ty: self.decode_primitive(PrimitiveInterfaceType::Bool)?,
                     })
                 })
                 .collect::<Result<_>>()?,
-            kind: RecordKind::Flags(None),
         };
 
         Ok(Type::Id(
-            self.alloc_type(Some(flags_name), TypeDefKind::Record(record)),
+            self.alloc_type(Some(flags_name), TypeDefKind::Flags(flags)),
         ))
     }
 

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -91,6 +91,16 @@ impl PartialEq for TypeDefKey<'_> {
                             })
                     })
                 }
+                (TypeDefKind::Flags(f1), TypeDefKind::Flags(f2)) => {
+                    if f1.flags.len() != f2.flags.len() {
+                        return false;
+                    }
+
+                    f1.flags
+                        .iter()
+                        .zip(f2.flags.iter())
+                        .all(|(f1, f2)| f1.name == f2.name)
+                }
                 (TypeDefKind::Variant(v1), TypeDefKind::Variant(v2)) => {
                     if v1.cases.len() != v2.cases.len() {
                         return false;

--- a/tests/runtime/many_arguments/host.rs
+++ b/tests/runtime/many_arguments/host.rs
@@ -3,9 +3,7 @@ use anyhow::Result;
 wit_bindgen_wasmtime::export!("../../tests/runtime/many_arguments/imports.wit");
 
 #[derive(Default)]
-pub struct MyImports {
-    scalar: u32,
-}
+pub struct MyImports {}
 
 impl imports::Imports for MyImports {
     fn many_arguments(


### PR DESCRIPTION
This commit creates a dedicated `flags` type which is distinct from the
`record` type rather than the previous inferred-from-the-structure
logic. This also additionally changes the canonical ABI of the `flags`
type where 64-bit flags are now passed as two `i32` values instead of
one `i64`. This ended up changing a significant amount of the logic
internally in each code generator, notably around the new lift/lower
behavior.

Along the way I tried to refactor code to support 64+ flags in a few
more places. While some support may be there, though, this is untested
and will need a full-fledged feature in the future.