### PR TITLE
Represent `Variant` with a non-optional payload type

### DIFF
--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -223,9 +223,7 @@ impl Types {
             TypeDefKind::Enum(_) => {}
             TypeDefKind::Variant(v) => {
                 for case in v.cases.iter() {
-                    if let Some(ty) = &case.ty {
-                        info |= self.type_info(iface, ty);
-                    }
+                    info |= self.type_info(iface, &case.ty);
                 }
             }
             TypeDefKind::List(ty) => {
@@ -279,9 +277,7 @@ impl Types {
             TypeDefKind::Enum(_) => {}
             TypeDefKind::Variant(v) => {
                 for case in v.cases.iter() {
-                    if let Some(ty) = &case.ty {
-                        self.set_param_result_ty(iface, ty, param, result)
-                    }
+                    self.set_param_result_ty(iface, &case.ty, param, result)
                 }
             }
             TypeDefKind::List(ty) | TypeDefKind::Type(ty) | TypeDefKind::Option(ty) => {

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -262,10 +262,8 @@ impl Generator for Markdown {
                 format!("{}::{}", name, case.name),
                 format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
             );
-            if let Some(ty) = &case.ty {
-                self.src.push_str(": ");
-                self.print_ty(iface, ty, false);
-            }
+            self.src.push_str(": ");
+            self.print_ty(iface, &case.ty, false);
             self.src.indent(1);
             self.src.push_str("\n\n");
             self.docs(&case.docs);

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -120,7 +120,6 @@ struct Flag<'a> {
 }
 
 struct Variant<'a> {
-    tag: Option<Box<Type<'a>>>,
     span: Span,
     cases: Vec<Case<'a>>,
 }
@@ -309,7 +308,6 @@ impl<'a> TypeDef<'a> {
         tokens.expect(Token::Variant)?;
         let name = parse_id(tokens)?;
         let ty = Type::Variant(Variant {
-            tag: None,
             span: name.span,
             cases: parse_list(
                 tokens,

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -143,25 +143,21 @@ pub struct Tuple {
 #[derive(Debug)]
 pub struct Variant {
     pub cases: Vec<Case>,
-    /// The bit representation of the width of this variant's tag when the
-    /// variant is stored in memory.
-    pub tag: Int,
 }
 
 #[derive(Debug)]
 pub struct Case {
     pub docs: Docs,
     pub name: String,
-    pub ty: Option<Type>,
+    pub ty: Type,
 }
 
 impl Variant {
-    pub fn infer_tag(cases: usize) -> Int {
-        match cases {
+    pub fn tag(&self) -> Int {
+        match self.cases.len() {
             n if n <= u8::max_value() as usize => Int::U8,
             n if n <= u16::max_value() as usize => Int::U16,
             n if n <= u32::max_value() as usize => Int::U32,
-            n if n <= u64::max_value() as usize => Int::U64,
             _ => panic!("too many cases to fit in a repr"),
         }
     }
@@ -411,9 +407,7 @@ impl Interface {
             }
             TypeDefKind::Variant(v) => {
                 for v in v.cases.iter() {
-                    if let Some(ty) = &v.ty {
-                        self.topo_visit_ty(ty, list, visited);
-                    }
+                    self.topo_visit_ty(&v.ty, list, visited);
                 }
             }
             TypeDefKind::Option(ty) => self.topo_visit_ty(ty, list, visited),

--- a/crates/parser/src/sizealign.rs
+++ b/crates/parser/src/sizealign.rs
@@ -25,11 +25,11 @@ impl SizeAlign {
                 FlagsRepr::U16 => (2, 2),
                 FlagsRepr::U32(n) => (n * 4, 4),
             },
-            TypeDefKind::Variant(v) => self.variant(v.tag, v.cases.iter().map(|c| c.ty.as_ref())),
+            TypeDefKind::Variant(v) => self.variant(v.tag(), v.cases.iter().map(|c| &c.ty)),
             TypeDefKind::Enum(e) => self.variant(e.tag(), []),
-            TypeDefKind::Option(t) => self.variant(Int::U8, [None, Some(t)]),
-            TypeDefKind::Expected(e) => self.variant(Int::U8, [Some(&e.ok), Some(&e.err)]),
-            TypeDefKind::Union(u) => self.variant(u.tag(), u.cases.iter().map(|c| Some(&c.ty))),
+            TypeDefKind::Option(t) => self.variant(Int::U8, [&Type::Unit, t]),
+            TypeDefKind::Expected(e) => self.variant(Int::U8, [&e.ok, &e.err]),
+            TypeDefKind::Union(u) => self.variant(u.tag(), u.cases.iter().map(|c| &c.ty)),
         }
     }
 
@@ -68,16 +68,10 @@ impl SizeAlign {
             .collect()
     }
 
-    pub fn payload_offset<'a>(
-        &self,
-        tag: Int,
-        cases: impl IntoIterator<Item = Option<&'a Type>>,
-    ) -> usize {
+    pub fn payload_offset<'a>(&self, tag: Int, cases: impl IntoIterator<Item = &'a Type>) -> usize {
         let mut max_align = 1;
-        for c in cases {
-            if let Some(ty) = c {
-                max_align = max_align.max(self.align(ty));
-            }
+        for ty in cases {
+            max_align = max_align.max(self.align(ty));
         }
         let tag_size = int_size_align(tag).0;
         align_to(tag_size, max_align)
@@ -95,21 +89,15 @@ impl SizeAlign {
         (align_to(size, align), align)
     }
 
-    fn variant<'a>(
-        &self,
-        tag: Int,
-        types: impl IntoIterator<Item = Option<&'a Type>>,
-    ) -> (usize, usize) {
+    fn variant<'a>(&self, tag: Int, types: impl IntoIterator<Item = &'a Type>) -> (usize, usize) {
         let (discrim_size, discrim_align) = int_size_align(tag);
         let mut size = discrim_size;
         let mut align = discrim_align;
         for ty in types {
-            if let Some(ty) = ty {
-                let case_size = self.size(ty);
-                let case_align = self.align(ty);
-                align = align.max(case_align);
-                size = size.max(align_to(discrim_size, case_align) + case_size);
-            }
+            let case_size = self.size(ty);
+            let case_align = self.align(ty);
+            align = align.max(case_align);
+            size = size.max(align_to(discrim_size, case_align) + case_size);
         }
         (size, align)
     }

--- a/crates/parser/tests/all.rs
+++ b/crates/parser/tests/all.rs
@@ -188,30 +188,15 @@ fn to_json(i: &Interface) -> String {
     #[serde(rename_all = "kebab-case")]
     enum Type {
         Primitive(String),
-        Record {
-            fields: Vec<(String, String)>,
-        },
-        Flags {
-            flags: Vec<String>,
-        },
-        Enum {
-            cases: Vec<String>,
-        },
-        Variant {
-            cases: Vec<(String, Option<String>)>,
-        },
-        Tuple {
-            types: Vec<String>,
-        },
+        Record { fields: Vec<(String, String)> },
+        Flags { flags: Vec<String> },
+        Enum { cases: Vec<String> },
+        Variant { cases: Vec<(String, String)> },
+        Tuple { types: Vec<String> },
         Option(String),
-        Expected {
-            ok: String,
-            err: String,
-        },
+        Expected { ok: String, err: String },
         List(String),
-        Union {
-            cases: Vec<String>,
-        },
+        Union { cases: Vec<String> },
     }
 
     #[derive(Serialize)]
@@ -298,7 +283,7 @@ fn to_json(i: &Interface) -> String {
                 cases: v
                     .cases
                     .iter()
-                    .map(|f| (f.name.clone(), f.ty.as_ref().map(translate_type)))
+                    .map(|f| (f.name.clone(), translate_type(&f.ty)))
                     .collect(),
             },
             TypeDefKind::Option(t) => Type::Option(translate_type(t)),

--- a/crates/parser/tests/ui/types.wit.result
+++ b/crates/parser/tests/ui/types.wit.result
@@ -269,7 +269,7 @@
         "cases": [
           [
             "a",
-            null
+            "unit"
           ]
         ]
       }
@@ -281,11 +281,11 @@
         "cases": [
           [
             "a",
-            null
+            "unit"
           ],
           [
             "b",
-            null
+            "unit"
           ]
         ]
       }
@@ -297,11 +297,11 @@
         "cases": [
           [
             "a",
-            null
+            "unit"
           ],
           [
             "b",
-            null
+            "unit"
           ]
         ]
       }
@@ -313,7 +313,7 @@
         "cases": [
           [
             "a",
-            null
+            "unit"
           ],
           [
             "b",
@@ -329,7 +329,7 @@
         "cases": [
           [
             "a",
-            null
+            "unit"
           ],
           [
             "b",

--- a/crates/wasmlink/src/module.rs
+++ b/crates/wasmlink/src/module.rs
@@ -51,11 +51,7 @@ fn has_list(interface: &WitInterface, ty: &WitType) -> bool {
             TypeDefKind::Flags(_) => false,
             TypeDefKind::Record(r) => r.fields.iter().any(|f| has_list(interface, &f.ty)),
             TypeDefKind::Tuple(t) => t.types.iter().any(|ty| has_list(interface, ty)),
-            TypeDefKind::Variant(v) => v.cases.iter().any(|c| {
-                c.ty.as_ref()
-                    .map(|t| has_list(interface, t))
-                    .unwrap_or(false)
-            }),
+            TypeDefKind::Variant(v) => v.cases.iter().any(|c| has_list(interface, &c.ty)),
             TypeDefKind::Union(v) => v.cases.iter().any(|c| has_list(interface, &c.ty)),
             TypeDefKind::Option(t) => has_list(interface, t),
             TypeDefKind::Expected(e) => has_list(interface, &e.ok) || has_list(interface, &e.err),

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -378,8 +378,6 @@ impl<'a> InterfaceDecoder<'a> {
         let variant_name =
             variant_name.ok_or_else(|| anyhow!("interface has an unnamed variant type"))?;
 
-        let cases_len = cases.len();
-
         let variant = Variant {
             cases: cases
                 .map(|(name, case)| {
@@ -393,16 +391,10 @@ impl<'a> InterfaceDecoder<'a> {
                     Ok(Case {
                         docs: Docs::default(),
                         name: name.to_string(),
-                        ty: match case.ty {
-                            types::InterfaceTypeRef::Primitive(PrimitiveInterfaceType::Unit) => {
-                                None
-                            }
-                            _ => Some(self.decode_type(&case.ty)?),
-                        },
+                        ty: self.decode_type(&case.ty)?,
                     })
                 })
                 .collect::<Result<_>>()?,
-            tag: Variant::infer_tag(cases_len),
         };
 
         Ok(Type::Id(self.alloc_type(

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -267,9 +267,7 @@ impl InterfacePrinter {
         variant: &Variant,
     ) -> Result<()> {
         for case in variant.cases.iter() {
-            if let Some(ty) = &case.ty {
-                self.declare_type(interface, ty)?;
-            }
+            self.declare_type(interface, &case.ty)?;
         }
 
         let name = match name {
@@ -279,9 +277,9 @@ impl InterfacePrinter {
         writeln!(&mut self.output, "variant {} {{", name)?;
         for case in &variant.cases {
             write!(&mut self.output, "  {}", case.name)?;
-            if let Some(ty) = &case.ty {
+            if case.ty != Type::Unit {
                 self.output.push('(');
-                self.print_type_name(interface, ty)?;
+                self.print_type_name(interface, &case.ty)?;
                 self.output.push(')');
             }
             self.output.push_str(",\n");


### PR DESCRIPTION
This commit updates the internal representation of the `Variant` type to
have a non-optional payload type as well as no customizable `tag` type.
This brings the `Variant` type into alignment with the current canonical
ABI where the payload type is non-optional as well. The `*.wit` syntax
is not changing, however, where `variant { foo }` is sugar for
`variant { foo(unit) }`. Various code generators were tweaked as well to
get the new type representation to work as well.