### PR TITLE
wit-component: update wasm-tools dependencies to latest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.11.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#f8200cf02a1e69dee33335bbd1dada84d31eb783"
+source = "git+https://github.com/bytecodealliance/wasm-tools#5f7171c417222c50ea2b12428c24844948876667"
 dependencies = [
  "leb128",
 ]
@@ -1715,7 +1715,7 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 [[package]]
 name = "wasmparser"
 version = "0.84.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#f8200cf02a1e69dee33335bbd1dada84d31eb783"
+source = "git+https://github.com/bytecodealliance/wasm-tools#5f7171c417222c50ea2b12428c24844948876667"
 dependencies = [
  "indexmap",
 ]
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.2.34"
-source = "git+https://github.com/bytecodealliance/wasm-tools#f8200cf02a1e69dee33335bbd1dada84d31eb783"
+source = "git+https://github.com/bytecodealliance/wasm-tools#5f7171c417222c50ea2b12428c24844948876667"
 dependencies = [
  "anyhow",
  "wasmparser 0.84.0",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "40.0.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#f8200cf02a1e69dee33335bbd1dada84d31eb783"
+source = "git+https://github.com/bytecodealliance/wasm-tools#5f7171c417222c50ea2b12428c24844948876667"
 dependencies = [
  "leb128",
  "memchr",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.0.42"
-source = "git+https://github.com/bytecodealliance/wasm-tools#f8200cf02a1e69dee33335bbd1dada84d31eb783"
+source = "git+https://github.com/bytecodealliance/wasm-tools#5f7171c417222c50ea2b12428c24844948876667"
 dependencies = [
  "wast 40.0.0",
 ]

--- a/crates/wit-component/tests/components/simple/component.wat
+++ b/crates/wit-component/tests/components/simple/component.wat
@@ -11,10 +11,10 @@
     (type (;3;) (func (result i32)))
     (type (;4;) (func (param i32 i32) (result i32)))
     (type (;5;) (func (param i32 i32)))
-    (func $canonical_abi_realloc (type 0) (param i32 i32 i32 i32) (result i32)
+    (func $canonical_abi_realloc (;0;) (type 0) (param i32 i32 i32 i32) (result i32)
       unreachable
     )
-    (func $canonical_abi_free (type 1) (param i32 i32 i32)
+    (func $canonical_abi_free (;1;) (type 1) (param i32 i32 i32)
       unreachable
     )
     (func (;2;) (type 2)
@@ -29,7 +29,7 @@
     (func (;5;) (type 5) (param i32 i32)
       unreachable
     )
-    (memory $memory 1)
+    (memory $memory (;0;) 1)
     (export "memory" (memory $memory))
     (export "canonical_abi_realloc" (func $canonical_abi_realloc))
     (export "canonical_abi_free" (func $canonical_abi_free))


### PR DESCRIPTION
This commit updates the `wasm-tools` dependencies for wit-component to the
latest out of main.

Fixes a test case baseline that changed due to fixes in `wasmprinter`.