### PR TITLE
Update grammar for `func` in `WIT.md`

### DIFF
--- a/WIT.md
+++ b/WIT.md
@@ -368,7 +368,7 @@ union-cases ::= ty,
               | ty ',' union-cases?
 ```
 
-## Item: `function`
+## Item: `func`
 
 Functions can also be defined in a `*.wit` document. Functions have a name,
 parameters, and results. Functions can optionally also be declared as `async`
@@ -383,7 +383,7 @@ sleep: async func(ms: u64)
 Specifically functions have the structure:
 
 ```wit
-func-item ::= id ':' 'async'? 'function' '(' func-args ')' func-ret
+func-item ::= id ':' 'async'? 'func' '(' func-args ')' func-ret
 
 func-args ::= func-arg
             | func-arg ',' func-args?

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -222,7 +222,7 @@ impl<'a> Item<'a> {
             Some((_span, Token::Id)) | Some((_span, Token::ExplicitId)) => {
                 Value::parse(tokens, docs).map(Item::Value)
             }
-            other => Err(err_expected(tokens, "`type`, `resource`, or `fn`", other).into()),
+            other => Err(err_expected(tokens, "`type`, `resource`, or `func`", other).into()),
         }
     }
 }

--- a/crates/wit-bindgen-demo/index.html
+++ b/crates/wit-bindgen-demo/index.html
@@ -39,7 +39,7 @@ record person {
   name: string,
   age: u32,
 }
-hello: function(who: person) -&gt; string
+hello: func(who: person) -&gt; string
 </textarea>
       </div>
       <div class='area'>


### PR DESCRIPTION
Just a documentation update for some instances of `function` that should be replaced with `func`.

https://github.com/bytecodealliance/wit-bindgen/issues/236