### PR TITLE
Correct *.wit format docs to reflect current implementation of resource-defs

### DIFF
--- a/WIT.md
+++ b/WIT.md
@@ -425,8 +425,7 @@ resource-item ::= 'resource' id resource-contents
 resource-contents ::= nil
                     | '{' resource-defs '}'
 
-resource-defs ::= resource-def
-                | resource-def ',' resource-defs?
+resource-defs ::= resource-def resource-defs?
 
 resource-def ::= 'static'? func-item
 ```


### PR DESCRIPTION
Correct the documentation of the current *.wit format implementation to no longer falsely claim that function definitions in resource types need to (or even can) be divided by commas.

Currently works:
```
resource foo{
    bar: func()
    fizz: func()
}
```

Also works:
```
resource foo{
    bar: func() fizz: func()
}
```

Currently does not work:
```
resource foo{
    bar: func(),
    fizz: func()
}
```