### PR TITLE
Improve naming of union cases in Rust

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -1680,8 +1680,13 @@ impl Bindgen for FunctionBindgen<'_> {
                 let op0 = &operands[0];
                 self.push_str(&format!("match {op0} {{\n"));
                 let name = self.typename_lower(iface, *ty);
-                for (i, block) in blocks.iter().enumerate() {
-                    self.push_str(&format!("{name}::V{i}(e) => {block},\n"));
+                for (case_name, block) in self
+                    .gen
+                    .union_case_names(iface, union)
+                    .into_iter()
+                    .zip(blocks)
+                {
+                    self.push_str(&format!("{name}::{case_name}(e) => {block},\n"));
                 }
                 self.push_str("};\n");
             }
@@ -1694,8 +1699,14 @@ impl Bindgen for FunctionBindgen<'_> {
                 let op0 = &operands[0];
                 let mut result = format!("match {op0} {{\n");
                 let name = self.typename_lift(iface, *ty);
-                for (i, block) in blocks.iter().enumerate() {
-                    result.push_str(&format!("{i} => {name}::V{i}({block}),\n"));
+                for (i, (case_name, block)) in self
+                    .gen
+                    .union_case_names(iface, union)
+                    .into_iter()
+                    .zip(blocks)
+                    .enumerate()
+                {
+                    result.push_str(&format!("{i} => {name}::{case_name}({block}),\n"));
                 }
                 result.push_str(&format!("_ => return Err(invalid_variant(\"{name}\")),\n"));
                 result.push_str("}");

--- a/tests/runtime/flavorful/host.rs
+++ b/tests/runtime/flavorful/host.rs
@@ -41,8 +41,8 @@ impl Imports for MyImports {
         assert_eq!(a.unwrap(), "foo");
         assert_eq!(b.unwrap_err(), "bar");
         match c {
-            ListInVariant1V3::V0(s) => assert_eq!(s, "baz"),
-            ListInVariant1V3::V1(_) => panic!(),
+            ListInVariant1V3::String(s) => assert_eq!(s, "baz"),
+            ListInVariant1V3::F32(_) => panic!(),
         }
     }
 
@@ -135,7 +135,7 @@ fn run(wasm: &str) -> Result<()> {
         &mut store,
         Some("foo"),
         Err("bar"),
-        ListInVariant1V3::V0("baz"),
+        ListInVariant1V3::String("baz"),
     )?;
     assert_eq!(
         exports.list_in_variant2(&mut store)?,

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -29,7 +29,7 @@ impl exports::Exports for Exports {
             "result4"
         );
 
-        list_in_variant1(Some("foo"), Err("bar"), ListInVariant1V3::V0("baz"));
+        list_in_variant1(Some("foo"), Err("bar"), ListInVariant1V3::String("baz"));
         assert_eq!(list_in_variant2(), Some("list_in_variant2".to_string()));
         assert_eq!(
             list_in_variant3(Some("input3")),
@@ -85,8 +85,8 @@ impl exports::Exports for Exports {
         assert_eq!(a.unwrap(), "foo");
         assert_eq!(b.unwrap_err(), "bar");
         match c {
-            ListInVariant1V3::V0(s) => assert_eq!(s, "baz"),
-            ListInVariant1V3::V1(_) => panic!(),
+            ListInVariant1V3::String(s) => assert_eq!(s, "baz"),
+            ListInVariant1V3::F32(_) => panic!(),
         }
     }
 

--- a/tests/runtime/handles/host.rs
+++ b/tests/runtime/handles/host.rs
@@ -65,7 +65,7 @@ impl Imports for MyImports {
         Ok(())
     }
     fn host_state2_result_variant(&mut self) -> HostStateResultVariant<Self> {
-        HostStateResultVariant::V0(())
+        HostStateResultVariant::HostState2(())
     }
     fn host_state2_result_list(&mut self) -> Vec<()> {
         vec![(), ()]
@@ -130,8 +130,8 @@ fn run(wasm: &str) -> Result<()> {
     exports.wasm_state2_param_option(&mut store, None)?;
     exports.wasm_state2_param_result(&mut store, Ok(&s2))?;
     exports.wasm_state2_param_result(&mut store, Err(2))?;
-    exports.wasm_state2_param_variant(&mut store, WasmStateParamVariant::V0(&s2))?;
-    exports.wasm_state2_param_variant(&mut store, WasmStateParamVariant::V1(2))?;
+    exports.wasm_state2_param_variant(&mut store, WasmStateParamVariant::WasmState2(&s2))?;
+    exports.wasm_state2_param_variant(&mut store, WasmStateParamVariant::U32(2))?;
     exports.wasm_state2_param_list(&mut store, &[])?;
     exports.wasm_state2_param_list(&mut store, &[&s2])?;
     exports.wasm_state2_param_list(&mut store, &[&s2, &s2])?;
@@ -145,8 +145,8 @@ fn run(wasm: &str) -> Result<()> {
     exports.drop_wasm_state2(&mut store, s)?;
     let s = exports.wasm_state2_result_result(&mut store)?.unwrap();
     match exports.wasm_state2_result_variant(&mut store)? {
-        WasmStateResultVariant::V0(s) => exports.drop_wasm_state2(&mut store, s)?,
-        WasmStateResultVariant::V1(_) => panic!(),
+        WasmStateResultVariant::WasmState2(s) => exports.drop_wasm_state2(&mut store, s)?,
+        WasmStateResultVariant::U32(_) => panic!(),
     }
     exports.drop_wasm_state2(&mut store, s)?;
     for s in exports.wasm_state2_result_list(&mut store)? {

--- a/tests/runtime/handles/wasm.rs
+++ b/tests/runtime/handles/wasm.rs
@@ -34,8 +34,8 @@ impl exports::Exports for Exports {
         host_state2_param_option(None);
         host_state2_param_result(Ok(&s2));
         host_state2_param_result(Err(2));
-        host_state2_param_variant(HostStateParamVariant::V0(&s2));
-        host_state2_param_variant(HostStateParamVariant::V1(2));
+        host_state2_param_variant(HostStateParamVariant::HostState2(&s2));
+        host_state2_param_variant(HostStateParamVariant::U32(2));
         host_state2_param_list(&[]);
         host_state2_param_list(&[&s2]);
         host_state2_param_list(&[&s2, &s2]);
@@ -104,7 +104,7 @@ impl exports::Exports for Exports {
         Ok(WasmState2(555).into())
     }
     fn wasm_state2_result_variant() -> WasmStateResultVariant {
-        WasmStateResultVariant::V0(Handle::new(WasmState2(666)))
+        WasmStateResultVariant::WasmState2(Handle::new(WasmState2(666)))
     }
     fn wasm_state2_result_list() -> Vec<Handle<WasmState2>> {
         vec![WasmState2(777).into(), WasmState2(888).into()]

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -11,161 +11,161 @@ impl exports::Exports for Exports {
 
         // All-Integers
         // Booleans
-        assert!(matches!(add_one_integer(AllIntegers::V0(false)), AllIntegers::V0(true)));
-        assert!(matches!(add_one_integer(AllIntegers::V0(true)), AllIntegers::V0(false)));
+        assert!(matches!(add_one_integer(AllIntegers::Bool(false)), AllIntegers::Bool(true)));
+        assert!(matches!(add_one_integer(AllIntegers::Bool(true)), AllIntegers::Bool(false)));
         // Unsigned integers
-        assert!(matches!(add_one_integer(AllIntegers::V1(0)), AllIntegers::V1(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V1(u8::MAX)), AllIntegers::V1(0)));
-        assert!(matches!(add_one_integer(AllIntegers::V2(0)), AllIntegers::V2(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V2(u16::MAX)), AllIntegers::V2(0)));
-        assert!(matches!(add_one_integer(AllIntegers::V3(0)), AllIntegers::V3(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V3(u32::MAX)), AllIntegers::V3(0)));
-        assert!(matches!(add_one_integer(AllIntegers::V4(0)), AllIntegers::V4(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V4(u64::MAX)), AllIntegers::V4(0)));
+        assert!(matches!(add_one_integer(AllIntegers::U8(0)), AllIntegers::U8(1)));
+        assert!(matches!(add_one_integer(AllIntegers::U8(u8::MAX)), AllIntegers::U8(0)));
+        assert!(matches!(add_one_integer(AllIntegers::U16(0)), AllIntegers::U16(1)));
+        assert!(matches!(add_one_integer(AllIntegers::U16(u16::MAX)), AllIntegers::U16(0)));
+        assert!(matches!(add_one_integer(AllIntegers::U32(0)), AllIntegers::U32(1)));
+        assert!(matches!(add_one_integer(AllIntegers::U32(u32::MAX)), AllIntegers::U32(0)));
+        assert!(matches!(add_one_integer(AllIntegers::U64(0)), AllIntegers::U64(1)));
+        assert!(matches!(add_one_integer(AllIntegers::U64(u64::MAX)), AllIntegers::U64(0)));
         // Signed integers
-        assert!(matches!(add_one_integer(AllIntegers::V5(0)), AllIntegers::V5(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V5(i8::MAX)), AllIntegers::V5(i8::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::V6(0)), AllIntegers::V6(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V6(i16::MAX)), AllIntegers::V6(i16::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::V7(0)), AllIntegers::V7(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V7(i32::MAX)), AllIntegers::V7(i32::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::V8(0)), AllIntegers::V8(1)));
-        assert!(matches!(add_one_integer(AllIntegers::V8(i64::MAX)), AllIntegers::V8(i64::MIN)));
+        assert!(matches!(add_one_integer(AllIntegers::I8(0)), AllIntegers::I8(1)));
+        assert!(matches!(add_one_integer(AllIntegers::I8(i8::MAX)), AllIntegers::I8(i8::MIN)));
+        assert!(matches!(add_one_integer(AllIntegers::I16(0)), AllIntegers::I16(1)));
+        assert!(matches!(add_one_integer(AllIntegers::I16(i16::MAX)), AllIntegers::I16(i16::MIN)));
+        assert!(matches!(add_one_integer(AllIntegers::I32(0)), AllIntegers::I32(1)));
+        assert!(matches!(add_one_integer(AllIntegers::I32(i32::MAX)), AllIntegers::I32(i32::MIN)));
+        assert!(matches!(add_one_integer(AllIntegers::I64(0)), AllIntegers::I64(1)));
+        assert!(matches!(add_one_integer(AllIntegers::I64(i64::MAX)), AllIntegers::I64(i64::MIN)));
 
         // All-Floats
-        assert!(matches!(add_one_float(AllFloats::V0(0.0)), AllFloats::V0(1.0)));
-        assert!(matches!(add_one_float(AllFloats::V1(0.0)), AllFloats::V1(1.0)));
+        assert!(matches!(add_one_float(AllFloats::F32(0.0)), AllFloats::F32(1.0)));
+        assert!(matches!(add_one_float(AllFloats::F64(0.0)), AllFloats::F64(1.0)));
 
         // All-Text
-        assert!(matches!(replace_first_char(AllTextParam::V0('a'), 'z'), AllTextResult::V0('z')));
+        assert!(matches!(replace_first_char(AllTextParam::Char('a'), 'z'), AllTextResult::Char('z')));
         let rhs = "zbc".to_string();
-        assert!(matches!(replace_first_char(AllTextParam::V1("abc"), 'z'), AllTextResult::V1(rhs)));
+        assert!(matches!(replace_first_char(AllTextParam::String("abc"), 'z'), AllTextResult::String(rhs)));
 
         // All-Integers
-        assert!(matches!(identify_integer(AllIntegers::V0(true)), 0));
-        assert!(matches!(identify_integer(AllIntegers::V1(0)), 1));
-        assert!(matches!(identify_integer(AllIntegers::V2(0)), 2));
-        assert!(matches!(identify_integer(AllIntegers::V3(0)), 3));
-        assert!(matches!(identify_integer(AllIntegers::V4(0)), 4));
-        assert!(matches!(identify_integer(AllIntegers::V5(0)), 5));
-        assert!(matches!(identify_integer(AllIntegers::V6(0)), 6));
-        assert!(matches!(identify_integer(AllIntegers::V7(0)), 7));
-        assert!(matches!(identify_integer(AllIntegers::V8(0)), 8));
+        assert!(matches!(identify_integer(AllIntegers::Bool(true)), 0));
+        assert!(matches!(identify_integer(AllIntegers::U8(0)), 1));
+        assert!(matches!(identify_integer(AllIntegers::U16(0)), 2));
+        assert!(matches!(identify_integer(AllIntegers::U32(0)), 3));
+        assert!(matches!(identify_integer(AllIntegers::U64(0)), 4));
+        assert!(matches!(identify_integer(AllIntegers::I8(0)), 5));
+        assert!(matches!(identify_integer(AllIntegers::I16(0)), 6));
+        assert!(matches!(identify_integer(AllIntegers::I32(0)), 7));
+        assert!(matches!(identify_integer(AllIntegers::I64(0)), 8));
 
         // All-Floats
-        assert!(matches!(identify_float(AllFloats::V0(0.0)), 0));
-        assert!(matches!(identify_float(AllFloats::V1(0.0)), 1));
+        assert!(matches!(identify_float(AllFloats::F32(0.0)), 0));
+        assert!(matches!(identify_float(AllFloats::F64(0.0)), 1));
 
         // All-Text
-        assert!(matches!(identify_text(AllTextParam::V0('a')), 0));
-        assert!(matches!(identify_text(AllTextParam::V1("abc")), 1));
+        assert!(matches!(identify_text(AllTextParam::Char('a')), 0));
+        assert!(matches!(identify_text(AllTextParam::String("abc")), 1));
 
         // Duplicated
-        assert!(matches!(add_one_duplicated(DuplicatedS32::V0(0)), DuplicatedS32::V0(1)));
-        assert!(matches!(add_one_duplicated(DuplicatedS32::V1(1)), DuplicatedS32::V1(2)));
-        assert!(matches!(add_one_duplicated(DuplicatedS32::V2(2)), DuplicatedS32::V2(3)));
+        assert!(matches!(add_one_duplicated(DuplicatedS32::I320(0)), DuplicatedS32::I320(1)));
+        assert!(matches!(add_one_duplicated(DuplicatedS32::I321(1)), DuplicatedS32::I321(2)));
+        assert!(matches!(add_one_duplicated(DuplicatedS32::I322(2)), DuplicatedS32::I322(3)));
 
-        assert!(matches!(identify_duplicated(DuplicatedS32::V0(0)), 0));
-        assert!(matches!(identify_duplicated(DuplicatedS32::V1(0)), 1));
-        assert!(matches!(identify_duplicated(DuplicatedS32::V2(0)), 2));
+        assert!(matches!(identify_duplicated(DuplicatedS32::I320(0)), 0));
+        assert!(matches!(identify_duplicated(DuplicatedS32::I321(0)), 1));
+        assert!(matches!(identify_duplicated(DuplicatedS32::I321(0)), 2));
 
         // Distinguishable
-        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::V0(0.0)), DistinguishableNum::V0(1.0)));
-        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::V1(0)), DistinguishableNum::V1(1)));
+        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::F64(0.0)), DistinguishableNum::F64(1.0)));
+        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::I64(0)), DistinguishableNum::I64(1)));
 
-        assert!(matches!(identify_distinguishable_num(DistinguishableNum::V0(0.0)), 0));
-        assert!(matches!(identify_distinguishable_num(DistinguishableNum::V1(1)), 1));
+        assert!(matches!(identify_distinguishable_num(DistinguishableNum::F64(0.0)), 0));
+        assert!(matches!(identify_distinguishable_num(DistinguishableNum::I64(1)), 1));
     }
 
     fn add_one_integer(num: AllIntegers) -> AllIntegers {
         match num {
             // Boolean
-            AllIntegers::V0(b) => AllIntegers::V0(!b),
+            AllIntegers::Bool(b) => AllIntegers::Bool(!b),
             // Unsigneed Integers
-            AllIntegers::V1(n) => AllIntegers::V1(n.wrapping_add(1)),
-            AllIntegers::V2(n) => AllIntegers::V2(n.wrapping_add(1)),
-            AllIntegers::V3(n) => AllIntegers::V3(n.wrapping_add(1)),
-            AllIntegers::V4(n) => AllIntegers::V4(n.wrapping_add(1)),
+            AllIntegers::U8(n) => AllIntegers::U8(n.wrapping_add(1)),
+            AllIntegers::U16(n) => AllIntegers::U16(n.wrapping_add(1)),
+            AllIntegers::U32(n) => AllIntegers::U32(n.wrapping_add(1)),
+            AllIntegers::U64(n) => AllIntegers::U64(n.wrapping_add(1)),
             // Signed Integers
-            AllIntegers::V5(n) => AllIntegers::V5(n.wrapping_add(1)),
-            AllIntegers::V6(n) => AllIntegers::V6(n.wrapping_add(1)),
-            AllIntegers::V7(n) => AllIntegers::V7(n.wrapping_add(1)),
-            AllIntegers::V8(n) => AllIntegers::V8(n.wrapping_add(1)),
+            AllIntegers::I8(n) => AllIntegers::I8(n.wrapping_add(1)),
+            AllIntegers::I16(n) => AllIntegers::I16(n.wrapping_add(1)),
+            AllIntegers::I32(n) => AllIntegers::I32(n.wrapping_add(1)),
+            AllIntegers::I64(n) => AllIntegers::I64(n.wrapping_add(1)),
         }
     }
 
     fn add_one_float(num: AllFloats) -> AllFloats {
         match num {
-            AllFloats::V0(n) => AllFloats::V0(n + 1.0),
-            AllFloats::V1(n) => AllFloats::V1(n + 1.0),
+            AllFloats::F32(n) => AllFloats::F32(n + 1.0),
+            AllFloats::F64(n) => AllFloats::F64(n + 1.0),
         }
     }
 
     fn replace_first_char(text: AllText, letter: char) -> AllText {
         match text {
-            AllText::V0(c) => AllText::V0(letter),
-            AllText::V1(s) => AllText::V1(format!("{}{}", letter, &s[1..]))
+            AllText::Char(c) => AllText::Char(letter),
+            AllText::String(s) => AllText::String(format!("{}{}", letter, &s[1..]))
         }
     }
 
     fn identify_integer(num: AllIntegers) -> u8 {
         match num {
             // Boolean
-            AllIntegers::V0(_b) => 0,
+            AllIntegers::Bool(_b) => 0,
             // Unsigneed Integers
-            AllIntegers::V1(_n) => 1,
-            AllIntegers::V2(_n) => 2,
-            AllIntegers::V3(_n) => 3,
-            AllIntegers::V4(_n) => 4,
+            AllIntegers::U8(_n) => 1,
+            AllIntegers::U16(_n) => 2,
+            AllIntegers::U32(_n) => 3,
+            AllIntegers::U64(_n) => 4,
             // Signed Integers
-            AllIntegers::V5(_n) => 5,
-            AllIntegers::V6(_n) => 6,
-            AllIntegers::V7(_n) => 7,
-            AllIntegers::V8(_n) => 8,
+            AllIntegers::I8(_n) => 5,
+            AllIntegers::I16(_n) => 6,
+            AllIntegers::I32(_n) => 7,
+            AllIntegers::I64(_n) => 8,
         }
     }
 
     fn identify_float(num: AllFloats) -> u8 {
         match num {
-            AllFloats::V0(_n) => 0,
-            AllFloats::V1(_n) => 1,
+            AllFloats::F32(_n) => 0,
+            AllFloats::F64(_n) => 1,
         }
     }
 
     fn identify_text(text: AllText) -> u8 {
         match text {
-            AllText::V0(_c) => 0,
-            AllText::V1(_s) => 1
+            AllText::Char(_c) => 0,
+            AllText::String(_s) => 1
         }
     }
 
     fn add_one_duplicated(num: DuplicatedS32) -> DuplicatedS32 {
         match num {
-            DuplicatedS32::V0(n) => DuplicatedS32::V0(n.wrapping_add(1)),
-            DuplicatedS32::V1(n) => DuplicatedS32::V1(n.wrapping_add(1)),
-            DuplicatedS32::V2(n) => DuplicatedS32::V2(n.wrapping_add(1)),
+            DuplicatedS32::I320(n) => DuplicatedS32::I320(n.wrapping_add(1)),
+            DuplicatedS32::I321(n) => DuplicatedS32::I321(n.wrapping_add(1)),
+            DuplicatedS32::I322(n) => DuplicatedS32::I322(n.wrapping_add(1)),
         }
     }
 
     fn identify_duplicated(num: DuplicatedS32) -> u8 {
         match num {
-            DuplicatedS32::V0(_n) => 0,
-            DuplicatedS32::V1(_n) => 1,
-            DuplicatedS32::V2(_n) => 2,
+            DuplicatedS32::I320(_n) => 0,
+            DuplicatedS32::I321(_n) => 1,
+            DuplicatedS32::I322(_n) => 2,
         }
     }
 
     fn add_one_distinguishable_num(num: DistinguishableNum) -> DistinguishableNum {
         match num {
-            DistinguishableNum::V0(n) => DistinguishableNum::V0(n + 1.0),
-            DistinguishableNum::V1(n) => DistinguishableNum::V1(n.wrapping_add(1)),
+            DistinguishableNum::F64(n) => DistinguishableNum::F64(n + 1.0),
+            DistinguishableNum::I64(n) => DistinguishableNum::I64(n.wrapping_add(1)),
         }
     }
 
     fn identify_distinguishable_num(num: DistinguishableNum) -> u8 {
         match num {
-            DistinguishableNum::V0(_n) => 0,
-            DistinguishableNum::V1(_n) => 1,
+            DistinguishableNum::F64(_n) => 0,
+            DistinguishableNum::I64(_n) => 1,
         }
     }
 }


### PR DESCRIPTION
Rather than naming them by their index, 'V0', 'V1', 'V2' etc., this changes the Rust backend to name union cases after their types.

For example, this union:

```wit
union foo {
    string,
    u8,
}
```

would previously have generated this enum:

```rust
enum Foo {
    V0(String),
    V1(u8),
}
```

With this change, it will generate this enum:

```rust
enum Foo {
    String(String),
    U8(u8),
}
```

I think that this makes code using these unions much more self-explanatory; it's more obvious that `Foo::String(s)` contains a string than `Foo::V0(s)`.

This handles cases where a union contains more than one of a single type by reintroducing a suffix to those cases - so, `union { char, string, string }` would get case names of `Char`, `String0` and `String1`.

I've named the cases after the types' Rust names rather than their WIT names, so `s32` gets a name of `I32` and `expected<T, E>` gets a name of `Result`. I think that makes it make more sense within Rust, but I don't mind it either way.

This does have some degenerate cases. `option<T>` is named `OptionalT`, and `list<T>` is named `TList`, so `option<list<option<list<list<T>>>>>` would get the unwieldy name of `OptionalOptionalTListListList`. I doubt that types like that would come up much in practice though.