### PR TITLE
feat: Use docstrings in Python generator

### DIFF
--- a/tests/codegen/char.wit
+++ b/tests/codegen/char.wit
@@ -1,2 +1,4 @@
+/// A function that accepts a character
 take-char: func(x: char)
+/// A function that returns a character
 return-char: func() -> char

--- a/tests/codegen/records.wit
+++ b/tests/codegen/records.wit
@@ -6,14 +6,20 @@ record empty {}
 empty-arg: func(x: empty)
 empty-result: func() -> empty
 
+/// A record containing two scalar fields
+/// that both have the same type
 record scalars {
+    /// The first field, named a
     a: u32,
+    /// The second field, named b
     b: u32,
 }
 
 scalar-arg: func(x: scalars)
 scalar-result: func() -> scalars
 
+/// A record that is really just flags
+/// All of the fields are bool
 record really-flags {
     a: bool,
     b: bool,


### PR DESCRIPTION
Instead of just using comments throughout where the `Docs` AST node is present, output them as comments or docstrings depending on the context to produce more idiomatic output.

e.g.
```py
@dataclass
class Scalars:
    """
    A record containing two scalar fields
    that both have the same type
    """
    # The first field, named a
    a: int
    # The second field, named b
    b: int
```