### PR TITLE
Update JS enum representation

### DIFF
--- a/crates/wit-bindgen-demo/main.ts
+++ b/crates/wit-bindgen-demo/main.ts
@@ -1,4 +1,4 @@
-import { Demo, Lang, Config } from './demo.js';
+import { Demo, Config } from './demo.js';
 import * as browser from './browser.js';
 
 class Editor {
@@ -105,13 +105,15 @@ class Editor {
     const is_import = this.mode.value === 'import';
     let lang;
     switch (this.language.value) {
-      case "js": lang = Lang.Js; break;
-      case "rust": lang = Lang.Rust; break;
-      case "wasmtime": lang = Lang.Wasmtime; break;
-      case "wasmtime-py": lang = Lang.WasmtimePy; break;
-      case "c": lang = Lang.C; break;
-      case "markdown": lang = Lang.Markdown; break;
-      case "spidermonkey": lang = Lang.Spidermonkey; break;
+      case "js":
+      case "rust":
+      case "wasmtime":
+      case "wasmtime-py":
+      case "c":
+      case "markdown":
+      case "spidermonkey":
+        lang = this.language.value;
+        break;
       default: return;
     }
     const result = this.config.render(lang, wit, is_import);

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -29,7 +29,7 @@ async function run() {
       return 'output3';
     },
 
-    errnoResult() { return { tag: 'err', val: MyErrno.B }; },
+    errnoResult() { return { tag: 'err', val: "b" }; },
     listTypedefs(x, y) {
       assert.strictEqual(x, 'typedef1');
       assert.deepStrictEqual(y, ['typedef2']);
@@ -39,11 +39,11 @@ async function run() {
     listOfVariants(bools, results, enums) {
       assert.deepStrictEqual(bools, [true, false]);
       assert.deepStrictEqual(results, [{ tag: 'ok', val: undefined }, { tag: 'err', val: undefined }]);
-      assert.deepStrictEqual(enums, [MyErrno.Success, MyErrno.A]);
+      assert.deepStrictEqual(enums, ["success", "a"]);
       return [
         [false, true],
         [{ tag: 'err', val: undefined }, { tag: 'ok', val: undefined }],
-        [MyErrno.A, MyErrno.B],
+        ["a", "b"],
       ];
     },
   };

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -24,11 +24,11 @@ async function run() {
     variantEnums(a, b, c) {
       assert.deepStrictEqual(a, true);
       assert.deepStrictEqual(b, { tag: 'ok', val: undefined });
-      assert.deepStrictEqual(c, MyErrno.Success);
+      assert.deepStrictEqual(c, "success");
       return [
         false,
         { tag: 'err', val: undefined },
-        MyErrno.A,
+        "a",
       ];
     },
   };
@@ -50,16 +50,11 @@ async function run() {
   const f = Math.fround(5.2);
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'err', val: f }), { tag: 'err', val: 5 });
 
-  assert.deepStrictEqual(wasm.roundtripEnum(exports.E1.A), exports.E1.A);
-  assert.deepStrictEqual(wasm.roundtripEnum(exports.E1.B), exports.E1.B);
+  assert.deepStrictEqual(wasm.roundtripEnum("a"), "a");
+  assert.deepStrictEqual(wasm.roundtripEnum("b"), "b");
 
   assert.deepStrictEqual(wasm.invertBool(true), false);
   assert.deepStrictEqual(wasm.invertBool(false), true);
-
-  {
-    const a: exports.E1.A = exports.E1.A;
-    const b: exports.E1.B = exports.E1.B;
-  }
 
   {
     const [a1, a2, a3, a4, a5, a6] = wasm.variantCasts([


### PR DESCRIPTION
Updates the representation of enums in JS to match the component model explainer.

Instead of being mapped to TypeScript enums (an integer discriminant, with constants to check against for each case), they're mapped to strings of the case names, the same as WebIDL enums.

I was originally going to make one big PR to update the representation of all the JS types, but I'm doing it one by one so that the whole thing doesn't get blocked if we decide to change any of the representations upstream.