### PR TITLE
Make `Docs::contents` `None` for regular comments.

### DIFF
--- a/crates/parser/src/ast/resolve.rs
+++ b/crates/parser/src/ast/resolve.rs
@@ -543,16 +543,15 @@ impl Resolver {
     }
 
     fn docs(&mut self, doc: &super::Docs<'_>) -> Docs {
-        if doc.docs.is_empty() {
-            return Docs { contents: None };
-        }
-        let mut docs = String::new();
+        let mut docs = None;
         for doc in doc.docs.iter() {
             // Comments which are not doc-comments are silently ignored
             if let Some(doc) = doc.strip_prefix("///") {
+                let docs = docs.get_or_insert_with(String::new);
                 docs.push_str(doc.trim_start_matches('/').trim());
                 docs.push('\n');
             } else if let Some(doc) = doc.strip_prefix("/**") {
+                let docs = docs.get_or_insert_with(String::new);
                 assert!(doc.ends_with("*/"));
                 for line in doc[..doc.len() - 2].lines() {
                     docs.push_str(line);
@@ -561,7 +560,7 @@ impl Resolver {
             }
         }
         Docs {
-            contents: Some(docs),
+            contents: docs,
         }
     }
 

--- a/crates/parser/src/ast/resolve.rs
+++ b/crates/parser/src/ast/resolve.rs
@@ -559,9 +559,7 @@ impl Resolver {
                 }
             }
         }
-        Docs {
-            contents: docs,
-        }
+        Docs { contents: docs }
     }
 
     fn resolve_value(&mut self, value: &Value<'_>) -> Result<()> {


### PR DESCRIPTION
There was already a check to make it `None` for something with no comments whatsoever, but it was still `Some` if all of the comments on something were regular comments. This fixes that so that it only becomes `Some` once an actual doc comment is found.

I ran into this because it was making the JS enum doc generation from #253 produce some odd results. This WIT:

```wit
// a comment
enum foo { bar }
```

Should have produced this type declaration:

```ts
/**
* # Variants
* 
* ## `"bar"`
*/
export type Foo = "bar";
```

But actually produced this:

```ts
/**
* 
* # Variants
* 
* ## `"bar"`
*/
export type Foo = "bar";
```

Note the extra leading line, caused because `foo`'s docs were `Some("")` instead of `None`. With this PR, it works as expected.