### PR TITLE
Implement `std::fmt::Write` for `Source`

### DIFF
--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::collections::{btree_map::Entry, BTreeMap, HashMap};
+use std::fmt::{self, Write};
 use std::ops::Deref;
 use std::path::Path;
 use wit_parser::*;
@@ -395,6 +396,13 @@ impl Source {
 
     pub fn as_mut_string(&mut self) -> &mut String {
         &mut self.s
+    }
+}
+
+impl Write for Source {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This allows using `write!` and `writeln!` to generate code with format strings instead of `format!`, which is both shorter and more efficient.

This semi-resolves #161 for cases where the things being interpolated implement `Display`, although not for stuff like `print_ty`. I could imagine solving that with an `fn format_ty(...) -> impl Display`, but I haven't done that here; this just aims to allow simplifying the very common `src.push_str(&format!("some {thing}\n"))` to `writeln!(src, "some {thing}").unwrap()`. 