### PR TITLE
Ignore clippy warnings in generated code

### DIFF
--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -1580,10 +1580,8 @@ impl Bindgen for FunctionBindgen<'_> {
                 match amt {
                     0 => {}
                     1 => {
-                        if &operands[0] != "()" {
-                            self.push_str(&operands[0]);
-                            self.push_str("\n");
-                        }
+                        self.push_str(&operands[0]);
+                        self.push_str("\n");
                     }
                     _ => {
                         self.push_str("(");

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -159,8 +159,10 @@ impl Generator for RustWasm {
         self.trait_name = iface.name.to_camel_case();
 
         if !self.opts.standalone {
-            self.src
-                .push_str(&format!("mod {} {{\n", iface.name.to_snake_case()));
+            self.src.push_str(&format!(
+                "#[allow(clippy::all)]\nmod {} {{\n",
+                iface.name.to_snake_case(),
+            ));
         }
 
         self.sizes.fill(iface);

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -1580,8 +1580,10 @@ impl Bindgen for FunctionBindgen<'_> {
                 match amt {
                     0 => {}
                     1 => {
-                        self.push_str(&operands[0]);
-                        self.push_str("\n");
+                        if &operands[0] != "()" {
+                            self.push_str(&operands[0]);
+                            self.push_str("\n");
+                        }
                     }
                     _ => {
                         self.push_str("(");

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -88,8 +88,10 @@ pub trait RustGenerator {
         sig: &FnSig,
     ) -> Vec<String> {
         let params = self.print_docs_and_params(iface, func, param_mode, &sig);
-        self.push_str(" -> ");
-        self.print_ty(iface, &func.result, TypeMode::Owned);
+        if !std::matches!(func.result, Type::Unit) {
+            self.push_str(" -> ");
+            self.print_ty(iface, &func.result, TypeMode::Owned);
+        }
         params
     }
 

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -88,10 +88,8 @@ pub trait RustGenerator {
         sig: &FnSig,
     ) -> Vec<String> {
         let params = self.print_docs_and_params(iface, func, param_mode, &sig);
-        if !std::matches!(func.result, Type::Unit) {
-            self.push_str(" -> ");
-            self.print_ty(iface, &func.result, TypeMode::Owned);
-        }
+        self.push_str(" -> ");
+        self.print_ty(iface, &func.result, TypeMode::Owned);
         params
     }
 

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -311,8 +311,10 @@ impl Generator for Wasmtime {
         self.types.analyze(iface);
         self.in_import = variant == AbiVariant::GuestImport;
         self.trait_name = iface.name.to_camel_case();
-        self.src
-            .push_str(&format!("pub mod {} {{\n", iface.name.to_snake_case()));
+        self.src.push_str(&format!(
+            "#[allow(clippy::all)]\npub mod {} {{\n",
+            iface.name.to_snake_case(),
+        ));
         self.src
             .push_str("#[allow(unused_imports)]\nuse wit_bindgen_wasmtime::{wasmtime, anyhow};\n");
         self.sizes.fill(iface);


### PR DESCRIPTION
Just meet `clippy::unused_unit` warning with a tiny test wit file:

![](https://user-images.githubusercontent.com/7822577/178320173-6af6c43a-34b3-4492-8277-c71619df018f.png)

because of generated code has redundant unit type/value in function signature/body, example:

```rust
    pub fn send(evt: EventParam<'_>) -> () {
        unsafe {
            // ... omit ...
            wit_import(result3_0, result3_1, result3_2, result3_3, result3_4);
            ()
        }
    }
```

This PR attempts to remove them, which in turn eliminates thoose warnings.

PS：Didn't find a good way to determine the return type during instruction translation, currently using string matching, if there is a better way please let me know.