### PR TITLE
Implement syntax support for resource subtyping.

### DIFF
--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -58,6 +58,7 @@ struct UseName<'a> {
 pub struct Resource<'a> {
     docs: Docs<'a>,
     name: Id<'a>,
+    supertype: Option<Id<'a>>,
     values: Vec<(bool, Value<'a>)>,
 }
 
@@ -377,6 +378,11 @@ impl<'a> Resource<'a> {
     fn parse(tokens: &mut Tokenizer<'a>, docs: Docs<'a>) -> Result<Self> {
         tokens.expect(Token::Resource)?;
         let name = parse_id(tokens)?;
+        let supertype = if tokens.eat(Token::Implements)? {
+            Some(parse_id(tokens)?)
+        } else {
+            None
+        };
         let mut values = Vec::new();
         if tokens.eat(Token::LeftBrace)? {
             loop {
@@ -388,7 +394,7 @@ impl<'a> Resource<'a> {
                 values.push((statik, Value::parse(tokens, docs)?));
             }
         }
-        Ok(Resource { docs, name, values })
+        Ok(Resource { docs, name, supertype, values })
     }
 }
 

--- a/crates/parser/src/ast/lex.rs
+++ b/crates/parser/src/ast/lex.rs
@@ -82,6 +82,7 @@ pub enum Token {
     Tuple,
     Async,
     Unit,
+    Implements,
 
     Id,
     ExplicitId,
@@ -272,6 +273,7 @@ impl<'a> Tokenizer<'a> {
                     "tuple" => Tuple,
                     "async" => Async,
                     "unit" => Unit,
+                    "implements" => Implements,
                     _ => Id,
                 }
             }
@@ -540,6 +542,7 @@ impl Token {
             Tuple => "keyword `tuple`",
             Async => "keyword `async`",
             Unit => "keyword `unit`",
+            Implements => "keyword `implements`",
         }
     }
 }

--- a/crates/parser/src/ast/resolve.rs
+++ b/crates/parser/src/ast/resolve.rs
@@ -175,6 +175,7 @@ impl Resolver {
                 let resource = Resource {
                     docs: r.docs.clone(),
                     name: r.name.clone(),
+                    supertype: r.supertype.clone(),
                     foreign_module: Some(
                         r.foreign_module
                             .clone()
@@ -279,6 +280,7 @@ impl Resolver {
                     let id = self.resources.alloc(Resource {
                         docs,
                         name: r.name.name.to_string(),
+                        supertype: r.supertype.as_ref().map(|supertype| supertype.name.to_string()),
                         foreign_module: None,
                     });
                     self.define_resource(&r.name.name, r.name.span, id)?;

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -238,6 +238,7 @@ pub struct Docs {
 pub struct Resource {
     pub docs: Docs,
     pub name: String,
+    pub supertype: Option<String>,
     /// `None` if this resource is defined within the containing instance,
     /// otherwise `Some` if it's defined in an instance named here.
     pub foreign_module: Option<String>,

--- a/crates/parser/tests/all.rs
+++ b/crates/parser/tests/all.rs
@@ -182,6 +182,8 @@ fn to_json(i: &Interface) -> String {
     struct Resource {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
+        supertype: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         foreign_module: Option<String>,
     }
 
@@ -233,6 +235,7 @@ fn to_json(i: &Interface) -> String {
         .iter()
         .map(|(_, r)| Resource {
             name: r.name.clone(),
+            supertype: r.supertype.as_ref().map(|supertype| supertype.clone()),
             foreign_module: r.foreign_module.clone(),
         })
         .collect::<Vec<_>>();

--- a/crates/parser/tests/ui/resource.wit
+++ b/crates/parser/tests/ui/resource.wit
@@ -9,3 +9,8 @@ resource f {
   x: func()
   y: func()
 }
+resource g implements a
+resource h implements b {}
+resource i implements e {
+  z: func()
+}

--- a/crates/parser/tests/ui/resource.wit.result
+++ b/crates/parser/tests/ui/resource.wit.result
@@ -17,6 +17,18 @@
     },
     {
       "name": "f"
+    },
+    {
+      "name": "g",
+      "supertype": "a"
+    },
+    {
+      "name": "h",
+      "supertype": "b"
+    },
+    {
+      "name": "i",
+      "supertype": "e"
     }
   ],
   "types": [
@@ -43,6 +55,18 @@
     {
       "idx": 5,
       "primitive": "handle-5"
+    },
+    {
+      "idx": 6,
+      "primitive": "handle-6"
+    },
+    {
+      "idx": 7,
+      "primitive": "handle-7"
+    },
+    {
+      "idx": 8,
+      "primitive": "handle-8"
     }
   ],
   "functions": [
@@ -64,6 +88,13 @@
       "name": "f::y",
       "params": [
         "handle-5"
+      ],
+      "result": "unit"
+    },
+    {
+      "name": "i::z",
+      "params": [
+        "handle-8"
       ],
       "result": "unit"
     }


### PR DESCRIPTION
This implements a basic syntax for [resource subtyping], using the
`implements` keyword:

```
resource file implements preopen {
   ...
}
```

I'm not attached to this specific syntax or keyword name, but it is
useful to have something that we can start using to mock up wit files.

[resource subtyping]: https://github.com/WebAssembly/component-model/issues/60