### PR TITLE
Fix some minor bugs in the WIT parser

### DIFF
--- a/crates/parser/src/ast/resolve.rs
+++ b/crates/parser/src/ast/resolve.rs
@@ -554,12 +554,17 @@ impl Resolver {
                 let docs = docs.get_or_insert_with(String::new);
                 docs.push_str(doc.trim_start_matches('/').trim());
                 docs.push('\n');
-            } else if let Some(doc) = doc.strip_prefix("/**") {
-                let docs = docs.get_or_insert_with(String::new);
-                assert!(doc.ends_with("*/"));
-                for line in doc[..doc.len() - 2].lines() {
-                    docs.push_str(line);
-                    docs.push('\n');
+            } else if let Some(doc) = doc.strip_prefix("/*") {
+                // We have to strip this before checking if this is a doc
+                // comment to avoid breaking on empty block comments, `/**/`.
+                let doc = doc.strip_suffix("*/").unwrap();
+
+                if let Some(doc) = doc.strip_prefix("*") {
+                    let docs = docs.get_or_insert_with(String::new);
+                    for line in doc.lines() {
+                        docs.push_str(line);
+                        docs.push('\n');
+                    }
                 }
             }
         }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -340,7 +340,15 @@ impl Interface {
         visiting: &mut HashSet<PathBuf>,
         map: &mut HashMap<String, Interface>,
     ) -> Result<Interface> {
-        let mut name = filename.file_stem().unwrap();
+        let name = filename
+            .file_name()
+            .context("wit path must end in a file name")?
+            .to_str()
+            .context("wit filename must be valid unicode")?
+            // TODO: replace with `file_prefix` if/when that gets stabilized.
+            .split(".")
+            .next()
+            .unwrap();
         let mut contents = contents;
 
         // If we have a ".md" file, it's a wit file wrapped in a markdown file;
@@ -349,9 +357,6 @@ impl Interface {
         if filename.extension().and_then(|s| s.to_str()) == Some("md") {
             md_contents = unwrap_md(contents);
             contents = &md_contents[..];
-
-            // Also strip the inner ".wit" extension.
-            name = Path::new(name).file_stem().unwrap();
         }
 
         // Parse the `contents `into an AST
@@ -385,7 +390,7 @@ impl Interface {
         visiting.remove(filename);
 
         // and finally resolve everything into our final instance
-        match ast.resolve(name.to_str().unwrap(), map) {
+        match ast.resolve(name, map) {
             Ok(i) => Ok(i),
             Err(mut e) => {
                 let file = filename.display().to_string();


### PR DESCRIPTION
- The parser would panic on empty block comments (`/**/`), since it would interpret the `/**` as the start of a doc comment, leaving the block comment with `/` instead of `*/` at the end and tripping an assertion.
- The parser would panic on `.md` files, since it assumed they were `.wit.md` files and tried to strip the nonexistent `.wit` from the filename. I worked around this by changing the parser to take everything before the first `.` as the name of the interface. 

I found these while trying out `cargo-fuzz`.