### PR TITLE
wit-bindgen-rust: use derived name for return area type. 

### DIFF
--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -84,8 +84,12 @@ impl RustWasm {
         }
     }
 
+    fn ret_area_type_name(iface: &Interface) -> String {
+        format!("__{}RetArea", iface.name.to_camel_case())
+    }
+
     fn ret_area_name(iface: &Interface) -> String {
-        format!("{}_RET_AREA", iface.name.to_shouty_snake_case())
+        format!("__{}_RET_AREA", iface.name.to_shouty_snake_case())
     }
 }
 
@@ -638,9 +642,10 @@ impl Generator for RustWasm {
             self.src.push_str(&format!(
                 "
                     #[repr(align({align}))]
-                    struct RetArea([u8; {size}]);
-                    static mut {name}: RetArea = RetArea([0; {size}]);
+                    struct {ty}([u8; {size}]);
+                    static mut {name}: {ty} = {ty}([0; {size}]);
                 ",
+                ty = Self::ret_area_type_name(iface),
                 name = Self::ret_area_name(iface),
                 align = self.return_pointer_area_align,
                 size = self.return_pointer_area_size,

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -11,35 +11,97 @@ impl exports::Exports for Exports {
 
         // All-Integers
         // Booleans
-        assert!(matches!(add_one_integer(AllIntegers::Bool(false)), AllIntegers::Bool(true)));
-        assert!(matches!(add_one_integer(AllIntegers::Bool(true)), AllIntegers::Bool(false)));
+        assert!(matches!(
+            add_one_integer(AllIntegers::Bool(false)),
+            AllIntegers::Bool(true)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::Bool(true)),
+            AllIntegers::Bool(false)
+        ));
         // Unsigned integers
-        assert!(matches!(add_one_integer(AllIntegers::U8(0)), AllIntegers::U8(1)));
-        assert!(matches!(add_one_integer(AllIntegers::U8(u8::MAX)), AllIntegers::U8(0)));
-        assert!(matches!(add_one_integer(AllIntegers::U16(0)), AllIntegers::U16(1)));
-        assert!(matches!(add_one_integer(AllIntegers::U16(u16::MAX)), AllIntegers::U16(0)));
-        assert!(matches!(add_one_integer(AllIntegers::U32(0)), AllIntegers::U32(1)));
-        assert!(matches!(add_one_integer(AllIntegers::U32(u32::MAX)), AllIntegers::U32(0)));
-        assert!(matches!(add_one_integer(AllIntegers::U64(0)), AllIntegers::U64(1)));
-        assert!(matches!(add_one_integer(AllIntegers::U64(u64::MAX)), AllIntegers::U64(0)));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U8(0)),
+            AllIntegers::U8(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U8(u8::MAX)),
+            AllIntegers::U8(0)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U16(0)),
+            AllIntegers::U16(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U16(u16::MAX)),
+            AllIntegers::U16(0)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U32(0)),
+            AllIntegers::U32(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U32(u32::MAX)),
+            AllIntegers::U32(0)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U64(0)),
+            AllIntegers::U64(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::U64(u64::MAX)),
+            AllIntegers::U64(0)
+        ));
         // Signed integers
-        assert!(matches!(add_one_integer(AllIntegers::I8(0)), AllIntegers::I8(1)));
-        assert!(matches!(add_one_integer(AllIntegers::I8(i8::MAX)), AllIntegers::I8(i8::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::I16(0)), AllIntegers::I16(1)));
-        assert!(matches!(add_one_integer(AllIntegers::I16(i16::MAX)), AllIntegers::I16(i16::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::I32(0)), AllIntegers::I32(1)));
-        assert!(matches!(add_one_integer(AllIntegers::I32(i32::MAX)), AllIntegers::I32(i32::MIN)));
-        assert!(matches!(add_one_integer(AllIntegers::I64(0)), AllIntegers::I64(1)));
-        assert!(matches!(add_one_integer(AllIntegers::I64(i64::MAX)), AllIntegers::I64(i64::MIN)));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I8(0)),
+            AllIntegers::I8(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I8(i8::MAX)),
+            AllIntegers::I8(i8::MIN)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I16(0)),
+            AllIntegers::I16(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I16(i16::MAX)),
+            AllIntegers::I16(i16::MIN)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I32(0)),
+            AllIntegers::I32(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I32(i32::MAX)),
+            AllIntegers::I32(i32::MIN)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I64(0)),
+            AllIntegers::I64(1)
+        ));
+        assert!(matches!(
+            add_one_integer(AllIntegers::I64(i64::MAX)),
+            AllIntegers::I64(i64::MIN)
+        ));
 
         // All-Floats
-        assert!(matches!(add_one_float(AllFloats::F32(0.0)), AllFloats::F32(1.0)));
-        assert!(matches!(add_one_float(AllFloats::F64(0.0)), AllFloats::F64(1.0)));
+        assert!(
+            matches!(add_one_float(AllFloats::F32(0.0)), AllFloats::F32(x) if x - 1.0 < f32::EPSILON)
+        );
+        assert!(
+            matches!(add_one_float(AllFloats::F64(0.0)), AllFloats::F64(x) if x - 1.0 < f64::EPSILON)
+        );
 
         // All-Text
-        assert!(matches!(replace_first_char(AllTextParam::Char('a'), 'z'), AllTextResult::Char('z')));
-        let rhs = "zbc".to_string();
-        assert!(matches!(replace_first_char(AllTextParam::String("abc"), 'z'), AllTextResult::String(rhs)));
+        assert!(matches!(
+            replace_first_char(AllTextParam::Char('a'), 'z'),
+            AllTextResult::Char('z')
+        ));
+        assert!(
+            matches!(replace_first_char(AllTextParam::String("abc"), 'z'), AllTextResult::String(r) if r == "zbc")
+        );
 
         // All-Integers
         assert!(matches!(identify_integer(AllIntegers::Bool(true)), 0));
@@ -61,27 +123,47 @@ impl exports::Exports for Exports {
         assert!(matches!(identify_text(AllTextParam::String("abc")), 1));
 
         // Duplicated
-        assert!(matches!(add_one_duplicated(DuplicatedS32::I320(0)), DuplicatedS32::I320(1)));
-        assert!(matches!(add_one_duplicated(DuplicatedS32::I321(1)), DuplicatedS32::I321(2)));
-        assert!(matches!(add_one_duplicated(DuplicatedS32::I322(2)), DuplicatedS32::I322(3)));
+        assert!(matches!(
+            add_one_duplicated(DuplicatedS32::I320(0)),
+            DuplicatedS32::I320(1)
+        ));
+        assert!(matches!(
+            add_one_duplicated(DuplicatedS32::I321(1)),
+            DuplicatedS32::I321(2)
+        ));
+        assert!(matches!(
+            add_one_duplicated(DuplicatedS32::I322(2)),
+            DuplicatedS32::I322(3)
+        ));
 
         assert!(matches!(identify_duplicated(DuplicatedS32::I320(0)), 0));
         assert!(matches!(identify_duplicated(DuplicatedS32::I321(0)), 1));
         assert!(matches!(identify_duplicated(DuplicatedS32::I321(0)), 2));
 
         // Distinguishable
-        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::F64(0.0)), DistinguishableNum::F64(1.0)));
-        assert!(matches!(add_one_distinguishable_num(DistinguishableNum::I64(0)), DistinguishableNum::I64(1)));
+        assert!(
+            matches!(add_one_distinguishable_num(DistinguishableNum::F64(0.0)), DistinguishableNum::F64(x) if x - 1.0 < f64::EPSILON)
+        );
+        assert!(matches!(
+            add_one_distinguishable_num(DistinguishableNum::I64(0)),
+            DistinguishableNum::I64(1)
+        ));
 
-        assert!(matches!(identify_distinguishable_num(DistinguishableNum::F64(0.0)), 0));
-        assert!(matches!(identify_distinguishable_num(DistinguishableNum::I64(1)), 1));
+        assert!(matches!(
+            identify_distinguishable_num(DistinguishableNum::F64(0.0)),
+            0
+        ));
+        assert!(matches!(
+            identify_distinguishable_num(DistinguishableNum::I64(1)),
+            1
+        ));
     }
 
     fn add_one_integer(num: AllIntegers) -> AllIntegers {
         match num {
             // Boolean
             AllIntegers::Bool(b) => AllIntegers::Bool(!b),
-            // Unsigneed Integers
+            // Unsigned Integers
             AllIntegers::U8(n) => AllIntegers::U8(n.wrapping_add(1)),
             AllIntegers::U16(n) => AllIntegers::U16(n.wrapping_add(1)),
             AllIntegers::U32(n) => AllIntegers::U32(n.wrapping_add(1)),
@@ -103,8 +185,8 @@ impl exports::Exports for Exports {
 
     fn replace_first_char(text: AllText, letter: char) -> AllText {
         match text {
-            AllText::Char(c) => AllText::Char(letter),
-            AllText::String(s) => AllText::String(format!("{}{}", letter, &s[1..]))
+            AllText::Char(_c) => AllText::Char(letter),
+            AllText::String(s) => AllText::String(format!("{}{}", letter, &s[1..])),
         }
     }
 
@@ -112,7 +194,7 @@ impl exports::Exports for Exports {
         match num {
             // Boolean
             AllIntegers::Bool(_b) => 0,
-            // Unsigneed Integers
+            // Unsigned Integers
             AllIntegers::U8(_n) => 1,
             AllIntegers::U16(_n) => 2,
             AllIntegers::U32(_n) => 3,
@@ -135,7 +217,7 @@ impl exports::Exports for Exports {
     fn identify_text(text: AllText) -> u8 {
         match text {
             AllText::Char(_c) => 0,
-            AllText::String(_s) => 1
+            AllText::String(_s) => 1,
         }
     }
 


### PR DESCRIPTION
This PR ensures that the return area type name is based on the name of the
interface being generated.

It prevents type name collisions when multiple interfaces are exported when
using the `export!` macro generated by the "stand alone" mode (i.e. for `cargo
component`).