### PR TITLE
wit-bindgen-rust: fix lowering and lifting of zero-length lists.

### DIFF
--- a/tests/runtime/lists/exports.wit
+++ b/tests/runtime/lists/exports.wit
@@ -1,6 +1,11 @@
 test-imports: func()
 allocated-bytes: func() -> u32
 
+empty-list-param: func(a: list<u8>)
+empty-string-param: func(a: string)
+empty-list-result: func() -> list<u8>
+empty-string-result: func() -> string
+
 list-param: func(a: list<u8>)
 list-param2: func(a: string)
 list-param3: func(a: list<string>)

--- a/tests/runtime/lists/host.py
+++ b/tests/runtime/lists/host.py
@@ -7,6 +7,18 @@ import sys
 import wasmtime
 
 class MyImports:
+    def empty_list_param(self, a: bytes) -> None:
+        assert(a == b'')
+
+    def empty_string_param(self, a: str) -> None:
+        assert(a == '')
+
+    def empty_list_result(self) -> bytes:
+        return b''
+
+    def empty_string_result(self) -> str:
+        return ''
+
     def list_param(self, a: bytes) -> None:
         assert(a == b'\x01\x02\x03\x04')
 
@@ -89,6 +101,10 @@ def run(wasm_file: str) -> None:
 
     allocated_bytes = wasm.allocated_bytes(store)
     wasm.test_imports(store)
+    wasm.empty_list_param(store, b'')
+    wasm.empty_string_param(store, '')
+    assert(wasm.empty_list_result(store) == b'')
+    assert(wasm.empty_string_result(store) == '')
     wasm.list_param(store, b'\x01\x02\x03\x04')
     wasm.list_param2(store, "foo")
     wasm.list_param3(store, ["foo", "bar", "baz"])

--- a/tests/runtime/lists/host.rs
+++ b/tests/runtime/lists/host.rs
@@ -9,6 +9,22 @@ use wit_bindgen_wasmtime::Le;
 pub struct MyImports;
 
 impl Imports for MyImports {
+    fn empty_list_param(&mut self, a: &[u8]) {
+        assert_eq!(a, []);
+    }
+
+    fn empty_string_param(&mut self, a: &str) {
+        assert_eq!(a, "");
+    }
+
+    fn empty_list_result(&mut self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn empty_string_result(&mut self) -> String {
+        String::new()
+    }
+
     fn list_param(&mut self, list: &[u8]) {
         assert_eq!(list, [1, 2, 3, 4]);
     }
@@ -139,6 +155,10 @@ fn run(wasm: &str) -> Result<()> {
 
     let bytes = exports.allocated_bytes(&mut store)?;
     exports.test_imports(&mut store)?;
+    exports.empty_list_param(&mut store, &[])?;
+    exports.empty_string_param(&mut store, "")?;
+    assert_eq!(exports.empty_list_result(&mut store)?, []);
+    assert_eq!(exports.empty_string_result(&mut store)?, "");
     exports.list_param(&mut store, &[1, 2, 3, 4])?;
     exports.list_param2(&mut store, "foo")?;
     exports.list_param3(&mut store, &["foo", "bar", "baz"])?;

--- a/tests/runtime/lists/host.ts
+++ b/tests/runtime/lists/host.ts
@@ -8,6 +8,16 @@ import * as assert from 'assert';
 async function run() {
   const importObj = {};
   const imports: Imports = {
+    emptyListParam(a) {
+      assert.deepStrictEqual(Array.from(a), []);
+    },
+    emptyStringParam(a) {
+      assert.strictEqual(a, '');
+    },
+    emptyListResult() {
+      return new Uint8Array([]);
+    },
+    emptyStringResult() { return ''; },
     listParam(a) {
       assert.deepStrictEqual(Array.from(a), [1, 2, 3, 4]);
     },
@@ -113,14 +123,18 @@ async function run() {
 
   const bytes = wasm.allocatedBytes();
   wasm.testImports();
+  wasm.emptyListParam(new Uint8Array([]));
+  wasm.emptyStringParam('');
   wasm.listParam(new Uint8Array([1, 2, 3, 4]));
   wasm.listParam2("foo");
   wasm.listParam3(["foo", "bar", "baz"]);
   wasm.listParam4([["foo", "bar"], ["baz"]]);
+  assert.deepStrictEqual(Array.from(wasm.emptyListResult()), []);
+  assert.deepStrictEqual(wasm.emptyStringResult(), "");
   assert.deepStrictEqual(Array.from(wasm.listResult()), [1, 2, 3, 4, 5]);
   assert.deepStrictEqual(wasm.listResult2(), "hello!");
   assert.deepStrictEqual(wasm.listResult3(), ["hello,", "world!"]);
-  
+
   const buffer = new ArrayBuffer(8);
   (new Uint8Array(buffer)).set(new Uint8Array([1, 2, 3, 4]), 2);
   // Create a view of the four bytes in the middle of the buffer

--- a/tests/runtime/lists/imports.wit
+++ b/tests/runtime/lists/imports.wit
@@ -16,6 +16,11 @@ flags flag64 {
   b56, b57, b58, b59, b60, b61, b62, b63,
 }
 
+empty-list-param: func(a: list<u8>)
+empty-string-param: func(a: string)
+empty-list-result: func() -> list<u8>
+empty-string-result: func() -> string
+
 list-param: func(a: list<u8>)
 list-param2: func(a: string)
 list-param3: func(a: list<string>)

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -36,6 +36,32 @@ uint32_t exports_allocated_bytes(void) {
 
 void exports_test_imports() {
   {
+    uint8_t list[] = {};
+    imports_list_u8_t a;
+    a.ptr = list;
+    a.len = 0;
+    imports_empty_list_param(&a);
+  }
+
+  {
+    imports_string_t a;
+    imports_string_set(&a, "");
+    imports_empty_string_param(&a);
+  }
+
+  {
+    imports_list_u8_t a;
+    imports_empty_list_result(&a);
+    assert(a.len == 0);
+  }
+
+  {
+    imports_string_t a;
+    imports_empty_string_result(&a);
+    assert(a.len == 0);
+  }
+
+  {
     uint8_t list[] = {1, 2, 3, 4};
     imports_list_u8_t a;
     a.ptr = list;
@@ -199,6 +225,24 @@ void exports_test_imports() {
     imports_list_float32_free(&list_float32_out);
     imports_list_float64_free(&list_float64_out);
   }
+}
+
+void exports_empty_list_param(exports_list_u8_t *a) {
+  assert(a->len == 0);
+}
+
+void exports_empty_string_param(exports_string_t *a) {
+  assert(a->len == 0);
+}
+
+void exports_empty_list_result(exports_list_u8_t *ret0) {
+  ret0->ptr = 0;
+  ret0->len = 0;
+}
+
+void exports_empty_string_result(exports_string_t *ret0) {
+  ret0->ptr = 0;
+  ret0->len = 0;
 }
 
 void exports_list_param(exports_list_u8_t *a) {

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -17,6 +17,11 @@ impl exports::Exports for Exports {
 
         let _guard = test_rust_wasm::guard();
 
+        empty_list_param(&[]);
+        empty_string_param("");
+        assert!(empty_list_result().is_empty());
+        assert!(empty_string_result().is_empty());
+
         list_param(&[1, 2, 3, 4]);
         list_param2("foo");
         list_param3(&["foo", "bar", "baz"]);
@@ -123,6 +128,22 @@ impl exports::Exports for Exports {
                 vec![f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY],
             ),
         );
+    }
+
+    fn empty_list_param(a: Vec<u8>) {
+        assert!(a.is_empty());
+    }
+
+    fn empty_string_param(a: String) {
+        assert!(a.is_empty());
+    }
+
+    fn empty_list_result() -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn empty_string_result() -> String {
+        String::new()
     }
 
     fn list_param(list: Vec<u8>) {


### PR DESCRIPTION
This PR fixes the Rust bindings generated for lifting and lowering of lists
to account for lists of zero-length.

It is undefined behavior to call `std::alloc::alloc` with a zero-sized layout.

Additionally, as the behavior of the `canonical_abi_realloc` implemented in
`wit-bindgen` is to return a non-null dummy pointer for a zero-sized alloc, the
bindings were calling `std::alloc::dealloc` with a pointer that was not
allocated with `std::alloc::alloc` (also undefined behavior).

To fix this, the bindings now account for zero-length lists and skip allocation
and deallocation where appropriate.