### PR TITLE
Derive more traits for wit-parser types

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -16,7 +16,7 @@ pub fn validate_id(s: &str) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Interface {
     pub name: String,
     /// The module name to use for bindings generation.
@@ -41,7 +41,7 @@ pub type TypeId = Id<TypeDef>;
 pub type ResourceId = Id<Resource>;
 pub type InterfaceId = Id<Interface>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeDef {
     pub docs: Docs,
     pub kind: TypeDefKind,
@@ -51,7 +51,7 @@ pub struct TypeDef {
     pub foreign_module: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TypeDefKind {
     Record(Record),
     Flags(Flags),
@@ -95,24 +95,24 @@ pub enum Int {
     U64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     pub fields: Vec<Field>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     pub docs: Docs,
     pub name: String,
     pub ty: Type,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Flags {
     pub flags: Vec<Flag>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Flag {
     pub docs: Docs,
     pub name: String,
@@ -145,17 +145,17 @@ impl FlagsRepr {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Tuple {
     pub types: Vec<Type>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Variant {
     pub cases: Vec<Case>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Case {
     pub docs: Docs,
     pub name: String,
@@ -173,12 +173,12 @@ impl Variant {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Enum {
     pub cases: Vec<EnumCase>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EnumCase {
     pub docs: Docs,
     pub name: String,
@@ -195,18 +195,18 @@ impl Enum {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Expected {
     pub ok: Type,
     pub err: Type,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Union {
     pub cases: Vec<UnionCase>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UnionCase {
     pub docs: Docs,
     pub ty: Type,
@@ -223,18 +223,18 @@ impl Union {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Stream {
     pub element: Type,
     pub end: Type,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct Docs {
     pub contents: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Resource {
     pub docs: Docs,
     pub name: String,
@@ -244,14 +244,14 @@ pub struct Resource {
     pub foreign_module: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Global {
     pub docs: Docs,
     pub name: String,
     pub ty: Type,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub is_async: bool,
     pub docs: Docs,
@@ -261,7 +261,7 @@ pub struct Function {
     pub result: Type,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FunctionKind {
     Freestanding,
     Static { resource: ResourceId, name: String },


### PR DESCRIPTION
This makes a lot of the `wit-parser` types more composable by automatically deriving `Clone` and `PartialEq`.