### PR TITLE
Remove an unused dependency from `wit-parser`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,15 +1869,6 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
 version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
@@ -2217,7 +2208,6 @@ dependencies = [
  "serde_json",
  "unicode-normalization",
  "unicode-xid",
- "wast 33.0.0",
 ]
 
 [[package]]

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 id-arena = "2"
 anyhow = "1.0"
 pulldown-cmark = { version = "0.8", default-features = false }
-wast = { version = "33", default-features = false, optional = true }
 unicode-xid = "0.2.2"
 unicode-normalization = "0.1.19"
 


### PR DESCRIPTION
Historically this used `wast` but it no longer does.