### PR TITLE
Move `RET_AREA` variables onto the stack.

### DIFF
--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -1114,7 +1114,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         .record(func.params.iter().map(|t| &t.1));
                     let ptr = match self.variant {
                         // When a wasm module calls an import it will provide
-                        // static space that isn't dynamically allocated.
+                        // space that isn't explicitly deallocated.
                         AbiVariant::GuestImport => {
                             self.bindgen.return_pointer(self.iface, size, align)
                         }


### PR DESCRIPTION
Move `RET_AREA` variables out of static memory and onto the stack.

 - This ensures that the bindings are reentrant, which will be needed when the [wasi-threads] proposal makes threads available in wasm.

 - This makes it easier to use wit-bindgen to generate polyfill modules that import their linear memory.

[wasi-threads]: https://github.com/WebAssembly/wasi-threads