### PR TITLE
wit-component: Don't import unused functions on an interface

### DIFF
--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -55,7 +55,7 @@ pub fn validate_module<'a>(
     interface: &Option<&Interface>,
     imports: &[Interface],
     exports: &[Interface],
-) -> Result<(IndexSet<&'a str>, bool, bool)> {
+) -> Result<(IndexMap<&'a str, IndexSet<&'a str>>, bool, bool)> {
     let imports: IndexMap<&str, &Interface> =
         imports.iter().map(|i| (i.name.as_str(), i)).collect();
     let exports: IndexMap<&str, &Interface> =
@@ -155,7 +155,10 @@ pub fn validate_module<'a>(
     }
 
     Ok((
-        import_funcs.keys().cloned().collect(),
+        import_funcs
+            .into_iter()
+            .map(|(name, funcs)| (name, funcs.into_iter().map(|(f, _ty)| f).collect()))
+            .collect(),
         has_memory,
         has_realloc,
     ))

--- a/crates/wit-component/tests/components/imports/import-foo.wit
+++ b/crates/wit-component/tests/components/imports/import-foo.wit
@@ -1,3 +1,4 @@
 foo1: func()
 foo2: func(x: u8)
 foo3: func(x: float32)
+unused: func()


### PR DESCRIPTION
This commit updates `wit-component` to pass around the "liveness" of actually used imported functions so that if an interface defines a full set of functions only those necessary are imported into the generated component.