### PR TITLE
Update to clap 4.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,37 +231,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -272,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1326,30 +1313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,21 +1381,6 @@ dependencies = [
  "futures-util",
  "wit-bindgen-guest-rust",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -2033,7 +1981,7 @@ name = "wit-bindgen-cli"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "structopt",
+ "clap",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-c",
  "wit-bindgen-gen-guest-rust",
@@ -2072,8 +2020,8 @@ dependencies = [
 name = "wit-bindgen-gen-guest-c"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.3.3",
- "structopt",
  "test-helpers",
  "wit-bindgen-core",
 ]
@@ -2082,8 +2030,8 @@ dependencies = [
 name = "wit-bindgen-gen-guest-rust"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.3.3",
- "structopt",
  "test-helpers",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
@@ -2094,8 +2042,8 @@ dependencies = [
 name = "wit-bindgen-gen-guest-teavm-java"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.4.0",
- "structopt",
  "test-helpers",
  "wit-bindgen-core",
 ]
@@ -2104,8 +2052,8 @@ dependencies = [
 name = "wit-bindgen-gen-host-js"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.3.3",
- "structopt",
  "test-helpers",
  "wit-bindgen-core",
 ]
@@ -2114,8 +2062,8 @@ dependencies = [
 name = "wit-bindgen-gen-host-wasmtime-py"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.3.3",
- "structopt",
  "test-helpers",
  "wit-bindgen-core",
 ]
@@ -2125,8 +2073,8 @@ name = "wit-bindgen-gen-host-wasmtime-rust"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "heck 0.3.3",
- "structopt",
  "test-helpers",
  "wasmtime",
  "wasmtime-wasi",
@@ -2139,9 +2087,9 @@ dependencies = [
 name = "wit-bindgen-gen-markdown"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "heck 0.3.3",
  "pulldown-cmark",
- "structopt",
  "wit-bindgen-core",
 ]
 
@@ -2200,7 +2148,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "clap 3.2.22",
+ "clap",
  "env_logger",
  "glob",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ version = "0.2.0"
 anyhow = "1.0.65"
 bitflags = "1.3.2"
 heck = "0.3"
-structopt = { version = "0.3", default-features = false }
 pulldown-cmark = { version = "0.8", default-features = false }
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.9", features = ["derive"] }
 
 wasmtime = "1.0"
 wasmtime-wasi = "1.0"
@@ -50,12 +49,12 @@ test = false
 
 [dependencies]
 anyhow = { workspace = true }
-structopt = { version = "0.3", default-features = false }
+clap = { workspace = true }
 wit-bindgen-core = { path = 'crates/bindgen-core' }
-wit-bindgen-gen-guest-rust = { path = 'crates/gen-guest-rust', features = ['structopt'] }
-wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', features = ['structopt'] }
-wit-bindgen-gen-host-wasmtime-py = { path = 'crates/gen-host-wasmtime-py', features = ['structopt'] }
-wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', features = ['structopt'] }
-wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', features = ['structopt'] }
-wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['structopt'] }
-wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', features = ['structopt'] }
+wit-bindgen-gen-guest-rust = { path = 'crates/gen-guest-rust', features = ['clap'] }
+wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', features = ['clap'] }
+wit-bindgen-gen-host-wasmtime-py = { path = 'crates/gen-host-wasmtime-py', features = ['clap'] }
+wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', features = ['clap'] }
+wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', features = ['clap'] }
+wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['clap'] }
+wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', features = ['clap'] }

--- a/crates/gen-guest-c/Cargo.toml
+++ b/crates/gen-guest-c/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 wit-bindgen-core = { workspace = true }
 heck = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers', features = ['guest-c'] }

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -41,7 +41,7 @@ struct Func {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
     // ...
 }

--- a/crates/gen-guest-rust/Cargo.toml
+++ b/crates/gen-guest-rust/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 wit-bindgen-core = { workspace = true }
 wit-bindgen-gen-rust-lib = { workspace = true }
 heck = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 wit-bindgen-guest-rust = { path = '../guest-rust' }

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -24,24 +24,24 @@ pub struct RustWasm {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
     /// Whether or not `rustfmt` is executed to format generated code.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub rustfmt: bool,
 
     /// Adds the wit module name into import binding names when enabled.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub multi_module: bool,
 
     /// Whether or not the bindings assume interface values are always
     /// well-formed or whether checks are performed.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub unchecked: bool,
 
     /// A prefix to prepend to all exported symbols. Note that this is only
     /// intended for testing because it breaks the general form of the ABI.
-    #[cfg_attr(feature = "structopt", structopt(skip))]
+    #[cfg_attr(feature = "clap", arg(skip))]
     pub symbol_namespace: String,
 
     /// If true, the code generation is intended for standalone crates.
@@ -51,7 +51,7 @@ pub struct Opts {
     /// For exported interfaces, an `export!` macro is also generated
     /// that can be used to export an implementation from a different
     /// crate.
-    #[cfg_attr(feature = "structopt", structopt(skip))]
+    #[cfg_attr(feature = "clap", arg(skip))]
     pub standalone: bool,
 }
 

--- a/crates/gen-guest-teavm-java/Cargo.toml
+++ b/crates/gen-guest-teavm-java/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 wit-bindgen-core = { workspace = true }
 heck = { version = "0.4", features = [ "unicode" ] }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers', default-features = false, features = ['guest-teavm-java'] }

--- a/crates/gen-guest-teavm-java/src/lib.rs
+++ b/crates/gen-guest-teavm-java/src/lib.rs
@@ -24,10 +24,10 @@ pub struct TeaVmJava {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
     /// Whether or not to generate a stub class for exported functions
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub generate_stub: bool,
 }
 

--- a/crates/gen-host-js/Cargo.toml
+++ b/crates/gen-host-js/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 wit-bindgen-core = { workspace = true }
 heck = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers', features = ['host-js'] }

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -37,9 +37,9 @@ struct Exports {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
-    #[cfg_attr(feature = "structopt", structopt(long = "no-typescript"))]
+    #[cfg_attr(feature = "clap", arg(long = "no-typescript"))]
     pub no_typescript: bool,
 }
 

--- a/crates/gen-host-wasmtime-py/Cargo.toml
+++ b/crates/gen-host-wasmtime-py/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 [dependencies]
 wit-bindgen-core = { workspace = true }
 heck = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers', features = ['host-wasmtime-py'] }

--- a/crates/gen-host-wasmtime-py/src/lib.rs
+++ b/crates/gen-host-wasmtime-py/src/lib.rs
@@ -60,9 +60,9 @@ struct Export {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
-    #[cfg_attr(feature = "structopt", structopt(long = "no-typescript"))]
+    #[cfg_attr(feature = "clap", arg(long = "no-typescript"))]
     pub no_typescript: bool,
 }
 

--- a/crates/gen-host-wasmtime-rust/Cargo.toml
+++ b/crates/gen-host-wasmtime-rust/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 wit-bindgen-core = { workspace = true }
 wit-bindgen-gen-rust-lib = { workspace = true }
 heck = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/gen-host-wasmtime-rust/src/lib.rs
+++ b/crates/gen-host-wasmtime-rust/src/lib.rs
@@ -53,19 +53,19 @@ struct Exports {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
     /// Whether or not `rustfmt` is executed to format generated code.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub rustfmt: bool,
 
     /// Whether or not to emit `tracing` macro calls on function entry/exit.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub tracing: bool,
 
     /// A flag to indicate that all trait methods in imports should return a
     /// custom trait-defined error. Applicable for import bindings.
-    #[cfg_attr(feature = "structopt", structopt(long))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub custom_error: bool,
 }
 

--- a/crates/gen-markdown/Cargo.toml
+++ b/crates/gen-markdown/Cargo.toml
@@ -10,5 +10,5 @@ test = false
 [dependencies]
 heck = { workspace = true }
 pulldown-cmark = { workspace = true }
-structopt = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 wit-bindgen-core = { workspace = true }

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -15,7 +15,7 @@ pub struct Markdown {
 }
 
 #[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Opts {
     // ...
 }

--- a/crates/wit-component/src/cli.rs
+++ b/crates/wit-component/src/cli.rs
@@ -43,11 +43,11 @@ fn parse_interface(name: Option<String>, path: &Path) -> Result<Interface> {
 #[clap(name = "component-encoder", version = env!("CARGO_PKG_VERSION"))]
 pub struct WitComponentApp {
     /// The path to an interface definition file the component imports.
-    #[clap(long = "import", value_name = "NAME=INTERFACE", parse(try_from_str = parse_named_interface))]
+    #[clap(long = "import", value_name = "NAME=INTERFACE", value_parser = parse_named_interface)]
     pub imports: Vec<Interface>,
 
     /// The path to an interface definition file the component exports.
-    #[clap(long = "export", value_name = "NAME=INTERFACE", parse(try_from_str = parse_named_interface))]
+    #[clap(long = "export", value_name = "NAME=INTERFACE", value_parser = parse_named_interface)]
     pub exports: Vec<Interface>,
 
     /// The path of the output WebAssembly component.
@@ -55,7 +55,7 @@ pub struct WitComponentApp {
     pub output: Option<PathBuf>,
 
     /// The default interface the component exports.
-    #[clap(long, short = 'i', value_name = "INTERFACE", parse(try_from_str = parse_unnamed_interface))]
+    #[clap(long, short = 'i', value_name = "INTERFACE", value_parser = parse_unnamed_interface)]
     pub interface: Option<Interface>,
 
     /// Skip validation of the output component.

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -1,100 +1,102 @@
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use wit_bindgen_core::{wit_parser, Files, Generator};
 use wit_parser::Interface;
 
-#[derive(Debug, StructOpt)]
-/// A utility that generates language bindings for WIT itnerfaces.
+#[derive(Debug, Parser)]
+/// A utility that generates language bindings for WIT interfaces.
 struct Opt {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     category: Category,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Category {
     /// Generators for creating hosts that embed WASM modules/components.
+    #[command(subcommand)]
     Host(HostGenerator),
     /// Generators for writing guest WASM modules/components.
+    #[command(subcommand)]
     Guest(GuestGenerator),
     /// This generator outputs a Markdown file describing an interface.
     Markdown {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_markdown::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum HostGenerator {
     /// Generates bindings for Rust hosts using the Wasmtime engine.
     WasmtimeRust {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_host_wasmtime_rust::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
     /// Generates bindings for Python hosts using the Wasmtime engine.
     WasmtimePy {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_host_wasmtime_py::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
     /// Generates bindings for JavaScript hosts.
     Js {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_host_js::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum GuestGenerator {
     /// Generates bindings for Rust guest modules.
     Rust {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_guest_rust::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
     /// Generates bindings for C/CPP guest modules.
     C {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_guest_c::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
     /// Generates bindings for TeaVM-based Java guest modules.
     TeavmJava {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         opts: wit_bindgen_gen_guest_teavm_java::Opts,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common: Common,
     },
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Common {
     /// Where to place output files
-    #[structopt(long = "out-dir")]
+    #[clap(long = "out-dir")]
     out_dir: Option<PathBuf>,
 
     /// Generate import bindings for the given `*.wit` interface. Can be
     /// specified multiple times.
-    #[structopt(long = "import", short)]
+    #[clap(long = "import", short)]
     imports: Vec<PathBuf>,
 
     /// Generate export bindings for the given `*.wit` interface. Can be
     /// specified multiple times.
-    #[structopt(long = "export", short)]
+    #[clap(long = "export", short)]
     exports: Vec<PathBuf>,
 }
 
 fn main() -> Result<()> {
-    let opt: Opt = Opt::from_args();
+    let opt: Opt = Opt::parse();
     let (mut generator, common): (Box<dyn Generator>, _) = match opt.category {
         Category::Guest(GuestGenerator::Rust { opts, common }) => (Box::new(opts.build()), common),
         Category::Host(HostGenerator::WasmtimeRust { opts, common }) => {


### PR DESCRIPTION
This migrates everything from structopt and clap 3.* to 4.0.9, while preserving the (sub)command syntax of all the binaries in all the crates in this repo.

Resolves #341 