### PR TITLE
Guest C custom sections containing component types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,10 +2038,13 @@ dependencies = [
 name = "wit-bindgen-gen-guest-c"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "clap",
  "heck 0.3.3",
  "test-helpers",
+ "wasm-encoder 0.18.0",
  "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]

--- a/crates/bindgen-core/src/lib.rs
+++ b/crates/bindgen-core/src/lib.rs
@@ -33,8 +33,9 @@ pub use ns::Ns;
 /// `export` means I'm exporting functions to be called, and `import` means I'm
 /// importing functions that I'm going to call, in both wasm modules and host
 /// code. The enum here represents this user perspective.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Default)]
 pub enum Direction {
+    #[default]
     Import,
     Export,
 }

--- a/crates/gen-guest-c/Cargo.toml
+++ b/crates/gen-guest-c/Cargo.toml
@@ -10,6 +10,9 @@ test = false
 
 [dependencies]
 wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+wasm-encoder = { workspace = true }
+anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
 

--- a/crates/gen-guest-c/src/component_type_object.rs
+++ b/crates/gen-guest-c/src/component_type_object.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use wasm_encoder::{
+    CodeSection, CustomSection, Encode, Function, FunctionSection, Module, TypeSection,
+};
+use wit_bindgen_core::{wit_parser::Interface, Direction};
+use wit_component::InterfaceEncoder;
+
+pub fn linking_symbol(iface: &Interface, direction: Direction) -> String {
+    format!(
+        "__component_type_object_force_link_{}_{}",
+        iface.name,
+        match direction {
+            Direction::Import => "import",
+            Direction::Export => "export",
+        }
+    )
+}
+
+pub fn object(iface: &Interface, direction: Direction) -> Result<Vec<u8>> {
+    let mut module = Module::new();
+
+    // Build a module with one function that's a "dummy function"
+    let mut types = TypeSection::new();
+    types.function([], []);
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+    let mut code = CodeSection::new();
+    code.function(&Function::new([]));
+    module.section(&code);
+
+    let name = format!(
+        "component-type:{}:{}",
+        match direction {
+            Direction::Import => "import",
+            Direction::Export => "export",
+        },
+        iface.name
+    );
+    let data = InterfaceEncoder::new(iface)
+        .encode()
+        .with_context(|| format!("translating interface {} to component type", iface.name))?;
+    // Add our custom section
+    module.section(&CustomSection {
+        name: &name,
+        data: data.as_slice(),
+    });
+
+    // Append the `.linking` section
+    let mut data = Vec::new();
+    data.push(0x02); // version 2
+    {
+        let mut subsection = Vec::<u8>::new();
+        subsection.push(0x01); // syminfo count
+        subsection.push(0x00); // SYMTAB_FUNCTION
+        0u32.encode(&mut subsection); // flags
+        0u32.encode(&mut subsection); // index
+        linking_symbol(iface, direction).encode(&mut subsection); // name
+
+        data.push(0x08); // `WASM_SYMBOL_TABLE`
+        subsection.encode(&mut data);
+    }
+    module.section(&CustomSection {
+        name: "linking",
+        data: &data,
+    });
+
+    Ok(module.finish())
+}

--- a/crates/gen-guest-c/src/component_type_object.rs
+++ b/crates/gen-guest-c/src/component_type_object.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use heck::SnakeCase;
 use wasm_encoder::{
     CodeSection, CustomSection, Encode, Function, FunctionSection, Module, TypeSection,
 };
@@ -8,7 +9,7 @@ use wit_component::InterfaceEncoder;
 pub fn linking_symbol(iface: &Interface, direction: Direction) -> String {
     format!(
         "__component_type_object_force_link_{}_{}",
-        iface.name,
+        iface.name.to_snake_case(),
         match direction {
             Direction::Import => "import",
             Direction::Export => "export",

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -704,6 +704,7 @@ impl Return {
 
 impl Generator for C {
     fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
+        self.direction = dir;
         let variant = Self::abi_variant(dir);
         self.sizes.fill(iface);
         self.in_import = variant == AbiVariant::GuestImport;

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -251,15 +251,35 @@ fn main() {
                 panic!("failed to build");
             }
 
+            let out_wasm = out_dir.join("target/generated/wasm/teavm-wasm/classes.wasm");
+
             wasms.push((
                 "java",
                 test_dir.file_stem().unwrap().to_str().unwrap().to_string(),
-                out_dir
-                    .join("target/generated/wasm/teavm-wasm/classes.wasm")
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
+                out_wasm.to_str().unwrap().to_string(),
             ));
+
+            let imports = [Interface::parse_file(test_dir.join("imports.wit")).unwrap()];
+            let interface = Interface::parse_file(test_dir.join("exports.wit")).unwrap();
+
+            // Validate that the module can be translated to a component, using
+            // wit interfaces explicitly passed to ComponentEncoder, because the
+            // TeaVM guest doesnt yet support putting component types into custom
+            // sections.
+            let module = fs::read(&out_wasm).expect("failed to read wasm file");
+            ComponentEncoder::default()
+                .imports(&imports)
+                .interface(&interface)
+                .module(module.as_slice())
+                .expect("pull custom sections from module")
+                .validate(true)
+                .adapter_file(&wasi_adapter)
+                .expect("adapter failed to get loaded")
+                .encode()
+                .expect(&format!(
+                    "module {:?} can be translated to a component",
+                    out_wasm
+                ));
         }
     }
 

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -152,23 +152,18 @@ fn main() {
                 out_wasm.to_str().unwrap().to_string(),
             ));
 
-            // The "invalid" test doesn't actually use the rust-guest macro
-            // and doesn't put the custom sections in, so component translation
-            // will fail.
-            if test_dir.file_stem().unwrap().to_str().unwrap() != "invalid" {
-                // Validate that the module can be translated to a component, using
-                // the component-type custom sections. We don't yet consume this component
-                // anywhere.
-                let module = fs::read(&out_wasm).expect("failed to read wasm file");
-                ComponentEncoder::default()
-                    .module(module.as_slice())
-                    .expect("pull custom sections from module")
-                    .validate(true)
-                    .adapter_file(&wasi_adapter)
-                    .expect("adapter failed to get loaded")
-                    .encode()
-                    .expect("module can be translated to a component");
-            }
+            // Validate that the module can be translated to a component, using
+            // the component-type custom sections. We don't yet consume this component
+            // anywhere.
+            let module = fs::read(&out_wasm).expect("failed to read wasm file");
+            ComponentEncoder::default()
+                .module(module.as_slice())
+                .expect("pull custom sections from module")
+                .validate(true)
+                .adapter_file(&wasi_adapter)
+                .expect("adapter failed to get loaded")
+                .encode()
+                .expect("module can be translated to a component");
         }
     }
 

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -118,7 +118,9 @@ fn main() {
             cmd.arg("--sysroot").arg(path.join("share/wasi-sysroot"));
             cmd.arg(c_impl)
                 .arg(out_dir.join("imports.c"))
+                .arg(out_dir.join("imports_component_type.o"))
                 .arg(out_dir.join("exports.c"))
+                .arg(out_dir.join("exports_component_type.o"))
                 .arg("-I")
                 .arg(&out_dir)
                 .arg("-Wall")
@@ -149,6 +151,26 @@ fn main() {
                 test_dir.file_stem().unwrap().to_str().unwrap().to_string(),
                 out_wasm.to_str().unwrap().to_string(),
             ));
+
+            // The "invalid" test doesn't actually use the rust-guest macro
+            // and doesn't put the custom sections in, so component translation
+            // will fail.
+            if test_dir.file_stem().unwrap().to_str().unwrap() != "invalid" {
+                // Validate that the module can be translated to a component, using
+                // the component-type custom sections. We don't yet consume this component
+                // anywhere.
+                // FIXME need a wasi_snapshot_preview1 shim in order to be able to encode as a
+                // component - then we can uncomment below
+                /*
+                let module = fs::read(&out_wasm).expect("failed to read wasm file");
+                ComponentEncoder::default()
+                    .module(module.as_slice())
+                    .expect("pull custom sections from module")
+                    .validate(true)
+                    .encode()
+                    .expect("module can be translated to a component");
+                */
+            }
         }
     }
 

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -159,17 +159,15 @@ fn main() {
                 // Validate that the module can be translated to a component, using
                 // the component-type custom sections. We don't yet consume this component
                 // anywhere.
-                // FIXME need a wasi_snapshot_preview1 shim in order to be able to encode as a
-                // component - then we can uncomment below
-                /*
                 let module = fs::read(&out_wasm).expect("failed to read wasm file");
                 ComponentEncoder::default()
                     .module(module.as_slice())
                     .expect("pull custom sections from module")
                     .validate(true)
+                    .adapter_file(&wasi_adapter)
+                    .expect("adapter failed to get loaded")
                     .encode()
                     .expect("module can be translated to a component");
-                */
             }
         }
     }

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -58,7 +58,10 @@ fn main() {
                 .adapter_file(&wasi_adapter)
                 .expect("adapter failed to get loaded")
                 .encode()
-                .expect("module can be translated to a component");
+                .expect(&format!(
+                    "module {:?} can be translated to a component",
+                    file
+                ));
 
             let dep_file = file.with_extension("d");
             let deps = fs::read_to_string(&dep_file).expect("failed to read dep file");
@@ -163,7 +166,10 @@ fn main() {
                 .adapter_file(&wasi_adapter)
                 .expect("adapter failed to get loaded")
                 .encode()
-                .expect("module can be translated to a component");
+                .expect(&format!(
+                    "module {:?} can be translated to a component",
+                    out_wasm
+                ));
         }
     }
 

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -29,6 +29,25 @@ pub extern "C" fn environ_sizes_get(environc: *mut Size, environ_buf_size: *mut 
 }
 
 #[no_mangle]
+pub extern "C" fn args_get(args: *mut *mut u8, args_buf: *mut u8) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn args_sizes_get(argc: *mut Size, arg_buf_size: *mut Size) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn clock_time_get(
+    clockid: Clockid,
+    precision: Timestamp,
+    out: *mut Timestamp,
+) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
 pub extern "C" fn fd_write(
     fd: Fd,
     iovs_ptr: *const Ciovec,

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -39,6 +39,16 @@ pub extern "C" fn fd_write(
 }
 
 #[no_mangle]
+pub extern "C" fn fd_seek(fd: Fd, offset: Filedelta, whence: Whence, filesize: *mut Size) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn fd_close(fd: Fd) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
 pub extern "C" fn proc_exit(rval: Exitcode) -> ! {
     unreachable()
 }


### PR DESCRIPTION
Adds the custom section component types generation to the guest C generator.

Also tests that TeaVM guests can be translated to components as well. In the TeaVM case, we explicitly pass the imports and export interface to the ComponentEncoder.

I added stub functions to the WASI adapter for the additional functions required by wasi-libc and the TeaVM guests.