### PR TITLE
Remove special case for "invalid" test

### DIFF
--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -38,21 +38,16 @@ fn main() {
                 file.to_str().unwrap().to_string(),
             ));
 
-            // The "invalid" test doesn't actually use the rust-guest macro
-            // and doesn't put the custom sections in, so component translation
-            // will fail.
-            if file.file_stem().unwrap().to_str().unwrap() != "invalid" {
-                // Validate that the module can be translated to a component, using
-                // the component-type custom sections. We don't yet consume this component
-                // anywhere.
-                let module = fs::read(&file).expect("failed to read wasm file");
-                ComponentEncoder::default()
-                    .module(module.as_slice())
-                    .expect("pull custom sections from module")
-                    .validate(true)
-                    .encode()
-                    .expect("module can be translated to a component");
-            }
+            // Validate that the module can be translated to a component, using
+            // the component-type custom sections. We don't yet consume this component
+            // anywhere.
+            let module = fs::read(&file).expect("failed to read wasm file");
+            ComponentEncoder::default()
+                .module(module.as_slice())
+                .expect("pull custom sections from module")
+                .validate(true)
+                .encode()
+                .expect("module can be translated to a component");
 
             let dep_file = file.with_extension("d");
             let deps = fs::read_to_string(&dep_file).expect("failed to read dep file");

--- a/tests/runtime/invalid/wasm.rs
+++ b/tests/runtime/invalid/wasm.rs
@@ -1,4 +1,5 @@
 wit_bindgen_guest_rust::export!("../../tests/runtime/invalid/exports.wit");
+wit_bindgen_guest_rust::import!("../../tests/runtime/invalid/imports.wit");
 
 #[link(wasm_import_module = "imports")]
 extern "C" {


### PR DESCRIPTION
While we don't actually use the `imports.wit` it should be possible to still generate the code for it as-if we used it to allow running the test through `wit-component`.