### PR TITLE
Compile test cases with `wasm32-wasi` again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi_snapshot_preview1"
+version = "0.0.0"
+dependencies = [
+ "wasi",
+ "wit-bindgen-guest-rust",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/test-rust-wasm",
   "crates/wit-bindgen-demo",
   "crates/wit-component",
+  "crates/wasi_snapshot_preview1",
 ]
 resolver = "2"
 

--- a/crates/wasi_snapshot_preview1/Cargo.toml
+++ b/crates/wasi_snapshot_preview1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasi_snapshot_preview1"
+version = "0.0.0"
+edition.workspace = true
+
+[dependencies]
+wasi = "0.11.0"
+wit-bindgen-guest-rust = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+test = false

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -1,0 +1,44 @@
+//! This module is intended to be an "adapter module" fed into `wit-component`
+//! to translate the `wasi_snapshot_preview1` ABI into an ABI that uses the
+//! component model. This library is compiled as a standalone wasm file and is
+//! used to implement `wasi_snapshot_preview1` interfaces required by the tests
+//! throughout the `wit-bindgen` repository.
+//!
+//! This is not intended to be a comprehensive polyfill. Instead this is just
+//! the bare bones necessary to get `wit-bindgen` itself and its tests working.
+//!
+//! Currently all functions are trapping stubs since nothing actually runs the
+//! output component just yet. These stubs should get filled in as necessary
+//! once hosts start running components. The current assumption is that the
+//! imports will be adapted to a custom `wit-bindgen`-specific host `*.wit` file
+//! which is only suitable for `wit-bindgen` tests.
+
+#![allow(unused_variables)]
+
+use std::arch::wasm32::unreachable;
+use wasi::*;
+
+#[no_mangle]
+pub extern "C" fn environ_get(environ: *mut *mut u8, environ_buf: *mut u8) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn environ_sizes_get(environc: *mut Size, environ_buf_size: *mut Size) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn fd_write(
+    fd: Fd,
+    iovs_ptr: *const Ciovec,
+    iovs_len: usize,
+    nwritten: *mut Size,
+) -> Errno {
+    unreachable()
+}
+
+#[no_mangle]
+pub extern "C" fn proc_exit(rval: Exitcode) -> ! {
+    unreachable()
+}

--- a/crates/wit-component/src/extract.rs
+++ b/crates/wit-component/src/extract.rs
@@ -1,0 +1,72 @@
+use crate::decode_interface_component;
+use anyhow::{Context, Result};
+use wit_parser::Interface;
+
+/// Result of extracting interfaces embedded within a core wasm file.
+///
+/// This structure is reated by the [`extract_module_interfaces`] function.
+#[derive(Default)]
+pub struct ModuleInterfaces {
+    /// The core wasm binary with custom sections removed.
+    pub wasm: Vec<u8>,
+
+    /// Imported interfaces found in custom sections.
+    pub imports: Vec<Interface>,
+
+    /// Exported interfaces found in custom sections.
+    pub exports: Vec<Interface>,
+
+    /// The default exported interface found in a custom section.
+    pub interface: Option<Interface>,
+}
+
+/// This function will parse the `wasm` binary given as input and return a
+/// [`ModuleInterfaces`] which extracts the custom sections describing
+/// component-level types from within the binary itself.
+///
+/// This is used to parse the output of `wit-bindgen`-generated modules and is
+/// one of the earliest phases in transitioning such a module to a component.
+/// The extraction here provides the metadata necessary to continue the process
+/// later on.
+pub fn extract_module_interfaces(wasm: &[u8]) -> Result<ModuleInterfaces> {
+    let mut ret = ModuleInterfaces::default();
+
+    for payload in wasmparser::Parser::new(0).parse_all(wasm) {
+        match payload.context("decoding item in module")? {
+            wasmparser::Payload::CustomSection(cs) => {
+                if let Some(export) = cs.name().strip_prefix("component-type:export:") {
+                    let mut i = decode_interface_component(cs.data()).with_context(|| {
+                        format!("decoding component-type in export section {}", export)
+                    })?;
+                    i.name = export.to_owned();
+                    ret.interface = Some(i);
+                } else if let Some(import) = cs.name().strip_prefix("component-type:import:") {
+                    let mut i = decode_interface_component(cs.data()).with_context(|| {
+                        format!("decoding component-type in import section {}", import)
+                    })?;
+                    i.name = import.to_owned();
+                    ret.imports.push(i);
+                } else if let Some(export_instance) =
+                    cs.name().strip_prefix("component-type:export-instance:")
+                {
+                    let mut i = decode_interface_component(cs.data()).with_context(|| {
+                        format!(
+                            "decoding component-type in export-instance section {}",
+                            export_instance
+                        )
+                    })?;
+                    i.name = export_instance.to_owned();
+                    ret.exports.push(i);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // TODO: should remove the custom setions decoded above from the wasm binary
+    // created here, and bytecodealliance/wasmparser#792 should help with that
+    // to make the loop above pretty small.
+    ret.wasm = wasm.to_vec();
+
+    Ok(ret)
+}

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -11,11 +11,13 @@ use wit_parser::Interface;
 pub mod cli;
 mod decoding;
 mod encoding;
+mod extract;
 mod gc;
 mod printing;
 mod validation;
 
 pub use encoding::*;
+pub use extract::*;
 pub use printing::*;
 
 /// Supported string encoding formats.


### PR DESCRIPTION
This commit is the next step in integrating `wasm32-wasi`, `wit-bindgen`, tests, and components all together. Tests are now again compiled with `wasm32-wasi` and use a repo-specific adapter module (with support from #338) to support transforming the final module into an actual component.

In supporting this feature the support from #331 is refactored into a new `extract` Rust module so the functionality can be shared between the ingestion of the main module as well as ingestion of adapter modules. Adapter modules now are also supported on the CLI as a standalone file without having to specify other options.

Note that the actual `wasi_snapshot_preview1.wasm` adapter is non-functional in this commit and doesn't do anything fancy. The tests in this repository don't really need all that much and I suspect all we'll really need to implement is `fd_write` for fd 1 (as that's stdout).