### PR TITLE
Add a `raw_strings` option.

### DIFF
--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -30,3 +30,39 @@ mod exports {
         "!host.wit"
     );
 }
+
+mod strings {
+    wit_bindgen_guest_rust::import!({
+        src["cat"]: "
+            foo: func(x: string)
+            bar: func() -> string
+        ",
+    });
+
+    fn test() {
+        // Test the argument is `&str`.
+        cat::foo("hello");
+
+        // Test the return type is `String`.
+        let _t: String = cat::bar();
+    }
+}
+
+/// Like `strings` but with raw_strings`.
+mod raw_strings {
+    wit_bindgen_guest_rust::import!({
+        src["cat"]: "
+            foo: func(x: string)
+            bar: func() -> string
+        ",
+        raw_strings,
+    });
+
+    fn test() {
+        // Test the argument is `&[u8]`.
+        cat::foo(b"hello");
+
+        // Test the return type is `Vec<u8>`.
+        let _t: Vec<u8> = cat::bar();
+    }
+}

--- a/crates/gen-rust-lib/src/lib.rs
+++ b/crates/gen-rust-lib/src/lib.rs
@@ -18,6 +18,11 @@ pub trait RustGenerator {
         true
     }
 
+    /// Return true iff the generator should use `&[u8]` instead of `&str` in bindings.
+    fn use_raw_strings(&self) -> bool {
+        false
+    }
+
     fn push_str(&mut self, s: &str);
     fn info(&self, ty: TypeId) -> TypeInfo;
     fn types_mut(&mut self) -> &mut Types;
@@ -179,7 +184,13 @@ pub trait RustGenerator {
                 TypeMode::AllBorrowed(lt) | TypeMode::LeafBorrowed(lt) => {
                     self.print_borrowed_str(lt)
                 }
-                TypeMode::Owned => self.push_str("String"),
+                TypeMode::Owned => {
+                    if self.use_raw_strings() {
+                        self.push_str("Vec<u8>")
+                    } else {
+                        self.push_str("String")
+                    }
+                }
             },
         }
     }

--- a/crates/guest-rust-macro/src/lib.rs
+++ b/crates/guest-rust-macro/src/lib.rs
@@ -53,6 +53,7 @@ mod kw {
     syn::custom_keyword!(unchecked);
     syn::custom_keyword!(multi_module);
     syn::custom_keyword!(no_std);
+    syn::custom_keyword!(raw_strings);
 }
 
 impl Parse for Opts {
@@ -71,6 +72,7 @@ impl Parse for Opts {
                     ConfigField::MultiModule => opts.multi_module = true,
                     ConfigField::Interfaces(v) => interfaces = v,
                     ConfigField::NoStd => opts.no_std = true,
+                    ConfigField::RawStrings => opts.raw_strings = true,
                 }
             }
             if interfaces.is_empty() {
@@ -107,6 +109,7 @@ enum ConfigField {
     Unchecked,
     MultiModule,
     NoStd,
+    RawStrings,
 }
 
 impl Parse for ConfigField {
@@ -147,6 +150,9 @@ impl Parse for ConfigField {
         } else if l.peek(kw::no_std) {
             input.parse::<kw::no_std>()?;
             Ok(ConfigField::NoStd)
+        } else if l.peek(kw::raw_strings) {
+            input.parse::<kw::raw_strings>()?;
+            Ok(ConfigField::RawStrings)
         } else {
             Err(l.error())
         }


### PR DESCRIPTION
Add a `raw_strings` option for the Rust guest bindings, to use `&[u8]` and `Vec<u8>` instead of `&str` and `String` for representing strings in bindings. This will allow polyfill modules that don't already have a `&str` to avoid doing a `str::from_utf8` to obtain one, which is redundant since the adapter will already be doing UTF-8 validation.
