### PR TITLE
Remove obsolete test exclusions.

### DIFF
--- a/crates/gen-guest-c/tests/codegen.rs
+++ b/crates/gen-guest-c/tests/codegen.rs
@@ -2,26 +2,27 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[rustfmt::skip]
 mod imports {
     test_helpers::codegen_c_import!(
         "*.wit"
 
-        // TODO: implement async support
-        "!async-functions.wit"
+        // If you want to exclude a specific test you can include it here with
+        // gitignore glob syntax:
+        //
+        // "!wasm.wit"
+        // "!host.wit"
+        //
+        //
+        // Similarly you can also just remove the `*.wit` glob and list tests
+        // individually if you're debugging.
     );
 }
 
+#[rustfmt::skip]
 mod exports {
     test_helpers::codegen_c_export!(
         "*.wit"
-
-        // TODO: implement async support
-        "!async-functions.wit"
-
-        // TODO: these use push/pull buffer in exports which isn't implemented
-        // yet
-        "!wasi-next.wit"
-        "!host.wit"
     );
 }
 

--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -20,13 +20,9 @@ mod imports {
     );
 }
 
+#[rustfmt::skip]
 mod exports {
     test_helpers::codegen_rust_wasm_export!(
         "*.wit"
-
-        // TODO: these use push/pull buffer which isn't implemented in the test
-        // generator just yet
-        "!wasi-next.wit"
-        "!host.wit"
     );
 }

--- a/crates/gen-guest-teavm-java/tests/codegen.rs
+++ b/crates/gen-guest-teavm-java/tests/codegen.rs
@@ -1,23 +1,27 @@
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use std::{fs, path::Path, process::Command};
 
+#[rustfmt::skip]
 mod imports {
     test_helpers::codegen_teavm_java_import!(
         "*.wit"
 
-        // TODO: implement async and resource support
-        "!async-functions.wit"
-        "!resource.wit"
+        // If you want to exclude a specific test you can include it here with
+        // gitignore glob syntax:
+        //
+        // "!wasm.wit"
+        // "!host.wit"
+        //
+        //
+        // Similarly you can also just remove the `*.wit` glob and list tests
+        // individually if you're debugging.
     );
 }
 
+#[rustfmt::skip]
 mod exports {
     test_helpers::codegen_teavm_java_export!(
         "*.wit"
-
-        // TODO: implement async and resource support
-        "!async-functions.wit"
-        "!resource.wit"
     );
 }
 

--- a/crates/gen-host-js/tests/codegen.rs
+++ b/crates/gen-host-js/tests/codegen.rs
@@ -1,21 +1,27 @@
 use std::path::Path;
 use std::process::Command;
 
+#[rustfmt::skip]
 mod exports {
     test_helpers::codegen_js_export!(
-        // ...
         "*.wit"
+
+        // If you want to exclude a specific test you can include it here with
+        // gitignore glob syntax:
+        //
+        // "!wasm.wit"
+        // "!host.wit"
+        //
+        //
+        // Similarly you can also just remove the `*.wit` glob and list tests
+        // individually if you're debugging.
     );
 }
 
+#[rustfmt::skip]
 mod imports {
     test_helpers::codegen_js_import!(
         "*.wit"
-
-        // This uses buffers, which we don't support in imports just yet
-        // TODO: should support this
-        "!wasi-next.wit"
-        "!host.wit"
     );
 }
 

--- a/crates/gen-host-wasmtime-py/tests/codegen.rs
+++ b/crates/gen-host-wasmtime-py/tests/codegen.rs
@@ -1,26 +1,27 @@
 use std::path::Path;
 use std::process::Command;
 
+#[rustfmt::skip]
 mod exports {
     test_helpers::codegen_py_export!(
         "*.wit"
 
-        // TODO: implement async support
-        "!async-functions.wit"
+        // If you want to exclude a specific test you can include it here with
+        // gitignore glob syntax:
+        //
+        // "!wasm.wit"
+        // "!host.wit"
+        //
+        //
+        // Similarly you can also just remove the `*.wit` glob and list tests
+        // individually if you're debugging.
     );
 }
 
+#[rustfmt::skip]
 mod imports {
     test_helpers::codegen_py_import!(
         "*.wit"
-
-        // TODO: implement async support
-        "!async-functions.wit"
-
-        // This uses buffers, which we don't support in imports just yet
-        // TODO: should support this
-        "!wasi-next.wit"
-        "!host.wit"
     );
 }
 

--- a/crates/gen-host-wasmtime-rust/tests/codegen.rs
+++ b/crates/gen-host-wasmtime-rust/tests/codegen.rs
@@ -9,9 +9,6 @@ mod exports {
     test_helpers::codegen_wasmtime_export!(
         "*.wit"
 
-        // TODO: implement async support
-        "!async-functions.wit"
-
         // If you want to exclude a specific test you can include it here with
         // gitignore glob syntax:
         //
@@ -24,17 +21,10 @@ mod exports {
     );
 }
 
+#[rustfmt::skip]
 mod imports {
     test_helpers::codegen_wasmtime_import!(
         "*.wit"
-
-        // TODO: implement async support
-        "!async-functions.wit"
-
-        // TODO: these use push/pull buffer which isn't implemented in the test
-        // generator just yet
-        "!wasi-next.wit"
-        "!host.wit"
     );
 }
 


### PR DESCRIPTION
async-functions.wit, host.wit, wasi-next.wit, and resource.wit are no longer in the tree, so we no longer need to explicitly disable testing them.

And add the comment about disabling tests to all the codegen tests, so that it's easy to find by people debugging them.