### PR TITLE
Remove async from features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,7 +2146,6 @@ name = "wit-bindgen-host-wasmtime-rust"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bitflags",
  "thiserror",
  "tracing",

--- a/crates/gen-host-wasmtime-rust/Cargo.toml
+++ b/crates/gen-host-wasmtime-rust/Cargo.toml
@@ -19,4 +19,4 @@ anyhow = { workspace = true }
 test-helpers = { path = '../test-helpers', features = ['host-wasmtime-rust'] }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-wit-bindgen-host-wasmtime-rust = { workspace = true, features = ['tracing', 'async'] }
+wit-bindgen-host-wasmtime-rust = { workspace = true, features = ['tracing'] }

--- a/crates/host-wasmtime-rust-macro/Cargo.toml
+++ b/crates/host-wasmtime-rust-macro/Cargo.toml
@@ -17,4 +17,3 @@ wit-bindgen-gen-host-wasmtime-rust = { workspace = true }
 
 [features]
 tracing = []
-async = []

--- a/crates/host-wasmtime-rust/Cargo.toml
+++ b/crates/host-wasmtime-rust/Cargo.toml
@@ -11,14 +11,9 @@ thiserror = "1.0"
 wasmtime = { workspace = true }
 wit-bindgen-host-wasmtime-rust-macro = { path = "../host-wasmtime-rust-macro", version = "0.2" }
 tracing-lib = { version = "0.1.26", optional = true, package = 'tracing' }
-async-trait = { version = "0.1.50", optional = true }
 
 [features]
 # Enables generated code to emit events via the `tracing` crate whenever wasm is
 # entered and when native functions are called. Note that tracing is currently
 # only done for imported functions.
 tracing = ['tracing-lib', 'wit-bindgen-host-wasmtime-rust-macro/tracing']
-
-# Enables async support for generated code, although when enabled this still
-# needs to be configured through the macro invocation.
-async = ['async-trait', 'wit-bindgen-host-wasmtime-rust-macro/async']

--- a/crates/host-wasmtime-rust/src/lib.rs
+++ b/crates/host-wasmtime-rust/src/lib.rs
@@ -1,7 +1,5 @@
 pub use wit_bindgen_host_wasmtime_rust_macro::{export, import};
 
-#[cfg(feature = "async")]
-pub use async_trait::async_trait;
 #[cfg(feature = "tracing-lib")]
 pub use tracing_lib as tracing;
 #[doc(hidden)]


### PR DESCRIPTION
Remove async feature from host-rust crates as it no longer available. Relates #307.

###### Context
I faced this when I tried to use `async` support but noticed that "async: *" is no longer available in `export`/`import` macro and `#[async_trait]` attribute is accepted but the program doesn't compile with it. Then I've found #307. Am I missing something?