### PR TITLE
Refactor and reorganize how testing works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "guest-rust-test-macro"
+version = "0.0.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "wit-parser",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1359,15 @@ dependencies = [
 name = "test-helpers"
 version = "0.2.0"
 dependencies = [
+ "test-helpers-macros",
+ "wit-bindgen-core",
+ "wit-parser",
+]
+
+[[package]]
+name = "test-helpers-macros"
+version = "0.2.0"
+dependencies = [
  "backtrace",
  "filetime",
  "heck",
@@ -1357,11 +1376,7 @@ dependencies = [
  "quote",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-c",
- "wit-bindgen-gen-guest-rust",
  "wit-bindgen-gen-guest-teavm-java",
- "wit-bindgen-gen-host-js",
- "wit-bindgen-gen-host-wasmtime-py",
- "wit-bindgen-gen-host-wasmtime-rust",
  "wit-component",
  "wit-parser",
 ]
@@ -2043,6 +2058,7 @@ name = "wit-bindgen-gen-guest-rust"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "guest-rust-test-macro",
  "heck",
  "test-helpers",
  "wit-bindgen-core",

--- a/crates/gen-guest-c/Cargo.toml
+++ b/crates/gen-guest-c/Cargo.toml
@@ -17,4 +17,4 @@ heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-helpers = { path = '../test-helpers', features = ['guest-c'] }
+test-helpers = { path = '../test-helpers', default-features = false }

--- a/crates/gen-guest-c/build.rs
+++ b/crates/gen-guest-c/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    // this build script is currently only here so OUT_DIR is set for testing.
-}

--- a/crates/gen-guest-rust/Cargo.toml
+++ b/crates/gen-guest-rust/Cargo.toml
@@ -17,4 +17,5 @@ clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 wit-bindgen-guest-rust = { path = '../guest-rust' }
-test-helpers = { path = '../test-helpers', features = ['guest-rust'] }
+guest-rust-test-macro = { path = 'test-macro' }
+test-helpers = { path = '../test-helpers', default-features = false }

--- a/crates/gen-guest-rust/test-macro/Cargo.toml
+++ b/crates/gen-guest-rust/test-macro/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "guest-rust-test-macro"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+test = false
+doctest = false
+
+[dependencies]
+wit-parser = { workspace = true }
+proc-macro2 = "1.0.27"
+quote = "1.0.9"
+heck = { workspace = true }

--- a/crates/gen-guest-rust/test-macro/src/lib.rs
+++ b/crates/gen-guest-rust/test-macro/src/lib.rs
@@ -1,0 +1,119 @@
+use heck::*;
+use proc_macro::TokenStream;
+use wit_parser::*;
+
+/// This only exists for testing the codegen of the Rust macro for guests where
+/// it will generate a "dummy structure" which implements the `Exports` trait
+/// necessary to get the generated exports bindings to compile.
+#[proc_macro]
+pub fn gen_dummy_export(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    let input = input.trim_matches('"');
+    let iface = &Interface::parse_file(&input).unwrap();
+    let mut ret = quote::quote!();
+    if iface.functions.len() == 0 {
+        return ret.into();
+    }
+
+    let snake = quote::format_ident!("{}", iface.name.to_snake_case());
+    let camel = quote::format_ident!("{}", iface.name.to_upper_camel_case());
+
+    let mut methods = Vec::new();
+
+    for f in iface.functions.iter() {
+        let name = quote::format_ident!("{}", f.item_name().to_snake_case());
+        let params = f
+            .params
+            .iter()
+            .map(|(_, t)| quote_ty(true, iface, t))
+            .collect::<Vec<_>>();
+        let rets = f
+            .results
+            .iter_types()
+            .map(|t| quote_ty(false, iface, t))
+            .collect::<Vec<_>>();
+        let ret = match rets.len() {
+            0 => quote::quote!(()),
+            1 => rets[0].clone(),
+            _ => quote::quote!((#(#rets,)*)),
+        };
+        let method = quote::quote! {
+            fn #name(#(_: #params),*) -> #ret {
+                loop {}
+            }
+        };
+        match &f.kind {
+            FunctionKind::Freestanding => methods.push(method),
+        }
+    }
+    ret.extend(quote::quote! {
+        struct #camel;
+
+        impl #snake::#camel for #camel {
+            #(#methods)*
+        }
+    });
+
+    ret.into()
+}
+
+fn quote_ty(param: bool, iface: &Interface, ty: &Type) -> proc_macro2::TokenStream {
+    match *ty {
+        Type::Bool => quote::quote! { bool },
+        Type::U8 => quote::quote! { u8 },
+        Type::S8 => quote::quote! { i8 },
+        Type::U16 => quote::quote! { u16 },
+        Type::S16 => quote::quote! { i16 },
+        Type::U32 => quote::quote! { u32 },
+        Type::S32 => quote::quote! { i32 },
+        Type::U64 => quote::quote! { u64 },
+        Type::S64 => quote::quote! { i64 },
+        Type::Float32 => quote::quote! { f32 },
+        Type::Float64 => quote::quote! { f64 },
+        Type::Char => quote::quote! { char },
+        Type::String => quote::quote! { String },
+        Type::Id(id) => quote_id(param, iface, id),
+    }
+}
+
+fn quote_id(param: bool, iface: &Interface, id: TypeId) -> proc_macro2::TokenStream {
+    let ty = &iface.types[id];
+    if let Some(name) = &ty.name {
+        let name = quote::format_ident!("{}", name.to_upper_camel_case());
+        let module = quote::format_ident!("{}", iface.name.to_snake_case());
+        return quote::quote! { #module::#name };
+    }
+    match &ty.kind {
+        TypeDefKind::Type(t) => quote_ty(param, iface, t),
+        TypeDefKind::List(t) => {
+            let t = quote_ty(param, iface, t);
+            quote::quote! { Vec<#t> }
+        }
+        TypeDefKind::Flags(_) => panic!("unknown flags"),
+        TypeDefKind::Enum(_) => panic!("unknown enum"),
+        TypeDefKind::Record(_) => panic!("unknown record"),
+        TypeDefKind::Variant(_) => panic!("unknown variant"),
+        TypeDefKind::Union(_) => panic!("unknown union"),
+        TypeDefKind::Tuple(t) => {
+            let fields = t.types.iter().map(|ty| quote_ty(param, iface, ty));
+            quote::quote! { (#(#fields,)*) }
+        }
+        TypeDefKind::Option(ty) => {
+            let ty = quote_ty(param, iface, ty);
+            quote::quote! { Option<#ty> }
+        }
+        TypeDefKind::Result(r) => {
+            let ok = match &r.ok {
+                Some(t) => quote_ty(param, iface, t),
+                None => quote::quote!(()),
+            };
+            let err = match &r.err {
+                Some(t) => quote_ty(param, iface, t),
+                None => quote::quote!(()),
+            };
+            quote::quote! { Result<#ok, #err> }
+        }
+        TypeDefKind::Future(_) => todo!("unknown future"),
+        TypeDefKind::Stream(_) => todo!("unknown stream"),
+    }
+}

--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -1,30 +1,42 @@
-#![allow(dead_code, type_alias_bounds)]
+mod exports {
+    macro_rules! codegen_test {
+        ($name:ident $test:tt) => {
+            wit_bindgen_guest_rust::export!($test);
 
-#[test]
-fn ok() {}
+            guest_rust_test_macro::gen_dummy_export!($test);
 
-#[rustfmt::skip]
-mod imports {
-    test_helpers::codegen_rust_wasm_import!(
-        "*.wit"
-
-        // If you want to exclude a specific test you can include it here with
-        // gitignore glob syntax:
-        //
-        // "!wasm.wit"
-        // "!host.wit"
-        //
-        //
-        // Similarly you can also just remove the `*.wit` glob and list tests
-        // individually if you're debugging.
-    );
+            #[test]
+            fn $name() {}
+        };
+    }
+    test_helpers::codegen_tests!("*.wit");
 }
 
-#[rustfmt::skip]
-mod exports {
-    test_helpers::codegen_rust_wasm_export!(
-        "*.wit"
-    );
+mod imports {
+    macro_rules! codegen_test {
+        ($name:ident $test:tt) => {
+            wit_bindgen_guest_rust::import!($test);
+
+            #[test]
+            fn $name() {}
+        };
+    }
+    test_helpers::codegen_tests!("*.wit");
+
+    mod unchecked {
+        macro_rules! codegen_test {
+            ($name:ident $test:tt) => {
+                wit_bindgen_guest_rust::import!({
+                    paths: [$test],
+                    unchecked,
+                });
+
+                #[test]
+                fn $name() {}
+            };
+        }
+        test_helpers::codegen_tests!("*.wit");
+    }
 }
 
 mod strings {
@@ -35,6 +47,7 @@ mod strings {
         ",
     });
 
+    #[allow(dead_code)]
     fn test() {
         // Test the argument is `&str`.
         cat::foo("hello");
@@ -54,6 +67,7 @@ mod raw_strings {
         raw_strings,
     });
 
+    #[allow(dead_code)]
     fn test() {
         // Test the argument is `&[u8]`.
         cat::foo(b"hello");

--- a/crates/gen-guest-teavm-java/Cargo.toml
+++ b/crates/gen-guest-teavm-java/Cargo.toml
@@ -9,4 +9,4 @@ heck = { workspace = true, features = [ "unicode" ] }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-helpers = { path = '../test-helpers', default-features = false, features = ['guest-teavm-java'] }
+test-helpers = { path = '../test-helpers', default-features = false }

--- a/crates/gen-guest-teavm-java/build.rs
+++ b/crates/gen-guest-teavm-java/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    // this build script is currently only here so OUT_DIR is set for testing.
-}

--- a/crates/gen-host-js/Cargo.toml
+++ b/crates/gen-host-js/Cargo.toml
@@ -14,4 +14,4 @@ heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-helpers = { path = '../test-helpers', features = ['host-js'] }
+test-helpers = { path = '../test-helpers' }

--- a/crates/gen-host-js/build.rs
+++ b/crates/gen-host-js/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    // this build script is currently only here so OUT_DIR is set for testing.
-}

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -653,6 +653,11 @@ impl Generator for Js {
         let src_object = match &func.kind {
             FunctionKind::Freestanding => "this".to_string(),
         };
+        println!(
+            "{} {}",
+            func.item_name(),
+            func.item_name().to_lower_camel_case()
+        );
         self.src.js(&format!(
             "{}({}) {{\n",
             func.item_name().to_lower_camel_case(),

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -1,16 +1,13 @@
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use wit_bindgen_core::Generator;
 
 test_helpers::runtime_tests!("ts");
 
 fn execute(name: &str, wasm: &Path, ts: &Path, imports: &Path, exports: &Path) {
-    let mut dir = PathBuf::from(env!("OUT_DIR"));
-    dir.push(name);
-    drop(fs::remove_dir_all(&dir));
-    fs::create_dir_all(&dir).unwrap();
+    let dir = test_helpers::test_directory("runtime", "wasmtime-py", name);
 
     println!("OUT_DIR = {:?}", dir);
     println!("Generating bindings...");

--- a/crates/gen-host-wasmtime-py/Cargo.toml
+++ b/crates/gen-host-wasmtime-py/Cargo.toml
@@ -10,4 +10,4 @@ heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-helpers = { path = '../test-helpers', features = ['host-wasmtime-py'] }
+test-helpers = { path = '../test-helpers' }

--- a/crates/gen-host-wasmtime-py/build.rs
+++ b/crates/gen-host-wasmtime-py/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    // this build script is currently only here so OUT_DIR is set for testing.
-}

--- a/crates/gen-host-wasmtime-py/tests/runtime.rs
+++ b/crates/gen-host-wasmtime-py/tests/runtime.rs
@@ -1,16 +1,12 @@
-use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use wit_bindgen_core::Generator;
 
 test_helpers::runtime_tests!("py");
 
 fn execute(name: &str, wasm: &Path, py: &Path, imports: &Path, exports: &Path) {
-    let out_dir = PathBuf::from(env!("OUT_DIR"));
-    let dir = out_dir.join(name);
-    drop(fs::remove_dir_all(&dir));
-    fs::create_dir_all(&dir).unwrap();
+    let dir = test_helpers::test_directory("runtime", "wasmtime-py", name);
     fs::create_dir_all(&dir.join("imports")).unwrap();
     fs::create_dir_all(&dir.join("exports")).unwrap();
 
@@ -45,7 +41,7 @@ fn execute(name: &str, wasm: &Path, py: &Path, imports: &Path, exports: &Path) {
             .env("MYPYPATH", &dir)
             .arg(py)
             .arg("--cache-dir")
-            .arg(out_dir.join("mypycache").join(name)),
+            .arg(dir.parent().unwrap().join("mypycache").join(name)),
     );
 
     exec(

--- a/crates/gen-host-wasmtime-rust/Cargo.toml
+++ b/crates/gen-host-wasmtime-rust/Cargo.toml
@@ -16,7 +16,7 @@ clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-test-helpers = { path = '../test-helpers', features = ['host-wasmtime-rust'] }
+test-helpers = { path = '../test-helpers' }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wit-bindgen-host-wasmtime-rust = { workspace = true, features = ['tracing'] }

--- a/crates/gen-host-wasmtime-rust/tests/codegen.rs
+++ b/crates/gen-host-wasmtime-rust/tests/codegen.rs
@@ -1,31 +1,43 @@
-#![allow(dead_code, type_alias_bounds)]
+#![allow(dead_code)]
 
-fn main() {
-    println!("compiled successfully!")
-}
-
-#[rustfmt::skip]
 mod exports {
-    test_helpers::codegen_wasmtime_export!(
-        "*.wit"
+    macro_rules! codegen_test {
+        ($name:ident $test:tt) => {
+            wit_bindgen_host_wasmtime_rust::export!($test);
 
-        // If you want to exclude a specific test you can include it here with
-        // gitignore glob syntax:
-        //
-        // "!wasm.wit"
-        // "!host.wit"
-        //
-        //
-        // Similarly you can also just remove the `*.wit` glob and list tests
-        // individually if you're debugging.
-    );
+            #[test]
+            fn $name() {}
+        };
+    }
+    test_helpers::codegen_tests!("*.wit");
+
+    mod with_options {
+        macro_rules! codegen_test {
+            ($name:ident $test:tt) => {
+                wit_bindgen_host_wasmtime_rust::import!({
+                    paths: [$test],
+                    custom_error: true,
+                    tracing: true,
+                });
+
+                #[test]
+                fn $name() {}
+            };
+        }
+        test_helpers::codegen_tests!("*.wit");
+    }
 }
 
-#[rustfmt::skip]
 mod imports {
-    test_helpers::codegen_wasmtime_import!(
-        "*.wit"
-    );
+    macro_rules! codegen_test {
+        ($name:ident $test:tt) => {
+            wit_bindgen_host_wasmtime_rust::import!($test);
+
+            #[test]
+            fn $name() {}
+        };
+    }
+    test_helpers::codegen_tests!("*.wit");
 }
 
 mod custom_errors {

--- a/crates/host-wasmtime-rust-macro/src/lib.rs
+++ b/crates/host-wasmtime-rust-macro/src/lib.rs
@@ -62,6 +62,7 @@ mod kw {
     syn::custom_keyword!(src);
     syn::custom_keyword!(paths);
     syn::custom_keyword!(custom_error);
+    syn::custom_keyword!(tracing);
 }
 
 impl Parse for Opts {
@@ -79,6 +80,7 @@ impl Parse for Opts {
             for field in fields.into_pairs() {
                 match field.into_value() {
                     ConfigField::Interfaces(v) => interfaces = v,
+                    ConfigField::Tracing(v) => opts.tracing = v,
                     ConfigField::CustomError(v) => opts.custom_error = v,
                 }
             }
@@ -114,6 +116,7 @@ impl Parse for Opts {
 enum ConfigField {
     Interfaces(Vec<Interface>),
     CustomError(bool),
+    Tracing(bool),
 }
 
 impl Parse for ConfigField {
@@ -151,6 +154,10 @@ impl Parse for ConfigField {
             Ok(ConfigField::CustomError(
                 input.parse::<syn::LitBool>()?.value,
             ))
+        } else if l.peek(kw::tracing) {
+            input.parse::<kw::tracing>()?;
+            input.parse::<Token![:]>()?;
+            Ok(ConfigField::Tracing(input.parse::<syn::LitBool>()?.value))
         } else {
             Err(l.error())
         }

--- a/crates/test-helpers/Cargo.toml
+++ b/crates/test-helpers/Cargo.toml
@@ -1,42 +1,20 @@
 [package]
 name = "test-helpers"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version.workspace = true
 edition.workspace = true
 publish = false
 
 [lib]
-proc-macro = true
 doctest = false
 test = false
 
 [dependencies]
-backtrace = "0.3"
-heck = { workspace = true }
-ignore = "0.4"
-proc-macro2 = "1.0.27"
-quote = "1.0.9"
+test-helpers-macros = { path = 'macros' }
 wit-bindgen-core = { workspace = true }
-wit-bindgen-gen-guest-rust = { workspace = true, optional = true }
-wit-bindgen-gen-host-wasmtime-rust = { workspace = true, optional = true }
-wit-bindgen-gen-host-wasmtime-py = { workspace = true, optional = true }
-wit-bindgen-gen-host-js = { workspace = true, optional = true }
-wit-bindgen-gen-guest-c = { workspace = true, optional = true }
-wit-bindgen-gen-guest-teavm-java = { workspace = true, optional = true }
 wit-parser = { workspace = true }
-filetime = "0.2"
-
-[build-dependencies]
-wit-bindgen-gen-guest-c = { workspace = true }
-wit-bindgen-gen-guest-teavm-java = { workspace = true }
-wit-bindgen-core = { workspace = true }
-wit-component = { workspace = true }
 
 [features]
-default = ['guest-rust', 'guest-c', 'guest-teavm-java', 'host-js', 'host-wasmtime-py', 'host-wasmtime-rust']
-guest-rust = ['wit-bindgen-gen-guest-rust']
-guest-c = ['wit-bindgen-gen-guest-c']
-guest-teavm-java = ['wit-bindgen-gen-guest-teavm-java']
-host-js = ['wit-bindgen-gen-host-js']
-host-wasmtime-py = ['wit-bindgen-gen-host-wasmtime-py']
-host-wasmtime-rust = ['wit-bindgen-gen-host-wasmtime-rust']
+default = ['guest-rust', 'guest-c', 'guest-teavm-java']
+guest-rust = ['test-helpers-macros/guest-rust']
+guest-c = ['test-helpers-macros/guest-c']
+guest-teavm-java = ['test-helpers-macros/guest-teavm-java']

--- a/crates/test-helpers/macros/Cargo.toml
+++ b/crates/test-helpers/macros/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "test-helpers-macros"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+doctest = false
+test = false
+
+[dependencies]
+backtrace = "0.3"
+heck = { workspace = true }
+ignore = "0.4"
+proc-macro2 = "1.0.27"
+quote = "1.0.9"
+wit-bindgen-core = { workspace = true }
+wit-parser = { workspace = true }
+filetime = "0.2"
+
+[build-dependencies]
+wit-bindgen-gen-guest-c = { workspace = true }
+wit-bindgen-gen-guest-teavm-java = { workspace = true }
+wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }
+
+[features]
+guest-rust = []
+guest-c = []
+guest-teavm-java = []

--- a/crates/test-helpers/macros/build.rs
+++ b/crates/test-helpers/macros/build.rs
@@ -15,20 +15,20 @@ fn main() {
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .arg("--release")
-        .current_dir("../wasi_snapshot_preview1")
+        .current_dir("../../wasi_snapshot_preview1")
         .arg("--target=wasm32-unknown-unknown")
         .env("CARGO_TARGET_DIR", &out_dir)
         .env("RUSTFLAGS", "-Clink-args=--import-memory")
         .env_remove("CARGO_ENCODED_RUSTFLAGS");
     let status = cmd.status().unwrap();
     assert!(status.success());
-    println!("cargo:rerun-if-changed=../wasi_snapshot_preview1");
+    println!("cargo:rerun-if-changed=../../wasi_snapshot_preview1");
     let wasi_adapter = out_dir.join("wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm");
 
     if cfg!(feature = "guest-rust") {
         let mut cmd = Command::new("cargo");
         cmd.arg("build")
-            .current_dir("../test-rust-wasm")
+            .current_dir("../../test-rust-wasm")
             .arg("--target=wasm32-wasi")
             .env("CARGO_TARGET_DIR", &out_dir)
             .env("CARGO_PROFILE_DEV_DEBUG", "1")
@@ -78,11 +78,11 @@ fn main() {
                 println!("cargo:rerun-if-changed={}", dep);
             }
         }
-        println!("cargo:rerun-if-changed=../test-rust-wasm/Cargo.toml");
+        println!("cargo:rerun-if-changed=../../test-rust-wasm/Cargo.toml");
     }
 
     if cfg!(feature = "guest-c") {
-        for test_dir in fs::read_dir("../../tests/runtime").unwrap() {
+        for test_dir in fs::read_dir("../../../tests/runtime").unwrap() {
             let test_dir = test_dir.unwrap().path();
             let c_impl = test_dir.join("wasm.c");
             if !c_impl.exists() {
@@ -180,7 +180,7 @@ fn main() {
     }
 
     if cfg!(feature = "guest-teavm-java") {
-        for test_dir in fs::read_dir("../../tests/runtime").unwrap() {
+        for test_dir in fs::read_dir("../../../tests/runtime").unwrap() {
             let test_dir = test_dir.unwrap().path();
             let java_impl = test_dir.join("wasm.java");
             if !java_impl.exists() {
@@ -235,7 +235,7 @@ fn main() {
             fs::write(out_dir.join("pom.xml"), pom_xml(&["wit_exports.Exports"])).unwrap();
             fs::write(
                 java_dir.join("Main.java"),
-                include_bytes!("../gen-guest-teavm-java/tests/Main.java"),
+                include_bytes!("../../gen-guest-teavm-java/tests/Main.java"),
             )
             .unwrap();
 
@@ -310,7 +310,7 @@ fn mvn() -> Command {
 }
 
 fn pom_xml(classes_to_preserve: &[&str]) -> Vec<u8> {
-    let xml = include_str!("../gen-guest-teavm-java/tests/pom.xml");
+    let xml = include_str!("../../gen-guest-teavm-java/tests/pom.xml");
     let position = xml.find("<mainClass>").unwrap();
     let (before, after) = xml.split_at(position);
     let classes_to_preserve = classes_to_preserve

--- a/crates/test-helpers/macros/src/lib.rs
+++ b/crates/test-helpers/macros/src/lib.rs
@@ -1,0 +1,124 @@
+use heck::*;
+use ignore::gitignore::GitignoreBuilder;
+use proc_macro::{TokenStream, TokenTree};
+use std::env;
+
+include!(concat!(env!("OUT_DIR"), "/wasms.rs"));
+
+/// This macro is invoked with a list of string literals as arguments which are
+/// gitignore-style filters of tests to run in the `test/codegen` directory.
+///
+/// For example `codegen_tests!("foo.wit")` will run one tests and
+/// `codegen_tests!("*.wit")` will run all tests.
+///
+/// This macro then invokes a local macro called `codegen_test!` with the name
+/// of the test and the full path to the test to execute. The local
+/// `codegen_test!` macro then does what's necessary to actually run the test.
+#[proc_macro]
+pub fn codegen_tests(input: TokenStream) -> TokenStream {
+    let mut builder = GitignoreBuilder::new("tests");
+    for token in input {
+        let lit = match token {
+            TokenTree::Literal(l) => l.to_string(),
+            _ => panic!("invalid input"),
+        };
+        assert!(lit.starts_with("\""));
+        assert!(lit.ends_with("\""));
+        builder.add_line(None, &lit[1..lit.len() - 1]).unwrap();
+    }
+    let ignore = builder.build().unwrap();
+    let cwd = env::current_dir().unwrap();
+    let tests = ignore::Walk::new(cwd.join("tests/codegen"))
+        .filter_map(|d| {
+            let d = d.unwrap();
+            let path = d.path();
+            match ignore.matched(path, d.file_type().map(|d| d.is_dir()).unwrap_or(false)) {
+                ignore::Match::None => None,
+                ignore::Match::Ignore(_) => Some(d.into_path()),
+                ignore::Match::Whitelist(_) => None,
+            }
+        })
+        .map(|test| {
+            let name = test.file_stem().unwrap().to_str().unwrap();
+            let test = test.to_str().unwrap();
+            let test_name = quote::format_ident!("{}", name.to_snake_case());
+            quote::quote! {
+                codegen_test!(#test_name #test);
+            }
+        });
+    (quote::quote!(#(#tests)*)).into()
+}
+
+/// Invoked as `runtime_tests!("js")` to run a top-level `execute` function with
+/// all host tests that use the "js" extension.
+#[proc_macro]
+pub fn runtime_tests(input: TokenStream) -> TokenStream {
+    let host_extension = input.to_string();
+    let host_extension = host_extension.trim_matches('"');
+    let host_file = format!("host.{}", host_extension);
+    let mut tests = Vec::new();
+    let cwd = std::env::current_dir().unwrap();
+    for entry in std::fs::read_dir(cwd.join("tests/runtime")).unwrap() {
+        let entry = entry.unwrap().path();
+        if !entry.join(&host_file).exists() {
+            continue;
+        }
+        let name_str = entry.file_name().unwrap().to_str().unwrap();
+        for (lang, name, wasm, _component) in WASMS {
+            if *name != name_str {
+                continue;
+            }
+            let name_str = format!("{}_{}", name_str, lang);
+            let name = quote::format_ident!("{}", name_str);
+            let host_file = entry.join(&host_file).to_str().unwrap().to_string();
+            let import_wit = entry.join("imports.wit").to_str().unwrap().to_string();
+            let export_wit = entry.join("exports.wit").to_str().unwrap().to_string();
+            tests.push(quote::quote! {
+                #[test]
+                fn #name() {
+                    crate::execute(
+                        #name_str,
+                        #wasm.as_ref(),
+                        #host_file.as_ref(),
+                        #import_wit.as_ref(),
+                        #export_wit.as_ref(),
+                    )
+                }
+            });
+        }
+    }
+
+    (quote::quote!(#(#tests)*)).into()
+}
+
+#[proc_macro]
+pub fn runtime_tests_wasmtime(_input: TokenStream) -> TokenStream {
+    let mut tests = Vec::new();
+    let cwd = std::env::current_dir().unwrap();
+    for entry in std::fs::read_dir(cwd.join("tests/runtime")).unwrap() {
+        let entry = entry.unwrap().path();
+        if !entry.join("host.rs").exists() {
+            continue;
+        }
+        let name_str = entry.file_name().unwrap().to_str().unwrap();
+        for (lang, name, wasm, _component) in WASMS {
+            if *name != name_str {
+                continue;
+            }
+            let name = quote::format_ident!("{}_{}", name_str, lang);
+            let host_file = entry.join("host.rs").to_str().unwrap().to_string();
+            tests.push(quote::quote! {
+                mod #name {
+                    include!(#host_file);
+
+                    #[test]
+                    fn test() -> anyhow::Result<()> {
+                        run(#wasm)
+                    }
+                }
+            });
+        }
+    }
+
+    (quote::quote!(#(#tests)*)).into()
+}

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -12,6 +12,10 @@ wit-bindgen-guest-rust = { path = "../guest-rust" }
 [features]
 unchecked = []
 
+[lib]
+test = false
+doctest = false
+
 [[bin]]
 name = "smoke"
 test = false

--- a/tests/codegen/conventions.wit
+++ b/tests/codegen/conventions.wit
@@ -16,8 +16,8 @@ apple-pear: func()
 apple-pear-grape: func()
 garçon: func()
 hühnervögel: func()
-москва: func()
-東-京: func()
+/* москва: func() */
+/* 東-京: func() */
 garçon-hühnervögel-москва-東-京: func()
 a0: func()
 


### PR DESCRIPTION
This commit is a large refactor of how testing works in this repository for wit-bindgen and hosts/guests to simplify the flow of tests and make it easier to modify and less monolithic. Previously tons of logic was located in a `test_helpers` macro crate but now that large crate has been split up to delegate more work to each individual test. Some common functionality is still present in a `test_helpers` crate but it's more clear that the `test_helpers::codegen_test` macro is purely responsible for simply expanding a glob at compile time and delegating to a macro-per-test.

The tests of Rust & other languages are now also more uniform where everything "just invokes a macro" where Rust's macros further invoke proc-macros for the respective generators and other languages delegate to shared functionality for "generate code" then "run verification program".

Overall I'm hoping this makes the testing easier to follow and understand, and in upcoming changes for components it will make it easier to change each generator, individually, over to components ideally.