### PR TITLE
Use the "unicode" feature with heck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.2.0"
 [workspace.dependencies]
 anyhow = "1.0.65"
 bitflags = "1.3.2"
-heck = "0.4"
+heck =  { version = "0.4", features = ["unicode"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 clap = { version = "4.0.9", features = ["derive"] }
 env_logger = "0.9.1"

--- a/crates/gen-guest-teavm-java/Cargo.toml
+++ b/crates/gen-guest-teavm-java/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 wit-bindgen-core = { workspace = true }
-heck = { workspace = true, features = [ "unicode" ] }
+heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/tests/codegen/conventions.wit
+++ b/tests/codegen/conventions.wit
@@ -16,8 +16,8 @@ apple-pear: func()
 apple-pear-grape: func()
 garçon: func()
 hühnervögel: func()
-/* москва: func() */
-/* 東-京: func() */
+москва: func()
+東-京: func()
 garçon-hühnervögel-москва-東-京: func()
 a0: func()
 


### PR DESCRIPTION
Compared to v0.3, heck 0.4 turns off unicode support by default. Only the teavm crate had turned it on explicitly when it moved to 0.4 on its own first. This just turns the feature on for the workspace.

Also, uncomment some failing wit items in test cases that were broken by the roll, and exposed by a recent test harness refactor.