### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,26 +509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "enum-iterator"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,15 +575,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "fs-set-times"
@@ -684,18 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,19 +663,6 @@ dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "git2"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
 ]
 
 [[package]]
@@ -795,16 +741,6 @@ name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "ignore"
@@ -936,30 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.4+1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,15 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,12 +990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,12 +1000,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1314,12 +1205,6 @@ dependencies = [
  "once_cell",
  "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
@@ -1534,17 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,12 +1491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,39 +1522,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "url"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "7.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "enum-iterator",
- "getset",
- "git2",
- "rustversion",
- "thiserror",
- "time",
-]
 
 [[package]]
 name = "version_check"
@@ -2171,8 +2006,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
- "lazy_static",
- "vergen",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-c",
  "wit-bindgen-gen-guest-rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +595,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs-set-times"
@@ -655,6 +684,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +704,19 @@ dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -741,6 +795,16 @@ name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "ignore"
@@ -872,6 +936,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1033,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1103,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1207,6 +1316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "test-helpers-macros",
  "wit-bindgen-core",
@@ -1366,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "filetime",
@@ -1383,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "test-rust-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "futures-util",
  "wit-bindgen-guest-rust",
@@ -1416,6 +1531,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -1491,6 +1617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1654,39 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "7.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustversion",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "version_check"
@@ -2002,10 +2167,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
+ "lazy_static",
+ "vergen",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-c",
  "wit-bindgen-gen-guest-rust",
@@ -2018,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "wit-parser",
@@ -2026,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-demo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasmprinter",
  "wit-bindgen-core",
@@ -2042,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-guest-c"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2055,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-guest-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "guest-rust-test-macro",
@@ -2069,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-guest-teavm-java"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "heck",
@@ -2079,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-host-js"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "heck",
@@ -2089,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-host-wasmtime-py"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "heck",
@@ -2099,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-host-wasmtime-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2114,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-markdown"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "heck",
@@ -2124,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-gen-rust-lib"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -2132,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-guest-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "wit-bindgen-guest-rust-macro",
@@ -2140,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-guest-rust-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2150,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-host-wasmtime-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2162,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-host-wasmtime-rust-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2172,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2191,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.dependencies]
 anyhow = "1.0.65"
@@ -32,19 +32,19 @@ wasmparser = "0.92.0"
 wasm-encoder = "0.18.0"
 wat = "1.0.49"
 
-wit-bindgen-core = { path = 'crates/bindgen-core', version = '0.2.0' }
-wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', version = '0.2.0' }
-wit-bindgen-gen-guest-rust = { path = "crates/gen-guest-rust", version = "0.2.0" }
-wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', version = '0.2.0' }
-wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', version = '0.2.0' }
-wit-bindgen-gen-host-wasmtime-py = { path = 'crates/gen-host-wasmtime-py', version = '0.2.0' }
-wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', version = '0.2.0' }
-wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', version = '0.2.0' }
-wit-bindgen-gen-rust-lib = { path = 'crates/gen-rust-lib', version = '0.2.0' }
-wit-bindgen-guest-rust = { path = 'crates/guest-rust', version = '0.2.0' }
-wit-bindgen-host-wasmtime-rust = { path = 'crates/host-wasmtime-rust', version = '0.2.0' }
-wit-parser = { path = 'crates/wit-parser', version = '0.2.0' }
-wit-component = { path = 'crates/wit-component', version = '0.2.0' }
+wit-bindgen-core = { path = 'crates/bindgen-core', version = '0.3.0' }
+wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', version = '0.3.0' }
+wit-bindgen-gen-guest-rust = { path = "crates/gen-guest-rust", version = "0.3.0" }
+wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', version = '0.3.0' }
+wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', version = '0.3.0' }
+wit-bindgen-gen-host-wasmtime-py = { path = 'crates/gen-host-wasmtime-py', version = '0.3.0' }
+wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', version = '0.3.0' }
+wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', version = '0.3.0' }
+wit-bindgen-gen-rust-lib = { path = 'crates/gen-rust-lib', version = '0.3.0' }
+wit-bindgen-guest-rust = { path = 'crates/guest-rust', version = '0.3.0' }
+wit-bindgen-host-wasmtime-rust = { path = 'crates/host-wasmtime-rust', version = '0.3.0' }
+wit-parser = { path = 'crates/wit-parser', version = '0.3.0' }
+wit-component = { path = 'crates/wit-component', version = '0.3.0' }
 
 [[bin]]
 name = "wit-bindgen"
@@ -52,7 +52,8 @@ test = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+lazy_static = "1.4.0"
 wit-bindgen-core = { path = 'crates/bindgen-core' }
 wit-bindgen-gen-guest-rust = { path = 'crates/gen-guest-rust', features = ['clap'] }
 wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', features = ['clap'] }
@@ -61,3 +62,6 @@ wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', features = ['clap'] }
 wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', features = ['clap'] }
 wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['clap'] }
 wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', features = ['clap'] }
+
+[build-dependencies]
+vergen = { version = "7", default-features = false, features = [ "build", "git" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ test = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
-lazy_static = "1.4.0"
+clap = { workspace = true }
 wit-bindgen-core = { path = 'crates/bindgen-core' }
 wit-bindgen-gen-guest-rust = { path = 'crates/gen-guest-rust', features = ['clap'] }
 wit-bindgen-gen-host-wasmtime-rust = { path = 'crates/gen-host-wasmtime-rust', features = ['clap'] }
@@ -62,6 +61,3 @@ wit-bindgen-gen-host-js = { path = 'crates/gen-host-js', features = ['clap'] }
 wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', features = ['clap'] }
 wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['clap'] }
 wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', features = ['clap'] }
-
-[build-dependencies]
-vergen = { version = "7", default-features = false, features = [ "build", "git" ] }

--- a/crates/host-wasmtime-rust/Cargo.toml
+++ b/crates/host-wasmtime-rust/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 bitflags = { workspace = true }
 thiserror = "1.0"
 wasmtime = { workspace = true }
-wit-bindgen-host-wasmtime-rust-macro = { path = "../host-wasmtime-rust-macro", version = "0.2" }
+wit-bindgen-host-wasmtime-rust-macro = { path = "../host-wasmtime-rust-macro", version = "0.3.0" }
 tracing-lib = { version = "0.1.26", optional = true, package = 'tracing' }
 
 [features]


### PR DESCRIPTION
Feel like #327 is a significant feature added to wit-bindgen. In addition, we already have tag `0.2.0` out so I am bumping the version to `0.3.0`.  See #333 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>