### PR TITLE
Add support for debug printing to the wasi_snapshot_preview1 adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
  "wit-bindgen-host-wasmtime-rust",
+ "wit-bindgen-testwasi-host-wasmtime-rust",
 ]
 
 [[package]]
@@ -2241,6 +2242,15 @@ dependencies = [
  "syn",
  "wit-bindgen-core",
  "wit-bindgen-gen-host-wasmtime-rust",
+]
+
+[[package]]
+name = "wit-bindgen-testwasi-host-wasmtime-rust"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "wasmtime",
+ "wit-bindgen-host-wasmtime-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/wit-bindgen-demo",
   "crates/wit-component",
   "crates/wasi_snapshot_preview1",
+  "crates/wasi_snapshot_preview1/host-wasmtime-rust",
 ]
 resolver = "2"
 

--- a/crates/gen-host-wasmtime-rust/Cargo.toml
+++ b/crates/gen-host-wasmtime-rust/Cargo.toml
@@ -20,6 +20,7 @@ test-helpers = { path = '../test-helpers' }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wit-bindgen-host-wasmtime-rust = { workspace = true, features = ['tracing'] }
+wit-bindgen-testwasi-host-wasmtime-rust = { path = "../wasi_snapshot_preview1/host-wasmtime-rust" }
 
 tracing = { version = "0.1.26" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"]}

--- a/crates/gen-host-wasmtime-rust/tests/runtime.rs
+++ b/crates/gen-host-wasmtime-rust/tests/runtime.rs
@@ -5,6 +5,7 @@ use wasmtime::{
     component::{Component, Instance, Linker},
     Config, Engine, Store,
 };
+use wit_bindgen_testwasi_host_wasmtime_rust as testwasi;
 
 test_helpers::runtime_tests_wasmtime!();
 
@@ -20,6 +21,7 @@ fn default_config() -> Result<Config> {
 
 struct Context<I> {
     imports: I,
+    testwasi: testwasi::TestWasi,
 }
 
 fn instantiate<I: Default, T>(
@@ -36,11 +38,13 @@ fn instantiate<I: Default, T>(
 
     let mut linker = Linker::new(&engine);
     add_imports(&mut linker)?;
+    testwasi::add_to_linker(&mut linker, |cx| &mut cx.testwasi)?;
 
     let mut store = Store::new(
         &engine,
         Context {
             imports: I::default(),
+            testwasi: testwasi::TestWasi::default(),
         },
     );
     let (exports, _instance) = mk_exports(&mut store, &module, &mut linker)?;

--- a/crates/wasi_snapshot_preview1/host-wasmtime-rust/Cargo.toml
+++ b/crates/wasi_snapshot_preview1/host-wasmtime-rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wit-bindgen-testwasi-host-wasmtime-rust"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+wasmtime = { workspace = true }
+wit-bindgen-host-wasmtime-rust = { workspace = true }

--- a/crates/wasi_snapshot_preview1/host-wasmtime-rust/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/host-wasmtime-rust/src/lib.rs
@@ -1,0 +1,15 @@
+wit_bindgen_host_wasmtime_rust::export!("../testwasi.wit");
+
+pub use testwasi::add_to_linker;
+
+#[derive(Default)]
+pub struct TestWasi;
+
+impl testwasi::Testwasi for TestWasi {
+    fn log(&mut self, bytes: Vec<u8>) {
+        match std::str::from_utf8(&bytes) {
+            Ok(s) => print!("{}", s),
+            Err(_) => println!("\nbinary: {:?}", bytes),
+        }
+    }
+}

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -13,10 +13,27 @@
 //! imports will be adapted to a custom `wit-bindgen`-specific host `*.wit` file
 //! which is only suitable for `wit-bindgen` tests.
 
+#![no_std]
 #![allow(unused_variables)]
 
-use std::arch::wasm32::unreachable;
+use core::arch::wasm32::unreachable;
 use wasi::*;
+
+wit_bindgen_guest_rust::import!({ paths: ["testwasi.wit"], no_std });
+
+// Nothing in this wasm module should end up needing cabi_realloc. However, if
+// we don't define this trapping implementation of the export, we'll pull in
+// the one from wit_bindgen_guest_rust, which will pull in the libc allocator
+// and a bunch of panic related machinery from std.
+#[no_mangle]
+unsafe extern "C" fn cabi_realloc(
+    old_ptr: *mut u8,
+    old_len: usize,
+    align: usize,
+    new_len: usize,
+) -> *mut u8 {
+    unreachable()
+}
 
 #[no_mangle]
 pub extern "C" fn environ_get(environ: *mut *mut u8, environ_buf: *mut u8) -> Errno {
@@ -58,11 +75,29 @@ pub extern "C" fn clock_time_get(
 #[no_mangle]
 pub extern "C" fn fd_write(
     fd: Fd,
-    iovs_ptr: *const Ciovec,
-    iovs_len: usize,
+    mut iovs_ptr: *const Ciovec,
+    mut iovs_len: usize,
     nwritten: *mut Size,
 ) -> Errno {
-    unreachable()
+    unsafe {
+        // Advance to the first non-empty buffer.
+        while iovs_len != 0 && (*iovs_ptr).buf_len == 0 {
+            iovs_ptr = iovs_ptr.add(1);
+            iovs_len -= 1;
+        }
+        if iovs_len == 0 {
+            *nwritten = 0;
+            return ERRNO_SUCCESS;
+        }
+
+        let ptr = (*iovs_ptr).buf;
+        let len = (*iovs_ptr).buf_len;
+
+        testwasi::log(core::slice::from_raw_parts(ptr, len));
+
+        *nwritten = len;
+    }
+    ERRNO_SUCCESS
 }
 
 #[no_mangle]

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -24,7 +24,9 @@ wit_bindgen_guest_rust::import!({ paths: ["testwasi.wit"], no_std });
 // Nothing in this wasm module should end up needing cabi_realloc. However, if
 // we don't define this trapping implementation of the export, we'll pull in
 // the one from wit_bindgen_guest_rust, which will pull in the libc allocator
-// and a bunch of panic related machinery from std.
+// and a bunch of panic related machinery from std, which will use vtables
+// and therefore create a Wasm ElementSection, which will make the resulting
+// wasm unusable as an adapter module.
 #[no_mangle]
 unsafe extern "C" fn cabi_realloc(
     old_ptr: *mut u8,

--- a/crates/wasi_snapshot_preview1/testwasi.wit
+++ b/crates/wasi_snapshot_preview1/testwasi.wit
@@ -1,0 +1,1 @@
+log: func(bytes: list<u8>)

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -157,6 +157,8 @@ impl exports::Exports for Exports {
             identify_distinguishable_num(DistinguishableNum::I64(1)),
             1
         ));
+
+        println!("There is power in a union!");
     }
 
     fn add_one_integer(num: AllIntegers) -> AllIntegers {


### PR DESCRIPTION
Based on #355 

This addition to the wasi_snapshot_preview1 adapter imports a component interface consisting solely of `log: func(bytes: list<u8>)`, which all `fd_write` calls will call.

@sunfishcode helped me with some of the gymnastics required to not pull in `std` by way of the guest-rust cabi_realloc export, which would in turn put some vtables in an ElementSection in the adapter.

```
diff --git a/tests/runtime/unions/wasm.rs b/tests/runtime/unions/wasm.rs
index 38de7c9..881bfc9 100644
--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -157,6 +157,8 @@ impl exports::Exports for Exports {
             identify_distinguishable_num(DistinguishableNum::I64(1)),
             1
         ));
+
+        println!("There is power in a union!");
     }

     fn add_one_integer(num: AllIntegers) -> AllIntegers {
```

```
[phickey@pch-tower:crates/gen-host-wasmtime-rust]% cargo test -p wit-bindgen-gen-host-wasmtime-rust --test runtime -- unions_rust --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.12s
     Running tests/runtime.rs (/home/phickey/src/wit-bindgen/target/debug/deps/runtime-d5315b66d02bf15e)

running 1 test
There is power in a union!
test unions_rust::test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.31s
```