### PR TITLE
fix incorrect size args when freeing lists in Java

### DIFF
--- a/crates/gen-guest-teavm-java/src/lib.rs
+++ b/crates/gen-guest-teavm-java/src/lib.rs
@@ -888,7 +888,7 @@ struct Block {
 
 struct Cleanup {
     address: String,
-    size: usize,
+    size: String,
     align: usize,
 }
 
@@ -1429,7 +1429,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     if realloc.is_none() {
                         self.cleanup.push(Cleanup {
                             address: format!("{address}.toInt()"),
-                            size,
+                            size: format!("{size} * ({op}).length"),
                             align: size,
                         });
                     }
@@ -1530,7 +1530,7 @@ impl Bindgen for FunctionBindgen<'_> {
                 if realloc.is_none() {
                     self.cleanup.push(Cleanup {
                         address: address.clone(),
-                        size,
+                        size: format!("({op}).size() * {size}"),
                         align,
                     });
                 }


### PR DESCRIPTION
This corrects my mistake such that the size passed to `free` when freeing a list was the element size, not the total size of the list.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>