### PR TITLE
guest-c: use string include

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -1166,7 +1166,7 @@ impl Generator for C {
             self.src.c,
             "\
                 #include <stdlib.h>
-                #include <{}.h>
+                #include \"{}.h\"
 
                 // The following symbols are never called, but they are sufficient
                 // to get the custom sections in the component type object linked


### PR DESCRIPTION
Using a string include was needed for compilation with clang to work out.