### PR TITLE
Fix git dep, and fix name parsing from filename in cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ambient-authority"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,7 +66,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -156,71 +150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
-name = "cap-fs-ext"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e103ce36d217d568903ad27b14ec2238ecb5d65bad2e756a8f3c0d651506e"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3f336aa91cce16033ed3c94ac91d98956c49b420e6d6cd0dd7d0e386a57085"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix",
- "winapi-util",
- "windows-sys 0.36.1",
- "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14b9606aa9550d34651bc481443203bc014237bdb992d201d2afa62d2ec6dea"
-dependencies = [
- "ambient-authority",
- "rand",
-]
-
-[[package]]
-name = "cap-std"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d6e70b626eceac9d6fc790fe2d72cc3f2f7bc3c35f467690c54a526b0f56db"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "rustix",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a0524f7c4cff2ea547ae2b652bf7a348fd3e48f76556dc928d8b45ab2f1d50"
-dependencies = [
- "cap-primitives",
- "once_cell",
- "rustix",
- "winx",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +222,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-entity",
 ]
@@ -301,7 +230,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -321,7 +250,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -329,12 +258,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 
 [[package]]
 name = "cranelift-egraph"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-entity",
  "fxhash",
@@ -347,7 +276,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "serde",
 ]
@@ -355,7 +284,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -366,7 +295,7 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "rayon",
 ]
@@ -374,7 +303,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -384,7 +313,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -495,26 +424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,17 +516,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fs-set-times"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
-dependencies = [
- "io-lifetimes",
- "rustix",
- "windows-sys 0.36.1",
-]
 
 [[package]]
 name = "futures-core"
@@ -744,15 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,42 +683,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.36.1",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
-dependencies = [
- "libc",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
-
-[[package]]
-name = "is-terminal"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d508111813f9af3afd2f92758f77e4ed2cc9371b642112c6a48d22eb73105c5"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.36.1",
-]
 
 [[package]]
 name = "itertools"
@@ -937,12 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,7 +844,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1278,10 +1129,8 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa",
  "libc",
  "linux-raw-sys",
- "once_cell",
  "windows-sys 0.36.1",
 ]
 
@@ -1358,15 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,22 +1267,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "system-interface"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92adbaf536f5aff6986e1e62ba36cee72b1718c5153eee08b9e728ddde3f6029"
-dependencies = [
- "atty",
- "bitflags",
- "cap-fs-ext",
- "cap-std",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.36.1",
- "winx",
 ]
 
 [[package]]
@@ -1583,7 +1407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1687,46 +1510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi-cap-std-sync"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "async-trait",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "is-terminal",
- "once_cell",
- "rustix",
- "system-interface",
- "tracing",
- "wasi-common",
- "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "wasi-common"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "bitflags",
- "cap-rand",
- "cap-std",
- "io-extras",
- "rustix",
- "thiserror",
- "tracing",
- "wiggle",
- "windows-sys 0.36.1",
-]
-
-[[package]]
 name = "wasi_snapshot_preview1"
 version = "0.0.0"
 dependencies = [
@@ -1765,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1798,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cfg-if",
 ]
@@ -1806,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "anyhow",
  "base64",
@@ -1825,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1836,12 +1619,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1861,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1882,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1894,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1919,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "object",
  "once_cell",
@@ -1929,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "2.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1939,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "anyhow",
  "cc",
@@ -1965,33 +1748,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
+source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
  "wasmparser",
-]
-
-[[package]]
-name = "wasmtime-wasi"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "wasi-cap-std-sync",
- "wasi-common",
- "wasmtime",
- "wiggle",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -2012,46 +1774,7 @@ version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aab4e20c60429fbba9670a6cae0fff9520046ba0aa3e6d0b1cd2653bea14898"
 dependencies = [
- "wast 47.0.1",
-]
-
-[[package]]
-name = "wiggle"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags",
- "thiserror",
- "tracing",
- "wasmtime",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "heck",
- "proc-macro2",
- "quote",
- "shellexpand",
- "syn",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wiggle-generate",
+ "wast",
 ]
 
 [[package]]
@@ -2186,17 +1909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
-name = "winx"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b01e010390eb263a4518c8cebf86cb67469d1511c00b749a47b64c39e8054d"
-dependencies = [
- "bitflags",
- "io-lifetimes",
- "windows-sys 0.36.1",
-]
-
-[[package]]
 name = "wit-bindgen-cli"
 version = "0.3.0"
 dependencies = [
@@ -2316,7 +2028,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasmtime",
- "wasmtime-wasi",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
  "wit-bindgen-host-wasmtime-rust",
@@ -2425,17 +2136,6 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-xid",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#5a4adde837dd15141b435775a4532bfbfe7f4963"
-dependencies = [
- "anyhow",
- "log",
- "thiserror",
- "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,8 @@ pulldown-cmark = { version = "0.8", default-features = false }
 clap = { version = "4.0.9", features = ["derive"] }
 env_logger = "0.9.1"
 
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" , features = ["component-model"] }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
-wasmtime-environ = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", features = ["component-model"] }
+wasmtime-environ = { git = "https://github.com/bytecodealliance/wasmtime" }
 wasmprinter = "0.2.41"
 wasmparser = "0.92.0"
 wasm-encoder = "0.18.0"

--- a/crates/gen-host-wasmtime-rust/Cargo.toml
+++ b/crates/gen-host-wasmtime-rust/Cargo.toml
@@ -19,7 +19,6 @@ clap = { workspace = true, optional = true }
 anyhow = { workspace = true }
 test-helpers = { path = '../test-helpers' }
 wasmtime = { workspace = true }
-wasmtime-wasi = { workspace = true }
 wit-bindgen-host-wasmtime-rust = { workspace = true, features = ['tracing'] }
 
 tokio = { version = "1", features = ["full"] }

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -137,11 +137,18 @@ fn parse_named_interface(s: &str) -> Result<Interface> {
     let (name, path) = match parts.next() {
         Some(path) => (name_or_path, path),
         None => {
+            // Take only the name *before* the first '.' in the filename.
+            // Unfortunately, file_stem gives the name before the final '.' in
+            // the filename, but we need this to get the correct name out of a
+            // `*.wit.md` file.
+            // TODO: this can be replaced with `Path::file_prefix()` once that
+            // method is stabilized in std.
             let name = Path::new(name_or_path)
-                .file_stem()
+                .file_name()
                 .unwrap()
                 .to_str()
                 .unwrap();
+            let name = name.split('.').next().unwrap();
             (name, name_or_path)
         }
     };


### PR DESCRIPTION
* Drop branch = "main" from wasmtime git dep: This is implied since main is the default branch, and means that in other places that depend on the default branch, the wasmtime brought in by these crates is not the same dependency.
* Drop the dep on wasmtime-wasi altogether, it is not used.
* Fix parsing of name from filename in cli, to handle `*.wit.md` files correctly.