### PR TITLE
Implement case-insensitive kebab-case comparison

### DIFF
--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -719,6 +719,7 @@ fn test_tokenizer() {
     assert_eq!(collect("APPLE-pear-GRAPE").unwrap(), vec![Token::Id]);
     assert_eq!(collect("ENOENT").unwrap(), vec![Token::Id]);
     assert_eq!(collect("is-XML").unwrap(), vec![Token::Id]);
+    assert_eq!(collect("XML-http-request").unwrap(), vec![Token::Id]);
 
     assert_eq!(collect("func").unwrap(), vec![Token::Func]);
     assert_eq!(

--- a/crates/wit-parser/src/kebab_namespace.rs
+++ b/crates/wit-parser/src/kebab_namespace.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::ops::Index;
+
+/// A namespace for Wit's kebab-case identifiers.
+///
+/// Wit's kebab-case identifier syntax is defined as:
+///
+/// ```ebnf
+/// name           ::= <word>
+///                  | <name>-<word>
+/// word           ::= [a-z][0-9a-z]*
+///                  | [A-Z][0-9A-Z]*
+/// ```
+///
+/// It allows segments between dashes to either be all lowercase, which is the
+/// common case, or all uppercase, indicating an acryonym. This means that Wit
+/// kebab-case namespaces must be compared case-insensitively when new names
+/// are added, but must also be case-preserving, as the different cases are
+/// sometimes significant for consumers such as bindings generators.
+///
+/// This struct wraps and acts like a `HashMap<String, V>`, adding this
+/// case-insensitive and case-preserving behavior.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KebabNamespace<V: Clone + PartialEq + Hash> {
+    /// Map holding lowercased names as keys, and pairs of original name
+    /// and value as the values.
+    map: HashMap<String, KebabNamed<V>>,
+}
+
+/// A struct holding a value of type `V` and its name.
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct KebabNamed<V: Clone + PartialEq + Hash> {
+    pub name: String,
+    pub value: V,
+}
+
+impl<V: Clone + PartialEq + Hash> KebabNamespace<V> {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Insert a value `v` into the map with name `k`.
+    ///
+    /// The insertion is done case-insensitively, so if any existing value has
+    /// a name which case-insensitively matches `k`, return it.
+    pub fn insert(&mut self, k: String, v: V) -> Option<KebabNamed<V>> {
+        // When inserting, compare keys case-insensitively.
+        self.map
+            .insert(k.to_lowercase(), KebabNamed { name: k, value: v })
+    }
+
+    /// Get the value with name `k`.
+    pub fn get(&self, k: &str) -> Option<&V> {
+        self.map.get(&k.to_lowercase()).map(|named| {
+            assert_eq!(k, named.name);
+            &named.value
+        })
+    }
+
+    /// Return an iterator over the names and values.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &V)> {
+        // Discard `entry.0`, which is the lower-cased name string, as users
+        // iterating over the namespace always want the original name.
+        self.map.iter().map(|entry| (&entry.1.name, &entry.1.value))
+    }
+}
+
+impl<V: Clone + PartialEq + Hash> Default for KebabNamespace<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: Clone + PartialEq + Hash> Index<&str> for KebabNamespace<V> {
+    type Output = V;
+
+    fn index(&self, i: &str) -> &V {
+        let named = self.map.index(&i.to_lowercase());
+        assert_eq!(i, named.name);
+        &named.value
+    }
+}

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -4,14 +4,17 @@ use id_arena::{Arena, Id};
 use indexmap::IndexMap;
 use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
 pub mod abi;
 mod ast;
+mod kebab_namespace;
 mod sizealign;
 pub use sizealign::*;
+
+pub use kebab_namespace::{KebabNamed, KebabNamespace};
 
 /// Checks if the given string is a legal identifier in wit.
 pub fn validate_id(s: &str) -> Result<()> {
@@ -76,7 +79,7 @@ pub struct Interface {
     pub name: String,
     pub docs: Docs,
     pub types: Arena<TypeDef>,
-    pub type_lookup: HashMap<String, TypeId>,
+    pub type_lookup: KebabNamespace<TypeId>,
     pub functions: Vec<Function>,
     pub globals: Vec<Global>,
 }

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-args.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-args.wit
@@ -1,0 +1,5 @@
+// parse-fail
+
+interface foo {
+  foo: func(purple: u32, purple: u32) -> u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-args.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-args.wit.result
@@ -1,0 +1,1 @@
+"purple" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-results.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-results.wit
@@ -1,0 +1,5 @@
+// parse-fail
+
+interface foo {
+  foo: func() -> (purple: u32, purple: u32)
+}

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-results.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-results.wit.result
@@ -1,0 +1,1 @@
+"purple" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-args.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-args.wit
@@ -1,0 +1,5 @@
+// parse-fail
+
+interface foo {
+  foo: func(purple: u32, PURPLE: u32) -> u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-args.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-args.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-enum.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-enum.wit
@@ -1,0 +1,8 @@
+// parse-fail
+
+interface foo {
+  variant thing {
+      purple(u32),
+      PURPLE(u32),
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-enum.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-enum.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-flags.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-flags.wit
@@ -1,0 +1,8 @@
+// parse-fail
+
+interface foo {
+  variant thing {
+      purple(u32),
+      PURPLE(u32),
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-flags.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-flags.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-func.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-func.wit
@@ -1,0 +1,6 @@
+// parse-fail
+
+interface foo {
+  foo: func() -> u32
+  FOO: func() -> u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-func.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-func.wit.result
@@ -1,0 +1,5 @@
+"FOO" conflicts with earlier name "foo"
+     --> tests/ui/parse-fail/kebab-case-collision-func.wit:5:3
+      |
+    5 |   FOO: func() -> u32
+      |   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-record.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-record.wit
@@ -1,0 +1,8 @@
+// parse-fail
+
+interface foo {
+  record thing {
+      purple: u32,
+      PURPLE: u32,
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-record.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-record.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-results.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-results.wit
@@ -1,0 +1,5 @@
+// parse-fail
+
+interface foo {
+  foo: func() -> (purple: u32, PURPLE: u32)
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-results.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-results.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-type.wit
@@ -1,0 +1,6 @@
+// parse-fail
+
+interface foo {
+  type purple = u32
+  type PURPLE = u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-type.wit.result
@@ -1,0 +1,5 @@
+"PURPLE" conflicts with earlier name "purple"
+     --> tests/ui/parse-fail/kebab-case-collision-type.wit:5:8
+      |
+    5 |   type PURPLE = u32
+      |        ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-variant.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-variant.wit
@@ -1,0 +1,8 @@
+// parse-fail
+
+interface foo {
+  variant thing {
+      purple(u32),
+      PURPLE(u32),
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-variant.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-case-collision-variant.wit.result
@@ -1,0 +1,1 @@
+"PURPLE" conflicts with earlier name "purple"

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-invalid.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-invalid.wit
@@ -1,0 +1,5 @@
+// parse-fail
+
+interface foo {
+  Foo: func() -> u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-invalid.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-invalid.wit.result
@@ -1,0 +1,5 @@
+invalid character in identifier 'o'
+     --> tests/ui/parse-fail/kebab-invalid.wit:4:3
+      |
+    4 |   Foo: func() -> u32
+      |   ^

--- a/tests/codegen/conventions.wit
+++ b/tests/codegen/conventions.wit
@@ -17,12 +17,6 @@ interface conventions {
   apple-pear-grape: func()
   a0: func()
 
-  // Comment out identifiers that collide when mapped to snake_case, for now; see
-  // https://github.com/WebAssembly/component-model/issues/118
-  //APPLE: func()
-  //APPLE-pear-GRAPE: func()
-  //apple-PEAR-grape: func()
-
   is-XML: func()
 
   %explicit: func()


### PR DESCRIPTION
Implement case-insensitive comparisons for kebab-case names as described in the component-model thread:

https://github.com/WebAssembly/component-model/issues/118

This also adds previously missing validation for duplicate names in some contexts.