### PR TITLE
Update markdown generator for world inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "heck",
  "pulldown-cmark",
  "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]

--- a/crates/gen-markdown/Cargo.toml
+++ b/crates/gen-markdown/Cargo.toml
@@ -12,3 +12,4 @@ heck = { workspace = true }
 pulldown-cmark = { workspace = true }
 clap = { workspace = true, optional = true }
 wit-bindgen-core = { workspace = true }
+wit-component = { workspace = true }

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -1,17 +1,18 @@
 use heck::*;
 use pulldown_cmark::{html, Event, LinkType, Parser, Tag};
 use std::collections::HashMap;
-use wit_bindgen_core::{wit_parser, Direction, Files, Generator, Source};
+use std::fmt::Write;
+use wit_bindgen_core::{
+    uwriteln, wit_parser, Files, InterfaceGenerator as _, Source, WorldGenerator,
+};
+use wit_component::ComponentInterfaces;
 use wit_parser::*;
 
 #[derive(Default)]
-pub struct Markdown {
+struct Markdown {
     src: Source,
     opts: Opts,
-    sizes: SizeAlign,
     hrefs: HashMap<String, String>,
-    funcs: usize,
-    types: usize,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -21,472 +22,36 @@ pub struct Opts {
 }
 
 impl Opts {
-    pub fn build(&self) -> Markdown {
-        let mut r = Markdown::new();
+    pub fn build(&self) -> Box<dyn WorldGenerator> {
+        let mut r = Markdown::default();
         r.opts = self.clone();
-        r
+        Box::new(r)
     }
 }
 
-impl Markdown {
-    pub fn new() -> Markdown {
-        Markdown::default()
+impl WorldGenerator for Markdown {
+    fn import(&mut self, name: &str, iface: &Interface, _files: &mut Files) {
+        uwriteln!(self.src, "# Import interface `{name}`\n");
+        let mut gen = self.interface(iface);
+        gen.types();
+        gen.funcs();
     }
 
-    fn print_ty(&mut self, iface: &Interface, ty: &Type, skip_name: bool) {
-        match ty {
-            Type::Bool => self.src.push_str("`bool`"),
-            Type::U8 => self.src.push_str("`u8`"),
-            Type::S8 => self.src.push_str("`s8`"),
-            Type::U16 => self.src.push_str("`u16`"),
-            Type::S16 => self.src.push_str("`s16`"),
-            Type::U32 => self.src.push_str("`u32`"),
-            Type::S32 => self.src.push_str("`s32`"),
-            Type::U64 => self.src.push_str("`u64`"),
-            Type::S64 => self.src.push_str("`s64`"),
-            Type::Float32 => self.src.push_str("`float32`"),
-            Type::Float64 => self.src.push_str("`float64`"),
-            Type::Char => self.src.push_str("`char`"),
-            Type::String => self.src.push_str("`string`"),
-            Type::Id(id) => {
-                let ty = &iface.types[*id];
-                if !skip_name {
-                    if let Some(name) = &ty.name {
-                        self.src.push_str("[`");
-                        self.src.push_str(name);
-                        self.src.push_str("`](#");
-                        self.src.push_str(&name.to_snake_case());
-                        self.src.push_str(")");
-                        return;
-                    }
-                }
-                match &ty.kind {
-                    TypeDefKind::Type(t) => self.print_ty(iface, t, false),
-                    TypeDefKind::Tuple(t) => {
-                        self.src.push_str("(");
-                        for (i, t) in t.types.iter().enumerate() {
-                            if i > 0 {
-                                self.src.push_str(", ");
-                            }
-                            self.print_ty(iface, t, false);
-                        }
-                        self.src.push_str(")");
-                    }
-                    TypeDefKind::Record(_)
-                    | TypeDefKind::Flags(_)
-                    | TypeDefKind::Enum(_)
-                    | TypeDefKind::Variant(_)
-                    | TypeDefKind::Union(_) => {
-                        unreachable!()
-                    }
-                    TypeDefKind::Option(t) => {
-                        self.src.push_str("option<");
-                        self.print_ty(iface, t, false);
-                        self.src.push_str(">");
-                    }
-                    TypeDefKind::Result(r) => match (r.ok, r.err) {
-                        (Some(ok), Some(err)) => {
-                            self.src.push_str("result<");
-                            self.print_ty(iface, &ok, false);
-                            self.src.push_str(", ");
-                            self.print_ty(iface, &err, false);
-                            self.src.push_str(">");
-                        }
-                        (None, Some(err)) => {
-                            self.src.push_str("result<_, ");
-                            self.print_ty(iface, &err, false);
-                            self.src.push_str(">");
-                        }
-                        (Some(ok), None) => {
-                            self.src.push_str("result<");
-                            self.print_ty(iface, &ok, false);
-                            self.src.push_str(">");
-                        }
-                        (None, None) => {
-                            self.src.push_str("result");
-                        }
-                    },
-                    TypeDefKind::List(t) => {
-                        self.src.push_str("list<");
-                        self.print_ty(iface, t, false);
-                        self.src.push_str(">");
-                    }
-                    TypeDefKind::Future(t) => match t {
-                        Some(t) => {
-                            self.src.push_str("future<");
-                            self.print_ty(iface, t, false);
-                            self.src.push_str(">");
-                        }
-                        None => {
-                            self.src.push_str("future");
-                        }
-                    },
-                    TypeDefKind::Stream(s) => match (s.element, s.end) {
-                        (Some(element), Some(end)) => {
-                            self.src.push_str("stream<");
-                            self.print_ty(iface, &element, false);
-                            self.src.push_str(", ");
-                            self.print_ty(iface, &end, false);
-                            self.src.push_str(">");
-                        }
-                        (None, Some(end)) => {
-                            self.src.push_str("stream<_, ");
-                            self.print_ty(iface, &end, false);
-                            self.src.push_str(">");
-                        }
-                        (Some(element), None) => {
-                            self.src.push_str("stream<");
-                            self.print_ty(iface, &element, false);
-                            self.src.push_str(">");
-                        }
-                        (None, None) => {
-                            self.src.push_str("stream");
-                        }
-                    },
-                }
-            }
-        }
+    fn export(&mut self, name: &str, iface: &Interface, _files: &mut Files) {
+        uwriteln!(self.src, "# Export interface `{name}`\n");
+        let mut gen = self.interface(iface);
+        gen.types();
+        gen.funcs();
     }
 
-    fn docs(&mut self, docs: &Docs) {
-        let docs = match &docs.contents {
-            Some(docs) => docs,
-            None => return,
-        };
-        for line in docs.lines() {
-            self.src.push_str(line.trim());
-            self.src.push_str("\n");
-        }
+    fn export_default(&mut self, name: &str, iface: &Interface, _files: &mut Files) {
+        uwriteln!(self.src, "# Default exported interface of `{name}`\n");
+        let mut gen = self.interface(iface);
+        gen.types();
+        gen.funcs();
     }
 
-    fn print_type_header(&mut self, name: &str) {
-        if self.types == 0 {
-            self.src.push_str("# Types\n\n");
-        }
-        self.types += 1;
-        self.src.push_str(&format!(
-            "## <a href=\"#{}\" name=\"{0}\"></a> `{}`: ",
-            name.to_snake_case(),
-            name,
-        ));
-        self.hrefs
-            .insert(name.to_string(), format!("#{}", name.to_snake_case()));
-    }
-
-    fn print_type_info(&mut self, ty: TypeId, docs: &Docs) {
-        self.docs(docs);
-        self.src.push_str("\n");
-        self.src
-            .push_str(&format!("Size: {}, ", self.sizes.size(&Type::Id(ty))));
-        self.src
-            .push_str(&format!("Alignment: {}\n", self.sizes.align(&Type::Id(ty))));
-    }
-}
-
-impl Generator for Markdown {
-    fn preprocess_one(&mut self, iface: &Interface, _dir: Direction) {
-        self.sizes.fill(iface);
-    }
-
-    fn type_record(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        record: &Record,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("record\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Record Fields\n\n");
-        for field in record.fields.iter() {
-            self.src.push_str(&format!(
-                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
-                r = name.to_snake_case(),
-                f = field.name.to_snake_case(),
-                name = field.name,
-            ));
-            self.hrefs.insert(
-                format!("{}::{}", name, field.name),
-                format!("#{}.{}", name.to_snake_case(), field.name.to_snake_case()),
-            );
-            self.print_ty(iface, &field.ty, false);
-            self.src.indent(1);
-            self.src.push_str("\n\n");
-            self.docs(&field.docs);
-            self.src.deindent(1);
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_tuple(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        tuple: &Tuple,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("tuple\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Tuple Fields\n\n");
-        for (i, ty) in tuple.types.iter().enumerate() {
-            self.src.push_str(&format!(
-                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
-                r = name.to_snake_case(),
-                f = i,
-                name = i,
-            ));
-            self.hrefs.insert(
-                format!("{}::{}", name, i),
-                format!("#{}.{}", name.to_snake_case(), i),
-            );
-            self.print_ty(iface, ty, false);
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_flags(
-        &mut self,
-        _iface: &Interface,
-        id: TypeId,
-        name: &str,
-        flags: &Flags,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("record\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Record Fields\n\n");
-        for (i, flag) in flags.flags.iter().enumerate() {
-            self.src.push_str(&format!(
-                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
-                r = name.to_snake_case(),
-                f = flag.name.to_snake_case(),
-                name = flag.name,
-            ));
-            self.hrefs.insert(
-                format!("{}::{}", name, flag.name),
-                format!("#{}.{}", name.to_snake_case(), flag.name.to_snake_case()),
-            );
-            self.src.indent(1);
-            self.src.push_str("\n\n");
-            self.docs(&flag.docs);
-            self.src.deindent(1);
-            self.src.push_str(&format!("Bit: {}\n", i));
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_variant(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        variant: &Variant,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("variant\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Variant Cases\n\n");
-        for case in variant.cases.iter() {
-            self.src.push_str(&format!(
-                "- <a href=\"{v}.{c}\" name=\"{v}.{c}\"></a> [`{name}`](#{v}.{c})",
-                v = name.to_snake_case(),
-                c = case.name.to_snake_case(),
-                name = case.name,
-            ));
-            self.hrefs.insert(
-                format!("{}::{}", name, case.name),
-                format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
-            );
-            if let Some(ty) = &case.ty {
-                self.src.push_str(": ");
-                self.print_ty(iface, ty, false);
-            }
-            self.src.indent(1);
-            self.src.push_str("\n\n");
-            self.docs(&case.docs);
-            self.src.deindent(1);
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_union(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        union: &Union,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("union\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Union Cases\n\n");
-        let snake = name.to_snake_case();
-        for (i, case) in union.cases.iter().enumerate() {
-            self.src.push_str(&format!(
-                "- <a href=\"{snake}.{i}\" name=\"{snake}.{i}\"></a> [`{i}`](#{snake}.{i})",
-            ));
-            self.hrefs
-                .insert(format!("{name}::{i}"), format!("#{snake}.{i}"));
-            self.src.push_str(": ");
-            self.print_ty(iface, &case.ty, false);
-            self.src.indent(1);
-            self.src.push_str("\n\n");
-            self.docs(&case.docs);
-            self.src.deindent(1);
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_enum(&mut self, _iface: &Interface, id: TypeId, name: &str, enum_: &Enum, docs: &Docs) {
-        self.print_type_header(name);
-        self.src.push_str("enum\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n### Enum Cases\n\n");
-        for case in enum_.cases.iter() {
-            self.src.push_str(&format!(
-                "- <a href=\"{v}.{c}\" name=\"{v}.{c}\"></a> [`{name}`](#{v}.{c})",
-                v = name.to_snake_case(),
-                c = case.name.to_snake_case(),
-                name = case.name,
-            ));
-            self.hrefs.insert(
-                format!("{}::{}", name, case.name),
-                format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
-            );
-            self.src.indent(1);
-            self.src.push_str("\n\n");
-            self.docs(&case.docs);
-            self.src.deindent(1);
-            self.src.push_str("\n");
-        }
-    }
-
-    fn type_option(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        payload: &Type,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        self.src.push_str("option<");
-        self.print_ty(iface, payload, false);
-        self.src.push_str(">");
-        self.print_type_info(id, docs);
-    }
-
-    fn type_result(
-        &mut self,
-        iface: &Interface,
-        id: TypeId,
-        name: &str,
-        result: &Result_,
-        docs: &Docs,
-    ) {
-        self.print_type_header(name);
-        match (result.ok, result.err) {
-            (Some(ok), Some(err)) => {
-                self.src.push_str("result<");
-                self.print_ty(iface, &ok, false);
-                self.src.push_str(", ");
-                self.print_ty(iface, &err, false);
-                self.src.push_str(">");
-            }
-            (None, Some(err)) => {
-                self.src.push_str("result<_, ");
-                self.print_ty(iface, &err, false);
-                self.src.push_str(">");
-            }
-            (Some(ok), None) => {
-                self.src.push_str("result<");
-                self.print_ty(iface, &ok, false);
-                self.src.push_str(">");
-            }
-            (None, None) => {
-                self.src.push_str("result");
-            }
-        }
-        self.print_type_info(id, docs);
-    }
-
-    fn type_alias(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
-        self.print_type_header(name);
-        self.print_ty(iface, ty, true);
-        self.src.push_str("\n\n");
-        self.print_type_info(id, docs);
-        self.src.push_str("\n");
-    }
-
-    fn type_list(&mut self, iface: &Interface, id: TypeId, name: &str, _ty: &Type, docs: &Docs) {
-        self.type_alias(iface, id, name, &Type::Id(id), docs);
-    }
-
-    fn type_builtin(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
-        self.type_alias(iface, id, name, ty, docs)
-    }
-
-    fn import(&mut self, iface: &Interface, func: &Function) {
-        if self.funcs == 0 {
-            self.src.push_str("# Functions\n\n");
-        }
-        self.funcs += 1;
-
-        self.src.push_str("----\n\n");
-        self.src.push_str(&format!(
-            "#### <a href=\"#{0}\" name=\"{0}\"></a> `",
-            func.name.to_snake_case()
-        ));
-        self.hrefs
-            .insert(func.name.clone(), format!("#{}", func.name.to_snake_case()));
-        self.src.push_str(&func.name);
-        self.src.push_str("` ");
-        self.src.push_str("\n\n");
-        self.docs(&func.docs);
-
-        if func.params.len() > 0 {
-            self.src.push_str("##### Params\n\n");
-            for (name, ty) in func.params.iter() {
-                self.src.push_str(&format!(
-                    "- <a href=\"#{f}.{p}\" name=\"{f}.{p}\"></a> `{}`: ",
-                    name,
-                    f = func.name.to_snake_case(),
-                    p = name.to_snake_case(),
-                ));
-                self.print_ty(iface, ty, false);
-                self.src.push_str("\n");
-            }
-        }
-
-        if func.results.len() > 0 {
-            self.src.push_str("##### Results\n\n");
-            for (i, ty) in func.results.iter_types().enumerate() {
-                self.src.push_str(&format!(
-                    "- <a href=\"#{f}.{p}{i}\" name=\"{f}.{p}{i}\"></a> `{}{i}`: ",
-                    "result",
-                    f = func.name.to_snake_case(),
-                    p = "result",
-                ));
-                self.print_ty(iface, ty, false);
-                self.src.push_str("\n");
-            }
-        }
-
-        self.src.push_str("\n");
-    }
-
-    fn export(&mut self, iface: &Interface, func: &Function) {
-        self.import(iface, func);
-    }
-
-    fn finish_one(&mut self, _iface: &Interface, files: &mut Files) {
+    fn finish(&mut self, name: &str, _interfaces: &ComponentInterfaces, files: &mut Files) {
         let parser = Parser::new(&self.src);
         let mut events = Vec::new();
         for event in parser {
@@ -504,7 +69,435 @@ impl Generator for Markdown {
         let mut html_output = String::new();
         html::push_html(&mut html_output, events.into_iter());
 
-        files.push("bindings.md", self.src.as_bytes());
-        files.push("bindings.html", html_output.as_bytes());
+        files.push(&format!("{name}.md"), self.src.as_bytes());
+        files.push(&format!("{name}.html"), html_output.as_bytes());
+    }
+}
+
+impl Markdown {
+    fn interface<'a>(&'a mut self, iface: &'a Interface) -> InterfaceGenerator<'_> {
+        let mut sizes = SizeAlign::default();
+        sizes.fill(iface);
+        InterfaceGenerator {
+            gen: self,
+            iface,
+            sizes,
+            types_header_printed: false,
+        }
+    }
+}
+
+struct InterfaceGenerator<'a> {
+    gen: &'a mut Markdown,
+    iface: &'a Interface,
+    sizes: SizeAlign,
+    types_header_printed: bool,
+}
+
+impl InterfaceGenerator<'_> {
+    fn funcs(&mut self) {
+        if self.iface.functions.is_empty() {
+            return;
+        }
+        self.push_str("## Functions\n\n");
+        for func in self.iface.functions.iter() {
+            self.push_str("----\n\n");
+            self.push_str(&format!(
+                "#### <a href=\"#{0}\" name=\"{0}\"></a> `",
+                func.name.to_snake_case()
+            ));
+            self.gen
+                .hrefs
+                .insert(func.name.clone(), format!("#{}", func.name.to_snake_case()));
+            self.push_str(&func.name);
+            self.push_str("` ");
+            self.push_str("\n\n");
+            self.docs(&func.docs);
+
+            if func.params.len() > 0 {
+                self.push_str("##### Params\n\n");
+                for (name, ty) in func.params.iter() {
+                    self.push_str(&format!(
+                        "- <a href=\"#{f}.{p}\" name=\"{f}.{p}\"></a> `{}`: ",
+                        name,
+                        f = func.name.to_snake_case(),
+                        p = name.to_snake_case(),
+                    ));
+                    self.print_ty(ty, false);
+                    self.push_str("\n");
+                }
+            }
+
+            if func.results.len() > 0 {
+                self.push_str("##### Results\n\n");
+                for (i, ty) in func.results.iter_types().enumerate() {
+                    self.push_str(&format!(
+                        "- <a href=\"#{f}.{p}{i}\" name=\"{f}.{p}{i}\"></a> `{}{i}`: ",
+                        "result",
+                        f = func.name.to_snake_case(),
+                        p = "result",
+                    ));
+                    self.print_ty(ty, false);
+                    self.push_str("\n");
+                }
+            }
+
+            self.push_str("\n");
+        }
+    }
+
+    fn push_str(&mut self, s: &str) {
+        self.gen.src.push_str(s);
+    }
+
+    fn print_ty(&mut self, ty: &Type, skip_name: bool) {
+        match ty {
+            Type::Bool => self.push_str("`bool`"),
+            Type::U8 => self.push_str("`u8`"),
+            Type::S8 => self.push_str("`s8`"),
+            Type::U16 => self.push_str("`u16`"),
+            Type::S16 => self.push_str("`s16`"),
+            Type::U32 => self.push_str("`u32`"),
+            Type::S32 => self.push_str("`s32`"),
+            Type::U64 => self.push_str("`u64`"),
+            Type::S64 => self.push_str("`s64`"),
+            Type::Float32 => self.push_str("`float32`"),
+            Type::Float64 => self.push_str("`float64`"),
+            Type::Char => self.push_str("`char`"),
+            Type::String => self.push_str("`string`"),
+            Type::Id(id) => {
+                let ty = &self.iface.types[*id];
+                if !skip_name {
+                    if let Some(name) = &ty.name {
+                        self.push_str("[`");
+                        self.push_str(name);
+                        self.push_str("`](#");
+                        self.push_str(&name.to_snake_case());
+                        self.push_str(")");
+                        return;
+                    }
+                }
+                match &ty.kind {
+                    TypeDefKind::Type(t) => self.print_ty(t, false),
+                    TypeDefKind::Tuple(t) => {
+                        self.push_str("(");
+                        for (i, t) in t.types.iter().enumerate() {
+                            if i > 0 {
+                                self.push_str(", ");
+                            }
+                            self.print_ty(t, false);
+                        }
+                        self.push_str(")");
+                    }
+                    TypeDefKind::Record(_)
+                    | TypeDefKind::Flags(_)
+                    | TypeDefKind::Enum(_)
+                    | TypeDefKind::Variant(_)
+                    | TypeDefKind::Union(_) => {
+                        unreachable!()
+                    }
+                    TypeDefKind::Option(t) => {
+                        self.push_str("option<");
+                        self.print_ty(t, false);
+                        self.push_str(">");
+                    }
+                    TypeDefKind::Result(r) => match (r.ok, r.err) {
+                        (Some(ok), Some(err)) => {
+                            self.push_str("result<");
+                            self.print_ty(&ok, false);
+                            self.push_str(", ");
+                            self.print_ty(&err, false);
+                            self.push_str(">");
+                        }
+                        (None, Some(err)) => {
+                            self.push_str("result<_, ");
+                            self.print_ty(&err, false);
+                            self.push_str(">");
+                        }
+                        (Some(ok), None) => {
+                            self.push_str("result<");
+                            self.print_ty(&ok, false);
+                            self.push_str(">");
+                        }
+                        (None, None) => {
+                            self.push_str("result");
+                        }
+                    },
+                    TypeDefKind::List(t) => {
+                        self.push_str("list<");
+                        self.print_ty(t, false);
+                        self.push_str(">");
+                    }
+                    TypeDefKind::Future(t) => match t {
+                        Some(t) => {
+                            self.push_str("future<");
+                            self.print_ty(t, false);
+                            self.push_str(">");
+                        }
+                        None => {
+                            self.push_str("future");
+                        }
+                    },
+                    TypeDefKind::Stream(s) => match (s.element, s.end) {
+                        (Some(element), Some(end)) => {
+                            self.push_str("stream<");
+                            self.print_ty(&element, false);
+                            self.push_str(", ");
+                            self.print_ty(&end, false);
+                            self.push_str(">");
+                        }
+                        (None, Some(end)) => {
+                            self.push_str("stream<_, ");
+                            self.print_ty(&end, false);
+                            self.push_str(">");
+                        }
+                        (Some(element), None) => {
+                            self.push_str("stream<");
+                            self.print_ty(&element, false);
+                            self.push_str(">");
+                        }
+                        (None, None) => {
+                            self.push_str("stream");
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    fn docs(&mut self, docs: &Docs) {
+        let docs = match &docs.contents {
+            Some(docs) => docs,
+            None => return,
+        };
+        for line in docs.lines() {
+            self.push_str(line.trim());
+            self.push_str("\n");
+        }
+    }
+
+    fn print_type_header(&mut self, name: &str) {
+        if !self.types_header_printed {
+            self.push_str("## Types\n\n");
+            self.types_header_printed = true;
+        }
+        self.push_str(&format!(
+            "## <a href=\"#{}\" name=\"{0}\"></a> `{}`: ",
+            name.to_snake_case(),
+            name,
+        ));
+        self.gen
+            .hrefs
+            .insert(name.to_string(), format!("#{}", name.to_snake_case()));
+    }
+
+    fn print_type_info(&mut self, ty: TypeId, docs: &Docs) {
+        self.docs(docs);
+        self.push_str("\n");
+        self.push_str(&format!("Size: {}, ", self.sizes.size(&Type::Id(ty))));
+        self.push_str(&format!("Alignment: {}\n", self.sizes.align(&Type::Id(ty))));
+    }
+}
+
+impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
+    fn iface(&self) -> &'a Interface {
+        self.iface
+    }
+
+    fn type_record(&mut self, id: TypeId, name: &str, record: &Record, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("record\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Record Fields\n\n");
+        for field in record.fields.iter() {
+            self.push_str(&format!(
+                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
+                r = name.to_snake_case(),
+                f = field.name.to_snake_case(),
+                name = field.name,
+            ));
+            self.gen.hrefs.insert(
+                format!("{}::{}", name, field.name),
+                format!("#{}.{}", name.to_snake_case(), field.name.to_snake_case()),
+            );
+            self.print_ty(&field.ty, false);
+            self.gen.src.indent(1);
+            self.push_str("\n\n");
+            self.docs(&field.docs);
+            self.gen.src.deindent(1);
+            self.push_str("\n");
+        }
+    }
+
+    fn type_tuple(&mut self, id: TypeId, name: &str, tuple: &Tuple, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("tuple\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Tuple Fields\n\n");
+        for (i, ty) in tuple.types.iter().enumerate() {
+            self.push_str(&format!(
+                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
+                r = name.to_snake_case(),
+                f = i,
+                name = i,
+            ));
+            self.gen.hrefs.insert(
+                format!("{}::{}", name, i),
+                format!("#{}.{}", name.to_snake_case(), i),
+            );
+            self.print_ty(ty, false);
+            self.push_str("\n");
+        }
+    }
+
+    fn type_flags(&mut self, id: TypeId, name: &str, flags: &Flags, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("record\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Record Fields\n\n");
+        for (i, flag) in flags.flags.iter().enumerate() {
+            self.push_str(&format!(
+                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
+                r = name.to_snake_case(),
+                f = flag.name.to_snake_case(),
+                name = flag.name,
+            ));
+            self.gen.hrefs.insert(
+                format!("{}::{}", name, flag.name),
+                format!("#{}.{}", name.to_snake_case(), flag.name.to_snake_case()),
+            );
+            self.gen.src.indent(1);
+            self.push_str("\n\n");
+            self.docs(&flag.docs);
+            self.gen.src.deindent(1);
+            self.push_str(&format!("Bit: {}\n", i));
+            self.push_str("\n");
+        }
+    }
+
+    fn type_variant(&mut self, id: TypeId, name: &str, variant: &Variant, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("variant\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Variant Cases\n\n");
+        for case in variant.cases.iter() {
+            self.push_str(&format!(
+                "- <a href=\"{v}.{c}\" name=\"{v}.{c}\"></a> [`{name}`](#{v}.{c})",
+                v = name.to_snake_case(),
+                c = case.name.to_snake_case(),
+                name = case.name,
+            ));
+            self.gen.hrefs.insert(
+                format!("{}::{}", name, case.name),
+                format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
+            );
+            if let Some(ty) = &case.ty {
+                self.push_str(": ");
+                self.print_ty(ty, false);
+            }
+            self.gen.src.indent(1);
+            self.push_str("\n\n");
+            self.docs(&case.docs);
+            self.gen.src.deindent(1);
+            self.push_str("\n");
+        }
+    }
+
+    fn type_union(&mut self, id: TypeId, name: &str, union: &Union, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("union\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Union Cases\n\n");
+        let snake = name.to_snake_case();
+        for (i, case) in union.cases.iter().enumerate() {
+            self.push_str(&format!(
+                "- <a href=\"{snake}.{i}\" name=\"{snake}.{i}\"></a> [`{i}`](#{snake}.{i})",
+            ));
+            self.gen
+                .hrefs
+                .insert(format!("{name}::{i}"), format!("#{snake}.{i}"));
+            self.push_str(": ");
+            self.print_ty(&case.ty, false);
+            self.gen.src.indent(1);
+            self.push_str("\n\n");
+            self.docs(&case.docs);
+            self.gen.src.deindent(1);
+            self.push_str("\n");
+        }
+    }
+
+    fn type_enum(&mut self, id: TypeId, name: &str, enum_: &Enum, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("enum\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n### Enum Cases\n\n");
+        for case in enum_.cases.iter() {
+            self.push_str(&format!(
+                "- <a href=\"{v}.{c}\" name=\"{v}.{c}\"></a> [`{name}`](#{v}.{c})",
+                v = name.to_snake_case(),
+                c = case.name.to_snake_case(),
+                name = case.name,
+            ));
+            self.gen.hrefs.insert(
+                format!("{}::{}", name, case.name),
+                format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
+            );
+            self.gen.src.indent(1);
+            self.push_str("\n\n");
+            self.docs(&case.docs);
+            self.gen.src.deindent(1);
+            self.push_str("\n");
+        }
+    }
+
+    fn type_option(&mut self, id: TypeId, name: &str, payload: &Type, docs: &Docs) {
+        self.print_type_header(name);
+        self.push_str("option<");
+        self.print_ty(payload, false);
+        self.push_str(">");
+        self.print_type_info(id, docs);
+    }
+
+    fn type_result(&mut self, id: TypeId, name: &str, result: &Result_, docs: &Docs) {
+        self.print_type_header(name);
+        match (result.ok, result.err) {
+            (Some(ok), Some(err)) => {
+                self.push_str("result<");
+                self.print_ty(&ok, false);
+                self.push_str(", ");
+                self.print_ty(&err, false);
+                self.push_str(">");
+            }
+            (None, Some(err)) => {
+                self.push_str("result<_, ");
+                self.print_ty(&err, false);
+                self.push_str(">");
+            }
+            (Some(ok), None) => {
+                self.push_str("result<");
+                self.print_ty(&ok, false);
+                self.push_str(">");
+            }
+            (None, None) => {
+                self.push_str("result");
+            }
+        }
+        self.print_type_info(id, docs);
+    }
+
+    fn type_alias(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.print_type_header(name);
+        self.print_ty(ty, true);
+        self.push_str("\n\n");
+        self.print_type_info(id, docs);
+        self.push_str("\n");
+    }
+
+    fn type_list(&mut self, id: TypeId, name: &str, _ty: &Type, docs: &Docs) {
+        self.type_alias(id, name, &Type::Id(id), docs);
+    }
+
+    fn type_builtin(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.type_alias(id, name, ty, docs)
     }
 }

--- a/crates/wit-bindgen-demo/src/lib.rs
+++ b/crates/wit-bindgen-demo/src/lib.rs
@@ -125,10 +125,7 @@ fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Option
             Box::new(wit_bindgen_gen_guest_c::Opts::default().build()),
             files,
         ),
-        demo::Lang::Markdown => gen_world_legacy(
-            Box::new(wit_bindgen_gen_markdown::Opts::default().build()),
-            files,
-        ),
+        demo::Lang::Markdown => gen_world(wit_bindgen_gen_markdown::Opts::default().build(), files),
         demo::Lang::Js => gen_component(wit_bindgen_gen_host_js::Opts::default().build(), files)?,
     }
 

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -34,7 +34,7 @@ enum Category {
         #[clap(flatten)]
         common: Common,
         #[clap(flatten)]
-        world: LegacyWorld,
+        world: World,
     },
 }
 
@@ -223,7 +223,7 @@ fn main() -> Result<()> {
             gen_legacy_world(Box::new(opts.build()), world, &mut files)?;
         }
         Category::Markdown { opts, world, .. } => {
-            gen_legacy_world(Box::new(opts.build()), world, &mut files)?;
+            gen_world(opts.build(), world, &mut files)?;
         }
     }
 


### PR DESCRIPTION
This commit migrates the markdown generator from the `Generator` trait of old to the new `WorldGenerator` trait which operates on a `ComponentInterfaces` and takes a "world" as first-class input.