### PR TITLE
Update wit-bindgen-rust code generation to support cargo component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 node_modules
 ace
 *.wasm
+__pycache__

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -47,6 +47,14 @@ pub struct Opts {
     /// validation if it doesn't already have a `&str`.
     #[cfg_attr(feature = "clap", arg(long))]
     pub raw_strings: bool,
+
+    /// The prefix to use when calling functions from within the generated
+    /// `export!` macro.
+    ///
+    /// This enables the generated `export!` macro to reference code from
+    /// another mod/crate.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub macro_call_prefix: Option<String>,
 }
 
 impl Opts {
@@ -351,7 +359,11 @@ impl InterfaceGenerator<'_> {
 
         // Finish out the macro-generated export implementation.
         macro_src.push_str(" {\n");
-        uwrite!(macro_src, "{module_name}::call_{name_snake}::<$t>(");
+        uwrite!(
+            macro_src,
+            "{prefix}{module_name}::call_{name_snake}::<$t>(",
+            prefix = self.gen.opts.macro_call_prefix.as_deref().unwrap_or("")
+        );
         for param in params.iter() {
             uwrite!(macro_src, "{param},");
         }
@@ -401,7 +413,11 @@ impl InterfaceGenerator<'_> {
             macro_src.push_str(") {\n");
 
             // Finish out the macro here
-            uwrite!(macro_src, "{module_name}::post_return_{name_snake}::<$t>(");
+            uwrite!(
+                macro_src,
+                "{prefix}{module_name}::post_return_{name_snake}::<$t>(",
+                prefix = self.gen.opts.macro_call_prefix.as_deref().unwrap_or("")
+            );
             for param in params.iter() {
                 uwrite!(macro_src, "{param},");
             }

--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -152,3 +152,25 @@ mod prefix {
 
     bindings::export_baz!(Component);
 }
+
+// This is a static compilation test to check that
+// the export macro name can be overridden.
+mod macro_name {
+    wit_bindgen_guest_rust::generate!({
+        export_str["exports2"]: "
+            foo: func(x: string)
+        ",
+        name: "baz",
+        export_macro_name: "jam"
+    });
+
+    struct Component;
+
+    impl exports2::Exports2 for Component {
+        fn foo(x: String) {
+            println!("foo: {}", x);
+        }
+    }
+
+    jam!(Component);
+}

--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -120,3 +120,35 @@ mod raw_strings {
         let _t: Vec<u8> = cat::bar();
     }
 }
+
+// This is a static compilation test to ensure that
+// export bindings can go inside of another mod/crate
+// and still compile.
+mod prefix {
+    mod bindings {
+        wit_bindgen_guest_rust::generate!({
+            export_str["exports1"]: "
+                foo: func(x: string)
+                bar: func() -> string
+            ",
+            name: "baz",
+            macro_call_prefix: "bindings::"
+        });
+
+        pub(crate) use export_baz;
+    }
+
+    struct Component;
+
+    impl bindings::exports1::Exports1 for Component {
+        fn foo(x: String) {
+            println!("foo: {}", x);
+        }
+
+        fn bar() -> String {
+            "bar".to_string()
+        }
+    }
+
+    bindings::export_baz!(Component);
+}

--- a/crates/guest-rust-macro/src/lib.rs
+++ b/crates/guest-rust-macro/src/lib.rs
@@ -1,5 +1,8 @@
 use proc_macro::TokenStream;
-use syn::parse::{Parse, ParseStream, Result};
+use syn::{
+    parse::{Parse, ParseStream, Result},
+    LitStr, Token,
+};
 use wit_bindgen_gen_guest_rust::Opts;
 
 #[proc_macro]
@@ -11,12 +14,14 @@ mod kw {
     syn::custom_keyword!(unchecked);
     syn::custom_keyword!(no_std);
     syn::custom_keyword!(raw_strings);
+    syn::custom_keyword!(macro_call_prefix);
 }
 
 enum Opt {
     Unchecked,
     NoStd,
     RawStrings,
+    MacroCallPrefix(LitStr),
 }
 
 impl Parse for Opt {
@@ -31,6 +36,10 @@ impl Parse for Opt {
         } else if l.peek(kw::raw_strings) {
             input.parse::<kw::raw_strings>()?;
             Ok(Opt::RawStrings)
+        } else if l.peek(kw::macro_call_prefix) {
+            input.parse::<kw::macro_call_prefix>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::MacroCallPrefix(input.parse()?))
         } else {
             Err(l.error())
         }
@@ -43,6 +52,7 @@ impl wit_bindgen_rust_macro_shared::Configure<Opts> for Opt {
             Opt::Unchecked => opts.unchecked = true,
             Opt::NoStd => opts.no_std = true,
             Opt::RawStrings => opts.raw_strings = true,
+            Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
         }
     }
 }

--- a/crates/guest-rust-macro/src/lib.rs
+++ b/crates/guest-rust-macro/src/lib.rs
@@ -15,6 +15,7 @@ mod kw {
     syn::custom_keyword!(no_std);
     syn::custom_keyword!(raw_strings);
     syn::custom_keyword!(macro_call_prefix);
+    syn::custom_keyword!(export_macro_name);
 }
 
 enum Opt {
@@ -22,6 +23,7 @@ enum Opt {
     NoStd,
     RawStrings,
     MacroCallPrefix(LitStr),
+    ExportMacroName(LitStr),
 }
 
 impl Parse for Opt {
@@ -40,6 +42,10 @@ impl Parse for Opt {
             input.parse::<kw::macro_call_prefix>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::MacroCallPrefix(input.parse()?))
+        } else if l.peek(kw::export_macro_name) {
+            input.parse::<kw::export_macro_name>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::ExportMacroName(input.parse()?))
         } else {
             Err(l.error())
         }
@@ -53,6 +59,7 @@ impl wit_bindgen_rust_macro_shared::Configure<Opts> for Opt {
             Opt::NoStd => opts.no_std = true,
             Opt::RawStrings => opts.raw_strings = true,
             Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
+            Opt::ExportMacroName(name) => opts.export_macro_name = Some(name.value()),
         }
     }
 }


### PR DESCRIPTION
This PR adds some additional (optional) functionality that enables cargo component to generate bindings the way it wants.

* Add a "call prefix" option for the export macro, which allows the bindings to be generated in a submodule, or in the case of `cargo component`, another crate.
* Add an "export macro name" option that overrides the default name of the export macro; this allows `cargo component` to simply emit a new project with `bindings::export!(Component)`.
* Force a reference to the object file containing the component type custom section static so that it gets linked in when bindings are generated into a separate crate.