### PR TITLE
Update the guest C generator for world-based generation

### DIFF
--- a/crates/bindgen-core/src/lib.rs
+++ b/crates/bindgen-core/src/lib.rs
@@ -564,6 +564,7 @@ mod tests {
 
 pub trait WorldGenerator {
     fn generate(&mut self, name: &str, interfaces: &ComponentInterfaces, files: &mut Files) {
+        self.preprocess(name);
         for (name, import) in interfaces.imports.iter() {
             self.import(name, import, files);
         }
@@ -574,6 +575,10 @@ pub trait WorldGenerator {
             self.export_default(name, iface, files);
         }
         self.finish(name, interfaces, files);
+    }
+
+    fn preprocess(&mut self, name: &str) {
+        drop(name);
     }
 
     fn import(&mut self, name: &str, iface: &Interface, files: &mut Files);

--- a/crates/gen-guest-c/Cargo.toml
+++ b/crates/gen-guest-c/Cargo.toml
@@ -17,4 +17,4 @@ heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-helpers = { path = '../test-helpers', default-features = false }
+test-helpers = { path = '../test-helpers', default-features = false, features = ['macros'] }

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -490,7 +490,7 @@ impl Js {
 
             Intrinsic::Utf16Encode => self.src.js("
                 function utf16Encode (str, realloc, memory) {
-                    const len = str.length, ptr = realloc(0, 0, 2, len), out = new Uint16Array(memory.buffer, ptr, len);
+                    const len = str.length, ptr = realloc(0, 0, 2, len * 2), out = new Uint16Array(memory.buffer, ptr, len);
                     let i = 0;
                     if (isLE) {
                         while (i < len) out[i] = str.charCodeAt(i++);

--- a/crates/wit-bindgen-demo/src/lib.rs
+++ b/crates/wit-bindgen-demo/src/lib.rs
@@ -121,10 +121,7 @@ fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Option
             wit_bindgen_gen_host_wasmtime_py::Opts::default().build(),
             files,
         )?,
-        demo::Lang::C => gen_world_legacy(
-            Box::new(wit_bindgen_gen_guest_c::Opts::default().build()),
-            files,
-        ),
+        demo::Lang::C => gen_world(wit_bindgen_gen_guest_c::Opts::default().build(), files),
         demo::Lang::Markdown => gen_world(wit_bindgen_gen_markdown::Opts::default().build(), files),
         demo::Lang::Js => gen_component(wit_bindgen_gen_host_js::Opts::default().build(), files)?,
     }

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -83,7 +83,7 @@ enum GuestGenerator {
         #[clap(flatten)]
         common: Common,
         #[clap(flatten)]
-        world: LegacyWorld,
+        world: World,
     },
     /// Generates bindings for TeaVM-based Java guest modules.
     TeavmJava {
@@ -217,7 +217,7 @@ fn main() -> Result<()> {
             gen_world(opts.build(), world, &mut files)?;
         }
         Category::Guest(GuestGenerator::C { opts, world, .. }) => {
-            gen_legacy_world(Box::new(opts.build()), world, &mut files)?;
+            gen_world(opts.build(), world, &mut files)?;
         }
         Category::Guest(GuestGenerator::TeavmJava { opts, world, .. }) => {
             gen_legacy_world(Box::new(opts.build()), world, &mut files)?;

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -1,13 +1,12 @@
 #include <assert.h>
-#include <imports.h>
-#include <exports.h>
+#include <flavorful.h>
 #include <stdlib.h>
 #include <string.h>
 
 void exports_test_imports() {
   {
     imports_list_in_record1_t a;
-    imports_string_set(&a.a, "list_in_record1");
+    flavorful_string_set(&a.a, "list_in_record1");
     imports_f_list_in_record1(&a);
 
     imports_list_in_record2_t b;
@@ -18,7 +17,7 @@ void exports_test_imports() {
 
   {
     imports_list_in_record3_t a, b;
-    imports_string_set(&a.a, "list_in_record3 input");
+    flavorful_string_set(&a.a, "list_in_record3 input");
     imports_f_list_in_record3(&a, &b);
     assert(memcmp(b.a.ptr, "list_in_record3 output", b.a.len) == 0);
     imports_list_in_record3_free(&b);
@@ -26,7 +25,7 @@ void exports_test_imports() {
 
   {
     imports_list_in_record4_t a, b;
-    imports_string_set(&a.a, "input4");
+    flavorful_string_set(&a.a, "input4");
     imports_f_list_in_record4(&a, &b);
     assert(memcmp(b.a.ptr, "result4", b.a.len) == 0);
     imports_list_in_record4_free(&b);
@@ -37,38 +36,38 @@ void exports_test_imports() {
     imports_list_in_variant1_v2_t b;
     imports_list_in_variant1_v3_t c;
     a.is_some = true;
-    imports_string_set(&a.val, "foo");
+    flavorful_string_set(&a.val, "foo");
     b.is_err = true;
-    imports_string_set(&b.val.err, "bar");
+    flavorful_string_set(&b.val.err, "bar");
     c.tag = 0;
-    imports_string_set(&c.val.f0, "baz");
+    flavorful_string_set(&c.val.f0, "baz");
     imports_f_list_in_variant1(&a, &b, &c);
   }
 
   {
-    imports_string_t a;
+    flavorful_string_t a;
     assert(imports_f_list_in_variant2(&a));
     assert(memcmp(a.ptr, "list_in_variant2", a.len) == 0);
-    imports_string_free(&a);
+    flavorful_string_free(&a);
   }
 
   {
     imports_list_in_variant3_t a;
     a.is_some = true;
-    imports_string_set(&a.val, "input3");
-    imports_string_t b;
+    flavorful_string_set(&a.val, "input3");
+    flavorful_string_t b;
     assert(imports_f_list_in_variant3(&a, &b));
     assert(memcmp(b.ptr, "output3", b.len) == 0);
-    imports_string_free(&b);
+    flavorful_string_free(&b);
   }
 
   assert(imports_errno_result() == IMPORTS_MY_ERRNO_B);
 
   {
-    imports_string_t a;
-    imports_string_set(&a, "typedef1");
-    imports_string_t b_str;
-    imports_string_set(&b_str, "typedef2");
+    flavorful_string_t a;
+    flavorful_string_set(&a, "typedef1");
+    flavorful_string_t b_str;
+    flavorful_string_set(&b_str, "typedef2");
     imports_list_typedef3_t b;
     b.ptr = &b_str;
     b.len = 1;
@@ -133,19 +132,19 @@ void exports_f_list_in_record1(exports_list_in_record1_t *a) {
 }
 
 void exports_f_list_in_record2(exports_list_in_record2_t *ret0) {
-  exports_string_dup(&ret0->a, "list_in_record2");
+  flavorful_string_dup(&ret0->a, "list_in_record2");
 }
 
 void exports_f_list_in_record3(exports_list_in_record3_t *a, exports_list_in_record3_t *ret0) {
   assert(memcmp(a->a.ptr, "list_in_record3 input", a->a.len) == 0);
   exports_list_in_record3_free(a);
-  exports_string_dup(&ret0->a, "list_in_record3 output");
+  flavorful_string_dup(&ret0->a, "list_in_record3 output");
 }
 
 void exports_f_list_in_record4(exports_list_in_alias_t *a, exports_list_in_alias_t *ret0) {
   assert(memcmp(a->a.ptr, "input4", a->a.len) == 0);
   exports_list_in_alias_free(a);
-  exports_string_dup(&ret0->a, "result4");
+  flavorful_string_dup(&ret0->a, "result4");
 }
 
 void exports_f_list_in_variant1(exports_list_in_variant1_v1_t *a, exports_list_in_variant1_v2_t *b, exports_list_in_variant1_v3_t *c) {
@@ -162,16 +161,16 @@ void exports_f_list_in_variant1(exports_list_in_variant1_v1_t *a, exports_list_i
   exports_list_in_variant1_v3_free(c);
 }
 
-bool exports_f_list_in_variant2(exports_string_t *ret0) {
-  exports_string_dup(ret0, "list_in_variant2");
+bool exports_f_list_in_variant2(flavorful_string_t *ret0) {
+  flavorful_string_dup(ret0, "list_in_variant2");
   return true;
 }
 
-bool exports_f_list_in_variant3(exports_list_in_variant3_t *a, exports_string_t *ret0) {
+bool exports_f_list_in_variant3(exports_list_in_variant3_t *a, flavorful_string_t *ret0) {
   assert(a->is_some);
   assert(memcmp(a->val.ptr, "input3", a->val.len) == 0);
   exports_list_in_variant3_free(a);
-  exports_string_dup(ret0, "output3");
+  flavorful_string_dup(ret0, "output3");
   return true;
 }
 
@@ -191,7 +190,7 @@ void exports_list_typedefs(exports_list_typedef_t *a, exports_list_typedef3_t *c
   ret0->len = 8;
   memcpy(ret0->ptr, "typedef3", 8);
 
-  ret1->ptr = malloc(sizeof(exports_string_t));
+  ret1->ptr = malloc(sizeof(flavorful_string_t));
   ret1->len = 1;
-  exports_string_dup(&ret1->ptr[0], "typedef4");
+  flavorful_string_dup(&ret1->ptr[0], "typedef4");
 }

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -1,7 +1,6 @@
 #include <assert.h>
-#include <exports.h>
+#include <lists.h>
 #include <float.h>
-#include <imports.h>
 #include <limits.h>
 #include <math.h>
 #include <stdalign.h>
@@ -22,8 +21,8 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t a;
-    imports_string_set(&a, "");
+    lists_string_t a;
+    lists_string_set(&a, "");
     imports_empty_string_param(&a);
   }
 
@@ -34,7 +33,7 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t a;
+    lists_string_t a;
     imports_empty_string_result(&a);
     assert(a.len == 0);
   }
@@ -48,16 +47,16 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t a;
-    imports_string_set(&a, "foo");
+    lists_string_t a;
+    lists_string_set(&a, "foo");
     imports_list_param2(&a);
   }
 
   {
-    imports_string_t list[3];
-    imports_string_set(&list[0], "foo");
-    imports_string_set(&list[1], "bar");
-    imports_string_set(&list[2], "baz");
+    lists_string_t list[3];
+    lists_string_set(&list[0], "foo");
+    lists_string_set(&list[1], "bar");
+    lists_string_set(&list[2], "baz");
     imports_list_string_t a;
     a.ptr = list;
     a.len = 3;
@@ -65,11 +64,11 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t list1[2];
-    imports_string_t list2[1];
-    imports_string_set(&list1[0], "foo");
-    imports_string_set(&list1[1], "bar");
-    imports_string_set(&list2[0], "baz");
+    lists_string_t list1[2];
+    lists_string_t list2[1];
+    lists_string_set(&list1[0], "foo");
+    lists_string_set(&list1[1], "bar");
+    lists_string_set(&list2[0], "baz");
     imports_list_list_string_t a;
     a.ptr[0].len = 2;
     a.ptr[0].ptr = list1;
@@ -88,11 +87,11 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t a;
+    lists_string_t a;
     imports_list_result2(&a);
     assert(a.len == 6);
     assert(memcmp(a.ptr, "hello!", 6) == 0);
-    imports_string_free(&a);
+    lists_string_free(&a);
   }
 
   {
@@ -131,29 +130,29 @@ void exports_test_imports() {
   }
 
   {
-    imports_string_t a, b;
-    imports_string_set(&a, "x");
+    lists_string_t a, b;
+    lists_string_set(&a, "x");
     imports_string_roundtrip(&a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    imports_string_free(&b);
+    lists_string_free(&b);
 
-    imports_string_set(&a, "");
+    lists_string_set(&a, "");
     imports_string_roundtrip(&a, &b);
     assert(b.len == a.len);
-    imports_string_free(&b);
+    lists_string_free(&b);
 
-    imports_string_set(&a, "hello");
-    imports_string_roundtrip(&a, &b);
-    assert(b.len == a.len);
-    assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    imports_string_free(&b);
-
-    imports_string_set(&a, "hello ⚑ world");
+    lists_string_set(&a, "hello");
     imports_string_roundtrip(&a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    imports_string_free(&b);
+    lists_string_free(&b);
+
+    lists_string_set(&a, "hello ⚑ world");
+    imports_string_roundtrip(&a, &b);
+    assert(b.len == a.len);
+    assert(memcmp(b.ptr, a.ptr, a.len) == 0);
+    lists_string_free(&b);
   }
 
   {
@@ -233,7 +232,7 @@ void exports_empty_list_param(exports_list_u8_t *a) {
   assert(a->len == 0);
 }
 
-void exports_empty_string_param(exports_string_t *a) {
+void exports_empty_string_param(lists_string_t *a) {
   assert(a->len == 0);
 }
 
@@ -242,7 +241,7 @@ void exports_empty_list_result(exports_list_u8_t *ret0) {
   ret0->len = 0;
 }
 
-void exports_empty_string_result(exports_string_t *ret0) {
+void exports_empty_string_result(lists_string_t *ret0) {
   ret0->ptr = 0;
   ret0->len = 0;
 }
@@ -256,12 +255,12 @@ void exports_list_param(exports_list_u8_t *a) {
   exports_list_u8_free(a);
 }
 
-void exports_list_param2(exports_string_t *a) {
+void exports_list_param2(lists_string_t *a) {
   assert(a->len == 3);
   assert(a->ptr[0] == 'f');
   assert(a->ptr[1] == 'o');
   assert(a->ptr[2] == 'o');
-  exports_string_free(a);
+  lists_string_free(a);
 }
 
 void exports_list_param3(exports_list_string_t *a) {
@@ -317,22 +316,22 @@ void exports_list_result(exports_list_u8_t *ret0) {
   ret0->ptr[4] = 5;
 }
 
-void exports_list_result2(exports_string_t *ret0) {
-  exports_string_dup(ret0, "hello!");
+void exports_list_result2(lists_string_t *ret0) {
+  lists_string_dup(ret0, "hello!");
 }
 
 void exports_list_result3(exports_list_string_t *ret0) {
   ret0->len = 2;
-  ret0->ptr = malloc(2 * sizeof(exports_string_t));
+  ret0->ptr = malloc(2 * sizeof(lists_string_t));
 
-  exports_string_dup(&ret0->ptr[0], "hello,");
-  exports_string_dup(&ret0->ptr[1], "world!");
+  lists_string_dup(&ret0->ptr[0], "hello,");
+  lists_string_dup(&ret0->ptr[1], "world!");
 }
 
 void exports_list_roundtrip(exports_list_u8_t *a, exports_list_u8_t *ret0) {
   *ret0 = *a;
 }
 
-void exports_string_roundtrip(exports_string_t *a, exports_string_t *ret0) {
+void exports_string_roundtrip(lists_string_t *a, lists_string_t *ret0) {
   *ret0 = *a;
 }

--- a/tests/runtime/many_arguments/wasm.c
+++ b/tests/runtime/many_arguments/wasm.c
@@ -1,6 +1,5 @@
 #include <assert.h>
-#include <exports.h>
-#include <imports.h>
+#include <many_arguments.h>
 #include <limits.h>
 #include <math.h>
 

--- a/tests/runtime/numbers/wasm.c
+++ b/tests/runtime/numbers/wasm.c
@@ -1,8 +1,7 @@
 #include <assert.h>
-#include <exports.h>
-#include <imports.h>
 #include <limits.h>
 #include <math.h>
+#include <numbers.h>
 
 uint8_t exports_roundtrip_u8(uint8_t a) {
   return a;

--- a/tests/runtime/records/wasm.c
+++ b/tests/runtime/records/wasm.c
@@ -1,6 +1,5 @@
 #include <assert.h>
-#include <imports.h>
-#include <exports.h>
+#include <records.h>
 
 void exports_test_imports() {
   {

--- a/tests/runtime/smoke/wasm.c
+++ b/tests/runtime/smoke/wasm.c
@@ -1,5 +1,4 @@
-#include <imports.h>
-#include <exports.h>
+#include <smoke.h>
 #include <stdio.h>
 
 void exports_thunk() {

--- a/tests/runtime/strings/exports.wit
+++ b/tests/runtime/strings/exports.wit
@@ -1,4 +1,3 @@
 test-imports: func()
 
-f1: func(s: string)
-f2: func() -> string
+roundtrip: func(s: string) -> string

--- a/tests/runtime/strings/host.ts
+++ b/tests/runtime/strings/host.ts
@@ -8,19 +8,18 @@ async function run() {
   const wasm = await instantiate(loadWasm, {
     testwasi,
     imports: {
-      f1 (s: string) {
+      takeBasic(s: string) {
         assert.strictEqual(s, 'latin utf16');
       },
-      f2 () {
+      returnUnicode() {
         return '🚀🚀🚀 𠈄𓀀';
       }
     }
   });
 
   wasm.testImports();
-  assert.strictEqual(wasm.f2(), '🚀🚀🚀 𠈄𓀀');
-  wasm.f1('str');
-  assert.strictEqual(wasm.f2(), 'str');
+  assert.strictEqual(wasm.roundtrip('str'), 'str');
+  assert.strictEqual(wasm.roundtrip('🚀🚀🚀 𠈄𓀀'), '🚀🚀🚀 𠈄𓀀');
 }
 
 await run()

--- a/tests/runtime/strings/imports.wit
+++ b/tests/runtime/strings/imports.wit
@@ -1,2 +1,2 @@
-f1: func(s: string)
-f2: func() -> string
+take-basic: func(s: string)
+return-unicode: func() -> string

--- a/tests/runtime/strings/wasm_utf16.c
+++ b/tests/runtime/strings/wasm_utf16.c
@@ -1,40 +1,34 @@
 #include <assert.h>
-#include <imports.h>
-#include <exports.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 
-char16_t BASIC_STRING[] = u"latin utf16";
-// 🚀 = 0xD83D 0xDE80
-// 𠈄 = 0xD840 0xDE04
-// 𓀀 = 0xD80C 0xDC00
-char16_t UNICODE_STRING[] = { 0xD83D, 0xDE80, 0xD83D, 0xDE80, 0xD83D, 0xDE80, ' ', 0xD840, 0xDE04, 0xD80C, 0xDC00 };
 char16_t STR_BUFFER[500];
 
-void assert_str(imports_string_t* str, char16_t* expected, size_t expected_len) {
+void assert_str(strings_string_t* str, char16_t* expected) {
+  size_t expected_len = 0;
+  while (expected[expected_len])
+    expected_len++;
   assert(str->len == expected_len);
   assert(memcmp(str->ptr, expected, expected_len * 2) == 0);
 }
 
 void exports_test_imports() {
-  imports_string_t str1;
-  imports_string_set(&str1, BASIC_STRING);
-  assert_str(&str1, &BASIC_STRING[0], 11);
-  imports_f1(&str1);
-  imports_string_t str2;
-  imports_f2(&str2);
-  memcpy(&STR_BUFFER[0], str2.ptr, str2.len * 2);
-  STR_BUFFER[str2.len] = '\0';
-  assert_str(&str2, &UNICODE_STRING[0], 11);
+  strings_string_t str1;
+  strings_string_set(&str1, u"latin utf16");
+  imports_take_basic(&str1);
+
+  strings_string_t str2;
+  imports_return_unicode(&str2);
+  assert_str(&str2, u"🚀🚀🚀 𠈄𓀀");
+  strings_string_free(&str2);
 }
 
-void exports_f1(exports_string_t *str) {
+void exports_roundtrip(strings_string_t *str, strings_string_t *ret) {
   assert(str->len > 0);
-  memcpy(&STR_BUFFER[0], str->ptr, str->len * 2);
-  STR_BUFFER[str->len] = '\0';
-}
-
-void exports_f2(exports_string_t *ret) {
-  exports_string_set(ret, STR_BUFFER);
+  ret->len = str->len;
+  ret->ptr = malloc(ret->len * 2);
+  memcpy(ret->ptr, str->ptr, 2 * ret->len);
+  strings_string_free(str);
 }

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -1,6 +1,5 @@
 #include <assert.h>
-#include <imports.h>
-#include <exports.h>
+#include <variants.h>
 
 void exports_test_imports() {
   {


### PR DESCRIPTION
This commit removes the `Generator` trait impl for the C generator and adds the `WorldGenerator` trait impl to replace it. This is the equivalent of #386 for the guest C generator.

The generated C code is largely the same, except that the entire world is represented in one header file instead of per-interface header files as before. Additionally a tiny amount of "type sharing" is now done where all interfaces share the same string type (namespaced by the world name). More type sharing should come with a more first-class implementation of worlds.

There was quite a lot of code movement within the generator as I got it working again, but at the surface level very little has changed and it should largely be the same as before.