### PR TITLE
cli: default naming, default string encoding flags

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Opts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub no_helpers: bool,
     /// Set component string encoding
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::UTF8))]
+    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::default()))]
     pub string_encoding: StringEncoding,
 }
 

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Opts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub no_helpers: bool,
     /// Set component string encoding
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::UTF16))]
     pub string_encoding: StringEncoding,
 }
 

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Opts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub no_helpers: bool,
     /// Set component string encoding
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::UTF16))]
+    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::UTF8))]
     pub string_encoding: StringEncoding,
 }
 

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 use anyhow::{bail, Result};
+use std::fmt::Display;
 use std::str::FromStr;
 use wasm_encoder::CanonicalOption;
 
@@ -34,6 +35,16 @@ pub enum StringEncoding {
 impl Default for StringEncoding {
     fn default() -> Self {
         StringEncoding::UTF8
+    }
+}
+
+impl Display for StringEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StringEncoding::UTF8 => write!(f, "utf8"),
+            StringEncoding::UTF16 => write!(f, "utf16"),
+            StringEncoding::CompactUTF16 => write!(f, "compact-utf16"),
+        }
     }
 }
 

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -288,12 +288,10 @@ fn gen_world(
         None => {
             if let Some(default) = &interfaces.default {
                 &default.name
-            } else if interfaces.exports.len() > 0 {
-                &interfaces.exports.first().unwrap().1.name
-            } else if interfaces.imports.len() > 0 {
-                &interfaces.imports.first().unwrap().1.name
             } else {
-                return Err(anyhow!("no interfaces provided to generate"));
+                return Err(anyhow!(
+                    "--name flag is required unless setting the interface via --default"
+                ));
             }
         }
     };

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -126,7 +126,7 @@ struct World {
     /// The top-level name of the generated bindings, which may be used for
     /// naming modules/files/etc.
     #[clap(long, short)]
-    name: String,
+    name: Option<String>,
 }
 
 fn parse_named_interface(s: &str) -> Result<Interface> {
@@ -283,7 +283,21 @@ fn gen_world(
         exports,
         default: world.default,
     };
-    generator.generate(&world.name, &interfaces, files);
+    let name = match &world.name {
+        Some(name) => name,
+        None => {
+            if let Some(default) = &interfaces.default {
+                &default.name
+            } else if interfaces.exports.len() > 0 {
+                &interfaces.exports.first().unwrap().1.name
+            } else if interfaces.imports.len() > 0 {
+                &interfaces.imports.first().unwrap().1.name
+            } else {
+                return Err(anyhow!("no interfaces provided to generate"));
+            }
+        }
+    };
+    generator.generate(name, &interfaces, files);
     Ok(())
 }
 


### PR DESCRIPTION
Recent PRs made the `--string-encoding` and `--name` flags mandatory. This makes those optional again with defaults. `--name` defaults to the default interface name, first export name or import name. This also adds a new CLI error if no interface option is provided as well.