### PR TITLE
gen-host-js: support undefined values in lowering for nullable options

### DIFF
--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -1848,7 +1848,8 @@ impl Bindgen for FunctionBindgen<'_> {
                     self.src.js(&format!(
                         "\
                         switch (variant{tmp}) {{
-                            case null: {{
+                            case null:
+                            case undefined: {{
                                 {none}\
                                 break;
                             }}

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -36,6 +36,8 @@ async function run() {
   wasm.testImports();
   assert.deepStrictEqual(wasm.roundtripOption(1), 1);
   assert.deepStrictEqual(wasm.roundtripOption(null), null);
+  assert.deepStrictEqual(wasm.roundtripOption(undefined), null);
+  assert.deepStrictEqual(wasm.roundtripOption(), null);
   assert.deepStrictEqual(wasm.roundtripOption(2), 2);
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -36,7 +36,10 @@ async function run() {
   wasm.testImports();
   assert.deepStrictEqual(wasm.roundtripOption(1), 1);
   assert.deepStrictEqual(wasm.roundtripOption(null), null);
+  // @ts-ignore
   assert.deepStrictEqual(wasm.roundtripOption(undefined), null);
+  // @ts-ignore
+  assert.deepStrictEqual(wasm.roundtripOption(), null);
   assert.deepStrictEqual(wasm.roundtripOption(2), 2);
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -37,7 +37,6 @@ async function run() {
   assert.deepStrictEqual(wasm.roundtripOption(1), 1);
   assert.deepStrictEqual(wasm.roundtripOption(null), null);
   assert.deepStrictEqual(wasm.roundtripOption(undefined), null);
-  assert.deepStrictEqual(wasm.roundtripOption(), null);
   assert.deepStrictEqual(wasm.roundtripOption(2), 2);
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });


### PR DESCRIPTION
This makes it so that a function with optional nullable parameters can accept undefined values as a substitute.

Eg `fn(a, null)` can now be `fn(a)` for a nice optional param pattern.