### PR TITLE
gen-host-js: instance ESM output by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
 name = "wit-bindgen-gen-host-js"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "clap",
  "heck",
  "indexmap",

--- a/crates/gen-host-js/.eslintrc.js
+++ b/crates/gen-host-js/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 12,
+        "ecmaVersion": 13,
         "sourceType": "module"
     },
     "rules": {

--- a/crates/gen-host-js/Cargo.toml
+++ b/crates/gen-host-js/Cargo.toml
@@ -10,6 +10,7 @@ test = false
 
 [dependencies]
 wit-bindgen-core = { workspace = true, features = ['component-generator'] }
+anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
 wasmtime-environ = { workspace = true, features = ['component-model'] }

--- a/crates/gen-host-js/package.json
+++ b/crates/gen-host-js/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
     "@types/node": "^15.12.2",
-    "@typescript-eslint/eslint-plugin": "^4.27.0",
-    "@typescript-eslint/parser": "^4.27.0",
-    "eslint": "^7.28.0",
+    "@typescript-eslint/eslint-plugin": "^5.41.0",
+    "@typescript-eslint/parser": "^5.41.0",
+    "eslint": "^8.26.0",
     "typescript": "^4.3.2"
   }
 }

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -717,10 +717,16 @@ impl Instantiator<'_> {
                 let local_name = format!("module{}", idx.as_u32());
                 let name = format!("module{}.wasm", idx.as_u32());
                 if self.gen.opts.instantiation {
-                    uwrite!(self.src.js, "const {local_name} = compileCore(\"{name}\");\n");
+                    uwrite!(
+                        self.src.js,
+                        "const {local_name} = compileCore(\"{name}\");\n"
+                    );
                 } else {
                     let load_wasm = self.gen.intrinsic(Intrinsic::LoadWasm);
-                    uwrite!(self.src.js, "const {local_name} = {load_wasm}(new URL('./{name}', import.meta.url));\n");
+                    uwrite!(
+                        self.src.js,
+                        "const {local_name} = {load_wasm}(new URL('./{name}', import.meta.url));\n"
+                    );
                 }
             }
         }

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -711,7 +711,9 @@ impl Instantiator<'_> {
             if let GlobalInitializer::InstantiateModule(InstantiateModule::Static(idx, _)) = init {
                 // Get the compiled WebAssembly.Module objects in parallel
                 if first {
-                    self.src.js.push_str("\n");
+                    if !instantiation {
+                        self.src.js.push_str("\n");
+                    }
                     first = false;
                 }
                 let local_name = format!("module{}", idx.as_u32());

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Opts {
     pub instantiation: bool,
     /// Comma-separated list of "from-specifier=./to-specifier.js" mappings of
     /// component import specifiers to JS import specifiers.
-    #[cfg_attr(feature = "clap", arg(long = "map", conflicts_with = "instantiation"))]
+    #[cfg_attr(feature = "clap", arg(long = "map"))]
     pub map: Option<String>,
     /// Enables all compat flags: --nodejs-compat.
     #[cfg_attr(feature = "clap", arg(long = "compat"))]

--- a/crates/gen-host-js/tests/codegen.rs
+++ b/crates/gen-host-js/tests/codegen.rs
@@ -12,7 +12,7 @@ macro_rules! gen_test {
                 test_helpers::Direction::$dir,
                 |name, component, files| {
                     wit_bindgen_core::component::generate(
-                        &mut *wit_bindgen_gen_host_js::Opts::default().build(),
+                        &mut *wit_bindgen_gen_host_js::Opts::default().build().unwrap(),
                         name,
                         component,
                         files,

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -16,11 +16,10 @@ export async function loadWasm(path: string, imports: any) {
   return await WebAssembly.instantiate(m, imports);
 }
 
-export const testwasi = {
-  log(bytes: Uint8Array) {
-    stdout.write(bytes);
-  },
-  logErr(bytes: Uint8Array) {
-    stderr.write(bytes);
-  },
-};
+// Export a WASI interface directly for instance imports
+export function log (bytes: Uint8Array) {
+  stdout.write(bytes);
+}
+export function logErr (bytes: Uint8Array) {
+  stderr.write(bytes);
+}

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -10,10 +10,9 @@ import { argv, stdout, stderr } from 'node:process';
 // This function loads the module named by `path` and instantiates it with the
 // `imports` object provided. The `path` is a relative path to a wasm file
 // within the generated directory which for tests is passed as argv 2.
-export async function loadWasm(path: string, imports: any) {
+export async function loadWasm(path: string) {
   const root = argv[2];
-  const m = await WebAssembly.compile(await readFile(root + '/' + path))
-  return await WebAssembly.instantiate(m, imports);
+  return await WebAssembly.compile(await readFile(root + '/' + path))
 }
 
 // Export a WASI interface directly for instance imports

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -94,7 +94,7 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
 
 fn get_first_line_flag_comment(src: &str) -> &str {
     if src.starts_with("// Flags:") {
-        if let Some(nl_idx) = src.find(|c| c == '\n') {
+        if let Some(nl_idx) = src.find(|c| c == '\r' || c == '\n') {
             return &src[9..nl_idx];
         }
     }

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -1,9 +1,17 @@
+use clap::Parser;
 use std::env;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use wit_bindgen_gen_host_js;
 
 test_helpers::runtime_component_tests!("ts");
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(flatten)]
+    opts: wit_bindgen_gen_host_js::Opts,
+}
 
 fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     let dir = test_helpers::test_directory("runtime", "js", &format!("{name}-{lang}"));
@@ -12,8 +20,16 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     println!("OUT_DIR = {:?}", dir);
     println!("Generating bindings...");
     let mut files = Default::default();
+
+    // Generation flags taken from first line comment
+    // of the test file.
+    let src_str = fs::read_to_string(ts).unwrap();
+    let flags = get_first_line_flag_comment(&src_str);
+    let flag_vec: Vec<&str> = flags.split(" ").collect();
+    let opts = Args::try_parse_from(flag_vec).unwrap();
+
     wit_bindgen_core::component::generate(
-        &mut *wit_bindgen_gen_host_js::Opts::default().build(),
+        &mut *opts.opts.build().unwrap(),
         name,
         &wasm,
         &mut files,
@@ -39,7 +55,7 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
         format!(
             r#"
                 {{
-                    "files": ["host.ts"],
+                    "files": ["host.ts", "helpers.ts"],
                     "compilerOptions": {{
                         "module": "esnext",
                         "target": "es2020",
@@ -74,4 +90,13 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
             .env("NODE_PATH", std::env::join_paths(&path).unwrap())
             .arg(dir),
     );
+}
+
+fn get_first_line_flag_comment(src: &str) -> &str {
+    if src.starts_with("// Flags:") {
+        if let Some(nl_idx) = src.find(|c| c == '\n') {
+            return &src[9..nl_idx];
+        }
+    }
+    return "";
 }

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -93,10 +93,8 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
 }
 
 fn get_first_line_flag_comment(src: &str) -> &str {
-    if src.starts_with("// Flags:") {
-        if let Some(nl_idx) = src.find(|c| c == '\r' || c == '\n') {
-            return &src[9..nl_idx];
-        }
-    }
-    return "";
+    src.lines()
+        .next()
+        .and_then(|s| s.strip_prefix("// Flags:"))
+        .unwrap_or("")
 }

--- a/crates/wit-bindgen-demo/build.sh
+++ b/crates/wit-bindgen-demo/build.sh
@@ -13,10 +13,10 @@ cargo run --release -p wit-component --bin wit-component -- \
   target/wasm32-unknown-unknown/release/wit_bindgen_demo.wasm -o target/demo.wasm
 
 # Generate JS host bindings
-cargo run host js target/demo.wasm --out-dir static
+cargo run host js target/demo.wasm --map "console=./console.js" --out-dir static
 
 # Build JS from TypeScript and then copy in the ace editor as well.
-cp crates/wit-bindgen-demo/{index.html,main.ts} static/
+cp crates/wit-bindgen-demo/{index.html,main.ts,console.js} static/
 (cd crates/wit-bindgen-demo && npx tsc ../../static/main.ts --target es6)
 
 if [ ! -d ace ]; then

--- a/crates/wit-bindgen-demo/console.js
+++ b/crates/wit-bindgen-demo/console.js
@@ -1,0 +1,7 @@
+export function log(msg) {
+  console.log(msg);
+}
+
+export function error(msg) {
+  console.error(msg);
+}

--- a/crates/wit-bindgen-demo/demo.wit
+++ b/crates/wit-bindgen-demo/demo.wit
@@ -14,6 +14,8 @@ enum lang {
 record options {
   rust-unchecked: bool,
   wasmtime-tracing: bool,
+  js-compat: bool,
+  js-instantiation: bool,
   import: bool,
 }
 

--- a/crates/wit-bindgen-demo/index.html
+++ b/crates/wit-bindgen-demo/index.html
@@ -74,6 +74,14 @@ hello: func(who: person) -&gt; string
           </select>
 
           <div id='configure-js' class='lang-configure'>
+            &middot;
+
+            <input type="checkbox" id="js-compat" name="unchecked">
+            <label for="js-compat">Compat</label>
+            &middot;
+
+            <input type="checkbox" id="js-instantiation" name="unchecked">
+            <label for="js-instantiation">Custom Instantiation</label>
           </div>
           <div id='configure-c' class='lang-configure'>
           </div>

--- a/crates/wit-bindgen-demo/main.ts
+++ b/crates/wit-bindgen-demo/main.ts
@@ -7,6 +7,8 @@ class Editor {
   files: HTMLSelectElement
   rustUnchecked: HTMLInputElement;
   wasmtimeTracing: HTMLInputElement;
+  jsCompat: HTMLInputElement;
+  jsInstantiation: HTMLInputElement;
   generatedFiles: Record<string, string>;
   options: Options;
   rerender: number | null;
@@ -20,6 +22,8 @@ class Editor {
     this.mode = document.getElementById('mode-select') as HTMLSelectElement;
     this.files = document.getElementById('file-select') as HTMLSelectElement;
     this.rustUnchecked = document.getElementById('rust-unchecked') as HTMLInputElement;
+    this.jsCompat = document.getElementById('js-compat') as HTMLInputElement;
+    this.jsInstantiation = document.getElementById('js-instantiation') as HTMLInputElement;
     this.wasmtimeTracing = document.getElementById('wasmtime-tracing') as HTMLInputElement;
     this.outputHtml = document.getElementById('html-output') as HTMLDivElement;
 
@@ -35,6 +39,8 @@ class Editor {
     this.options = {
       rustUnchecked: false,
       wasmtimeTracing: false,
+      jsCompat: false,
+      jsInstantiation: false,
       import: false,
     };
     this.rerender = null;
@@ -58,6 +64,16 @@ class Editor {
 
     this.rustUnchecked.addEventListener('change', () => {
       this.options.rustUnchecked = this.rustUnchecked.checked;
+      this.render();
+    });
+
+    this.jsCompat.addEventListener('change', () => {
+      this.options.jsCompat = this.jsCompat.checked;
+      this.render();
+    });
+
+    this.jsInstantiation.addEventListener('change', () => {
+      this.options.jsInstantiation = this.jsInstantiation.checked;
       this.render();
     });
 

--- a/crates/wit-bindgen-demo/main.ts
+++ b/crates/wit-bindgen-demo/main.ts
@@ -1,4 +1,4 @@
-import { Demo, Options, instantiate } from './demo.js';
+import { render, Options } from './demo.js';
 
 class Editor {
   input: HTMLTextAreaElement;
@@ -8,7 +8,6 @@ class Editor {
   rustUnchecked: HTMLInputElement;
   wasmtimeTracing: HTMLInputElement;
   generatedFiles: Record<string, string>;
-  demo?: Demo;
   options: Options;
   rerender: number | null;
   inputEditor: AceAjax.Editor;
@@ -41,14 +40,7 @@ class Editor {
     this.rerender = null;
   }
 
-  async instantiate() {
-    this.demo = await instantiate(
-      async (name, imports) => {
-        const obj = await WebAssembly.instantiateStreaming(fetch(name), imports)
-        return obj.instance;
-      },
-      { console },
-    );
+  init() {
     this.installListeners();
     this.render();
   }
@@ -101,7 +93,7 @@ class Editor {
       default: return;
     }
     this.options.import = is_import;
-    const result = this.demo.render(lang, wit, this.options);
+    const result = render(lang, wit, this.options);
     if (result.tag === 'err') {
       this.outputEditor.setValue(result.val);
       this.outputEditor.clearSelection();
@@ -166,4 +158,4 @@ class Editor {
 }
 
 
-(new Editor()).instantiate()
+(new Editor()).init()

--- a/crates/wit-bindgen-demo/src/lib.rs
+++ b/crates/wit-bindgen-demo/src/lib.rs
@@ -118,7 +118,7 @@ fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Option
         )?,
         demo::Lang::C => gen_world(wit_bindgen_gen_guest_c::Opts::default().build(), files),
         demo::Lang::Markdown => gen_world(wit_bindgen_gen_markdown::Opts::default().build(), files),
-        demo::Lang::Js => gen_component(wit_bindgen_gen_host_js::Opts::default().build(), files)?,
+        demo::Lang::Js => gen_component(wit_bindgen_gen_host_js::Opts::default().build()?, files)?,
     }
 
     Ok(())

--- a/crates/wit-bindgen-demo/src/lib.rs
+++ b/crates/wit-bindgen-demo/src/lib.rs
@@ -118,7 +118,12 @@ fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Option
         )?,
         demo::Lang::C => gen_world(wit_bindgen_gen_guest_c::Opts::default().build(), files),
         demo::Lang::Markdown => gen_world(wit_bindgen_gen_markdown::Opts::default().build(), files),
-        demo::Lang::Js => gen_component(wit_bindgen_gen_host_js::Opts::default().build()?, files)?,
+        demo::Lang::Js => {
+            let mut opts = wit_bindgen_gen_host_js::Opts::default();
+            opts.instantiation = options.js_instantiation;
+            opts.compat = options.js_compat;
+            gen_component(opts.build()?, files)?
+        }
     }
 
     Ok(())

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
             gen_component(opts.build(), component, &mut files)?;
         }
         Category::Host(HostGenerator::Js { opts, component }) => {
-            gen_component(opts.build(), component, &mut files)?;
+            gen_component(opts.build()?, component, &mut files)?;
         }
         Category::Guest(GuestGenerator::Rust { opts, world, .. }) => {
             gen_world(opts.build(), world, &mut files)?;

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -1,53 +1,49 @@
-import { loadWasm, testwasi } from "./helpers.js";
-import { instantiate } from "./flavorful.js";
+// Flags: --nodejs-compat --map testwasi=./helpers.js,imports=./host.js
 
 // @ts-ignore
 import * as assert from 'assert';
 
-async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
-    imports: {
-      fListInRecord1(x) {},
-      fListInRecord2() { return { a: 'list_in_record2' }; },
-      fListInRecord3(x) {
-        assert.strictEqual(x.a, 'list_in_record3 input');
-        return { a: 'list_in_record3 output' };
-      },
-      fListInRecord4(x) {
-        assert.strictEqual(x.a, 'input4');
-        return { a: 'result4' };
-      },
-      fListInVariant1(a, b, c) {
-        assert.strictEqual(a, 'foo');
-        assert.deepStrictEqual(b, { tag: 'err', val: 'bar' });
-        assert.deepStrictEqual(c, { tag: 0, val: 'baz' });
-      },
-      fListInVariant2() { return 'list_in_variant2'; },
-      fListInVariant3(x) {
-        assert.strictEqual(x, 'input3');
-        return 'output3';
-      },
+// Imports
+export function fListInRecord1(x: any) {}
+export function fListInRecord2() { return { a: 'list_in_record2' }; }
+export function fListInRecord3(x: any) {
+  assert.strictEqual(x.a, 'list_in_record3 input');
+  return { a: 'list_in_record3 output' };
+}
+export function fListInRecord4(x: any) {
+  assert.strictEqual(x.a, 'input4');
+  return { a: 'result4' };
+}
+export function fListInVariant1(a: any, b: any, c: any) {
+  assert.strictEqual(a, 'foo');
+  assert.deepStrictEqual(b, { tag: 'err', val: 'bar' });
+  assert.deepStrictEqual(c, { tag: 0, val: 'baz' });
+}
+export function fListInVariant2() { return 'list_in_variant2'; }
+export function fListInVariant3(x: any) {
+  assert.strictEqual(x, 'input3');
+  return 'output3';
+}
+export function errnoResult() { return { tag: 'err', val: "b" }; }
+export function listTypedefs(x: any, y: any) {
+  assert.strictEqual(x, 'typedef1');
+  assert.deepStrictEqual(y, ['typedef2']);
+  return [(new TextEncoder).encode('typedef3'), ['typedef4']];
+}
+export function listOfVariants(bools: any, results: any, enums: any) {
+  assert.deepStrictEqual(bools, [true, false]);
+  assert.deepStrictEqual(results, [{ tag: 'ok', val: undefined }, { tag: 'err', val: undefined }]);
+  assert.deepStrictEqual(enums, ["success", "a"]);
+  return [
+    [false, true],
+    [{ tag: 'err', val: undefined }, { tag: 'ok', val: undefined }],
+    ["a", "b"],
+  ];
+}
 
-      errnoResult() { return { tag: 'err', val: "b" }; },
-      listTypedefs(x, y) {
-        assert.strictEqual(x, 'typedef1');
-        assert.deepStrictEqual(y, ['typedef2']);
-        return [(new TextEncoder).encode('typedef3'), ['typedef4']];
-      },
-
-      listOfVariants(bools, results, enums) {
-        assert.deepStrictEqual(bools, [true, false]);
-        assert.deepStrictEqual(results, [{ tag: 'ok', val: undefined }, { tag: 'err', val: undefined }]);
-        assert.deepStrictEqual(enums, ["success", "a"]);
-        return [
-          [false, true],
-          [{ tag: 'err', val: undefined }, { tag: 'ok', val: undefined }],
-          ["a", "b"],
-        ];
-      },
-    },
-  });
+export async function run () {
+  // @ts-ignore
+  const wasm = await import('./flavorful.js');
 
   wasm.testImports();
   wasm.fListInRecord1({ a: "list_in_record1" });
@@ -75,4 +71,5 @@ async function run() {
   assert.deepStrictEqual(r2, ['typedef4']);
 }
 
-await run()
+// TLA cycle avoidance
+setTimeout(run);

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -42,7 +42,6 @@ export function listOfVariants(bools: any, results: any, enums: any) {
 }
 
 export async function run () {
-  // @ts-ignore
   const wasm = await import('./flavorful.js');
 
   wasm.testImports();

--- a/tests/runtime/invalid/host.ts
+++ b/tests/runtime/invalid/host.ts
@@ -1,11 +1,13 @@
+// Flags: --instantiation
+
 import { instantiate } from "./invalid.js";
-import { loadWasm, testwasi } from "./helpers.js";
+import * as helpers from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       roundtripU8(x) { throw new Error('unreachable'); },
       roundtripS8(x) { throw new Error('unreachable'); },

--- a/tests/runtime/lists/host.ts
+++ b/tests/runtime/lists/host.ts
@@ -1,12 +1,14 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate } from "./lists.js";
 
 // @ts-ignore
 import * as assert from 'assert';
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       emptyListParam(a) {
         assert.deepStrictEqual(Array.from(a), []);

--- a/tests/runtime/many_arguments/host.ts
+++ b/tests/runtime/many_arguments/host.ts
@@ -1,5 +1,7 @@
+// Flags: --instantiation
+
 import { instantiate } from "./many_arguments.js";
-import { loadWasm, testwasi } from "./helpers.js";
+import * as helpers from "./helpers.js";
 
 function assertEq(x: any, y: any) {
   if (x !== y)
@@ -12,8 +14,8 @@ function assert(x: boolean) {
 }
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       manyArguments(
         a1,

--- a/tests/runtime/numbers/host.ts
+++ b/tests/runtime/numbers/host.ts
@@ -1,4 +1,6 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate } from "./numbers.js";
 
 function assertEq(x: any, y: any) {
@@ -13,8 +15,8 @@ function assert(x: boolean) {
 
 async function run() {
   let scalar = 0;
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       roundtripU8(x) { return x; },
       roundtripS8(x) { return x; },

--- a/tests/runtime/records/host.ts
+++ b/tests/runtime/records/host.ts
@@ -1,11 +1,13 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate, ImportObject } from "./records.js";
 // @ts-ignore
 import * as assert from 'node:assert';
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       multipleResults() { return [4, 5]; },
       swapTuple([a, b]) { return [b, a]; },

--- a/tests/runtime/smoke/host.ts
+++ b/tests/runtime/smoke/host.ts
@@ -1,4 +1,6 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate } from "./smoke.js";
 
 function assert(x: boolean, msg: string) {
@@ -9,8 +11,8 @@ function assert(x: boolean, msg: string) {
 async function run() {
   let hit = false;
 
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       thunk() {
         hit = true;

--- a/tests/runtime/strings/host.ts
+++ b/tests/runtime/strings/host.ts
@@ -1,12 +1,14 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate } from "./strings.js";
 
 // @ts-ignore
 import * as assert from 'assert';
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       takeBasic(s: string) {
         assert.strictEqual(s, 'latin utf16');

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -1,11 +1,13 @@
-import { loadWasm, testwasi } from "./helpers.js";
+// Flags: --instantiation
+
+import * as helpers from "./helpers.js";
 import { instantiate } from "./variants.js";
 // @ts-ignore
 import * as assert from 'assert';
 
 async function run() {
-  const wasm = await instantiate(loadWasm, {
-    testwasi,
+  const wasm = await instantiate(helpers.loadWasm, {
+    testwasi: helpers,
     imports: {
       roundtripOption(x) { return x; },
       roundtripResult(x) {


### PR DESCRIPTION
Outputs a direct ES module from the JS host generator by default that can be directly imported in JS environments.

For the custom instantiation API that was the previous output, a new `--instantiation` flag is provided.

Instance-level customization flags are also added including:
* `--compat`: Enables all compatibility mode flags (right now just `--nodejs-compat`, but based on the assumption that a new --tla-compat flag will be added in a follow-up PR).
* `--nodejs-compat`: Handle Node.js instantiation when no fetch global is present

The above flags are only compatible with instance output and will throw otherwise.

This PR also parallelizes the core Wasm instantiations, and converts the instantiation API from `instantiateCore(path, imports)` to `compileCore(path)` to enable this parallelization.

In addition a new `--map` is added with support for custom import specifier mappings that can apply to both output modes. For example - `--map "imports=./imports.js"` allows specifying that the imports should resolve to a relative JS specifier.

For testing, the first line comment of the JS file starting with `// Flags:` is used to pass these output options flags, with most tests now including `// Flags: --instantiation` for backwards-compat.