### PR TITLE
Emit component name in core Wasm file names

### DIFF
--- a/crates/bindgen-core/src/component.rs
+++ b/crates/bindgen-core/src/component.rs
@@ -62,13 +62,7 @@ pub fn generate(
     // Insert all core wasm modules into the generated `Files` which will
     // end up getting used in the `generate_instantiate` method.
     for (i, module) in modules.iter() {
-        let i_str = if i.as_u32() == 0 {
-            String::from("")
-        } else {
-            i.as_u32().to_string()
-        };
-        let name = format!("{}.core{i_str}.wasm", name);
-        files.push(&name, module.wasm);
+        files.push(&gen.core_file_name(name, i), module.wasm);
     }
 
     // With all that prep work delegate to `WorldGenerator::generate` here
@@ -103,6 +97,15 @@ pub trait ComponentGenerator: WorldGenerator {
         modules: &PrimaryMap<StaticModuleIndex, ModuleTranslation<'_>>,
         interfaces: &ComponentInterfaces,
     );
+
+    fn core_file_name(&mut self, name: &str, idx: StaticModuleIndex) -> String {
+        let i_str = if idx.as_u32() == 0 {
+            String::from("")
+        } else {
+            (idx.as_u32() + 1).to_string()
+        };
+        format!("{}.core{i_str}.wasm", name)
+    }
 
     fn finish_component(&mut self, name: &str, files: &mut Files);
 }

--- a/crates/bindgen-core/src/component.rs
+++ b/crates/bindgen-core/src/component.rs
@@ -62,8 +62,12 @@ pub fn generate(
     // Insert all core wasm modules into the generated `Files` which will
     // end up getting used in the `generate_instantiate` method.
     for (i, module) in modules.iter() {
-        let i = i.as_u32();
-        let name = format!("module{i}.wasm");
+        let i_str = if i.as_u32() == 0 {
+            String::from("")
+        } else {
+            i.as_u32().to_string()
+        };
+        let name = format!("{}.core{i_str}.wasm", name);
         files.push(&name, module.wasm);
     }
 

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -220,7 +220,7 @@ impl ComponentGenerator for Js {
         // bindings is the actual `instantiate` method itself, created by this
         // structure.
         let mut instantiator = Instantiator {
-            name: name.into(),
+            name,
             src: Source::default(),
             gen: self,
             modules,

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -685,7 +685,7 @@ impl Js {
 ///
 /// This is the main structure for parsing the output of Wasmtime.
 struct Instantiator<'a> {
-    name: String,
+    name: &'a str,
     src: Source,
     gen: &'a mut Js,
     modules: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -712,7 +712,6 @@ impl Instantiator<'_> {
         let mut multiple = false;
         for init in self.component.initializers.iter() {
             if let GlobalInitializer::InstantiateModule(InstantiateModule::Static(idx, _)) = init {
-                let idx = idx.as_u32();
                 // Get the compiled WebAssembly.Module objects in parallel
                 if first {
                     if !instantiation {
@@ -723,13 +722,8 @@ impl Instantiator<'_> {
                     multiple = true;
                 }
 
-                let local_name = format!("module{}", idx);
-                let idx_str = if idx == 0 {
-                    String::from("")
-                } else {
-                    idx.to_string()
-                };
-                let name = format!("{}.core{}.wasm", self.name, idx_str);
+                let local_name = format!("module{}", idx.as_u32());
+                let name = self.gen.core_file_name(&self.name, *idx);
                 if self.gen.opts.instantiation {
                     uwrite!(
                         self.src.js,

--- a/crates/gen-host-wasmtime-py/src/lib.rs
+++ b/crates/gen-host-wasmtime-py/src/lib.rs
@@ -452,6 +452,7 @@ impl ComponentGenerator for WasmtimePy {
         );
         self.init.indent();
         let mut i = Instantiator {
+            name,
             gen: self,
             modules,
             component,
@@ -496,6 +497,7 @@ impl ComponentGenerator for WasmtimePy {
 }
 
 struct Instantiator<'a> {
+    name: &'a str,
     gen: &'a mut WasmtimePy,
     modules: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
     instances: PrimaryMap<RuntimeInstanceIndex, StaticModuleIndex>,
@@ -582,8 +584,13 @@ impl<'a> Instantiator<'a> {
 
         uwriteln!(
             self.gen.init,
-            "path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'module{}.wasm')",
-            idx.as_u32(),
+            "path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '{}.core{}.wasm')",
+            self.name,
+            if idx.as_u32() == 0 {
+                String::from("")
+            } else {
+                idx.as_u32().to_string()
+            },
         );
         uwriteln!(
             self.gen.init,

--- a/crates/gen-host-wasmtime-py/src/lib.rs
+++ b/crates/gen-host-wasmtime-py/src/lib.rs
@@ -580,17 +580,13 @@ impl<'a> Instantiator<'a> {
 
     fn instantiate_static_module(&mut self, idx: StaticModuleIndex, args: &[CoreDef]) {
         let i = self.instances.push(idx);
+        let core_file_name = self.gen.core_file_name(&self.name, idx);
         self.gen.init.pyimport("os", None);
 
         uwriteln!(
             self.gen.init,
-            "path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '{}.core{}.wasm')",
-            self.name,
-            if idx.as_u32() == 0 {
-                String::from("")
-            } else {
-                idx.as_u32().to_string()
-            },
+            "path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '{}')",
+            core_file_name,
         );
         uwriteln!(
             self.gen.init,


### PR DESCRIPTION
This updates the generator to rather than outputting `module{n}.wasm` for the core Wasm files, to instead use the naming scheme `{name}.core{n}.wasm` and also in addition when `n == 0` to emit the `n`.

This way applications with a single Wasm file get an unnumbered Wasm, and the loaded Wasm file has a component-specific name eg in the network tab etc.

In addition this also fixes a one-liner regression in the Node.js compat output which wasn't using `compileStreaming`, and corrects the unhandled rejection handler attachment in the singular case for the JS generator.