### PR TITLE
gen-host-js: Error wrapping and unwrapping for singular Result types

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -221,12 +221,7 @@ impl WorldGenerator for C {
         if self.needs_string {
             uwrite!(
                 h_str,
-                "
-                   typedef struct {{
-                       {ty} *ptr;
-                       size_t len;
-                   }} {snake}_string_t;
-               ",
+                "typedef struct {{\n  {ty} *ptr;\n  size_t len;\n}} {snake}_string_t;\n",
                 ty = self.char_type(),
             );
         }
@@ -255,10 +250,7 @@ impl WorldGenerator for C {
         if self.return_pointer_area_size > 0 {
             uwrite!(
                 c_str,
-                "
-                   __attribute__((aligned({})))
-                   static uint8_t RET_AREA[{}];
-               ",
+                "\n__attribute__((aligned({})))\nstatic uint8_t RET_AREA[{}];\n",
                 self.return_pointer_area_align,
                 self.return_pointer_area_size,
             );
@@ -717,7 +709,7 @@ impl InterfaceGenerator<'_> {
         // canonical ABI.
         uwriteln!(
             self.src.c_adapters,
-            "__attribute__((export_name(\"{export_name}\")))"
+            "\n__attribute__((export_name(\"{export_name}\")))"
         );
         let import_name = self.gen.names.tmp(&format!(
             "__wasm_export_{}_{}",

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -219,6 +219,7 @@ impl WorldGenerator for C {
         c_str.push_str(&self.src.c_fns);
 
         if self.needs_string {
+            // Automatic indentation avoided due to `extern "C" {` declaration
             uwrite!(
                 h_str,
                 "typedef struct {{\n  {ty} *ptr;\n  size_t len;\n}} {snake}_string_t;\n",
@@ -248,6 +249,7 @@ impl WorldGenerator for C {
         // this for export bindings, because import bindings allocate their
         // return-area on the stack.
         if self.return_pointer_area_size > 0 {
+            // Automatic indentation avoided due to `extern "C" {` declaration
             uwrite!(
                 c_str,
                 "\n__attribute__((aligned({})))\nstatic uint8_t RET_AREA[{}];\n",

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -123,7 +123,6 @@ impl WorldGenerator for C {
         let linking_symbol = component_type_object::linking_symbol(name);
         self.include("<stdlib.h>");
         let snake = name.to_snake_case();
-        self.include(&format!("\"{snake}.h\""));
         uwrite!(
             self.src.c_adapters,
             "

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -1291,8 +1291,8 @@ impl<'a> JsInterface<'a> {
             self.print_ty(ty);
         }
         self.src.ts("): ");
-        if let Some((_, throw_result)) = func.results.throws(self.iface) {
-            self.print_optional_ty(throw_result);
+        if let Some((ok_ty, _)) = func.results.throws(self.iface) {
+            self.print_optional_ty(ok_ty);
         } else {
             match func.results.len() {
                 0 => self.src.ts("void"),

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -2129,7 +2129,10 @@ impl Bindgen for FunctionBindgen<'_> {
                             }}
                             case 1: {{
                                 {some}\
-                                variant{tmp} = {{ tag: 'some', val: {some_result} }};
+                                variant{tmp} = {{
+                                    tag: 'some',
+                                    val: {some_result}
+                                }};
                                 break;
                             }}
                         ",
@@ -2225,12 +2228,18 @@ impl Bindgen for FunctionBindgen<'_> {
                     switch ({op0}) {{
                         case 0: {{
                             {ok}\
-                            variant{tmp} = {{ tag: 'ok', val: {ok_result} }};
+                            variant{tmp} = {{
+                                tag: 'ok',
+                                val: {ok_result}
+                            }};
                             break;
                         }}
                         case 1: {{
                             {err}\
-                            variant{tmp} = {{ tag: 'err', val: {err_result} }};
+                            variant{tmp} = {{
+                                tag: 'err',
+                                val: {err_result}
+                            }};
                             break;
                         }}
                         default: {{
@@ -2475,7 +2484,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         }} catch (e) {{
                             ret = {{
                                 tag: 'err',
-                                val: 'payload' in e ? e.payload : String(e)
+                                val: e && 'payload' in e ? e.payload : String(e)
                             }};
                         }}",
                         self.callee,
@@ -2498,17 +2507,17 @@ impl Bindgen for FunctionBindgen<'_> {
                     let operand = &operands[0];
                     uwriteln!(
                         self.src.js,
-                        "
-                        if ({operand}.tag === 'err') {{
+                        "if ({operand}.tag === 'err') {{
                             throw new {component_err}({operand}.val);
-                        }}"
+                        }}
+                        return {operand}.val;"
                     );
-                }
-
-                match amt {
-                    0 => {}
-                    1 => uwriteln!(self.src.js, "return {};", operands[0]),
-                    _ => uwriteln!(self.src.js, "return [{}];", operands.join(", ")),
+                } else {
+                    match amt {
+                        0 => {}
+                        1 => uwriteln!(self.src.js, "return {};", operands[0]),
+                        _ => uwriteln!(self.src.js, "return [{}];", operands.join(", ")),
+                    }
                 }
             }
 

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -648,7 +648,7 @@ impl Js {
                         ptr = realloc(ptr, allocLen, 1, writtenTotal);
                     utf8EncodedLen = writtenTotal;
                     return ptr;
-                }\n
+                }
             "),
 
             Intrinsic::Utf16Encode => {
@@ -799,9 +799,9 @@ impl Instantiator<'_> {
                     );
                 } else {
                     let load_wasm = self.gen.intrinsic(Intrinsic::LoadWasm);
-                    uwrite!(
+                    uwriteln!(
                         self.src.js,
-                        "const {local_name} = {load_wasm}(new URL('./{name}', import.meta.url));\n"
+                        "const {local_name} = {load_wasm}(new URL('./{name}', import.meta.url));"
                     );
                 }
             }
@@ -825,7 +825,7 @@ impl Instantiator<'_> {
                     self.src.js.push_str(&format!("module{}", idx.as_u32()));
                 }
             }
-            self.src.js.push_str("]).catch(() => {});\n");
+            uwriteln!(self.src.js, "]).catch(() => {{}});");
         }
 
         for init in self.component.initializers.iter() {
@@ -839,7 +839,7 @@ impl Instantiator<'_> {
         self.exports(&self.component.exports, 0, self.interfaces.default.as_ref());
 
         if instantiation {
-            self.src.js(";\n");
+            uwriteln!(self.src.js, ";");
             uwriteln!(self.src.js, "}}");
         }
     }
@@ -1026,7 +1026,7 @@ impl Instantiator<'_> {
             self.src.js(&param);
             params.push(param);
         }
-        self.src.js(") {\n");
+        uwriteln!(self.src.js, ") {{");
 
         let mut sizes = SizeAlign::default();
         sizes.fill(iface);
@@ -1117,7 +1117,7 @@ impl Instantiator<'_> {
         }
 
         if self.gen.opts.instantiation {
-            self.src.js("{\n");
+            uwriteln!(self.src.js, "{{");
         }
 
         for (name, export) in exports {

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -466,7 +466,7 @@ impl Js {
             Intrinsic::ComponentError => self.src.js("
                 class ComponentError extends Error {
                     constructor (payload) {
-                        super(String(payload));
+                        super(payload);
                         this.payload = payload;
                     }
                 }

--- a/crates/wit-bindgen-demo/main.ts
+++ b/crates/wit-bindgen-demo/main.ts
@@ -109,26 +109,26 @@ class Editor {
       default: return;
     }
     this.options.import = is_import;
-    const result = render(lang, wit, this.options);
-    if (result.tag === 'err') {
-      this.outputEditor.setValue(result.val);
+    try {
+      const results = render(lang, wit, this.options);
+      this.generatedFiles = {};
+      const selectedFile = this.files.value;
+      this.files.options.length = 0;
+      for (let i = 0; i < results.length; i++) {
+        const name = results[i][0];
+        const contents = results[i][1];
+        this.files.options[i] = new Option(name, name);
+        this.generatedFiles[name] = contents;
+      }
+      if (selectedFile in this.generatedFiles)
+        this.files.value = selectedFile;
+  
+      this.updateSelectedFile();  
+    } catch (e) {
+      this.outputEditor.setValue(e.payload);
       this.outputEditor.clearSelection();
       this.showOutputEditor();
-      return;
     }
-    this.generatedFiles = {};
-    const selectedFile = this.files.value;
-    this.files.options.length = 0;
-    for (let i = 0; i < result.val.length; i++) {
-      const name = result.val[i][0];
-      const contents = result.val[i][1];
-      this.files.options[i] = new Option(name, name);
-      this.generatedFiles[name] = contents;
-    }
-    if (selectedFile in this.generatedFiles)
-      this.files.value = selectedFile;
-
-    this.updateSelectedFile();
   }
 
   showOutputEditor() {

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -275,14 +275,13 @@ impl Results {
         }
     }
 
-    pub fn throws<'a>(&self, iface: &'a Interface) -> Option<(&Type, Option<&'a Type>)> {
+    pub fn throws<'a>(&self, iface: &'a Interface) -> Option<(Option<&'a Type>, Option<&'a Type>)> {
         if self.len() != 1 {
             return None;
         }
-        let t = self.iter_types().next().unwrap();
-        match t {
+        match self.iter_types().next().unwrap() {
             Type::Id(id) => match &iface.types[*id].kind {
-                TypeDefKind::Result(r) => Some((t, r.ok.as_ref())),
+                TypeDefKind::Result(r) => Some((r.ok.as_ref(), r.err.as_ref())),
                 _ => None,
             },
             _ => None,

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -275,14 +275,18 @@ impl Results {
         }
     }
 
-    pub fn throws(&self, iface: &Interface) -> bool {
+    pub fn throws<'a>(&self, iface: &'a Interface) -> Option<(&Type, Option<&'a Type>)> {
         if self.len() != 1 {
-            return false;
+            return None;
         }
-        return match self.iter_types().next().unwrap() {
-            Type::Id(id) => matches!(iface.types[*id].kind, TypeDefKind::Result(_)),
-            _ => false,
-        };
+        let t = self.iter_types().next().unwrap();
+        match t {
+            Type::Id(id) => match &iface.types[*id].kind {
+                TypeDefKind::Result(r) => Some((t, r.ok.as_ref())),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     pub fn iter_types(&self) -> ResultsTypeIter {

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -275,6 +275,19 @@ impl Results {
         }
     }
 
+    pub fn throws(&self, iface: &Interface) -> bool {
+        if self.len() != 1 {
+            return false;
+        }
+        for result in self.iter_types() {
+            return match result {
+                Type::Id(id) => matches!(iface.types[*id].kind, TypeDefKind::Result(_)),
+                _ => false,
+            };
+        }
+        unreachable!();
+    }
+
     pub fn iter_types(&self) -> ResultsTypeIter {
         match self {
             Results::Named(ps) => ResultsTypeIter::Named(ps.iter()),

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -279,13 +279,10 @@ impl Results {
         if self.len() != 1 {
             return false;
         }
-        for result in self.iter_types() {
-            return match result {
-                Type::Id(id) => matches!(iface.types[*id].kind, TypeDefKind::Result(_)),
-                _ => false,
-            };
-        }
-        unreachable!();
+        return match self.iter_types().next().unwrap() {
+            Type::Id(id) => matches!(iface.types[*id].kind, TypeDefKind::Result(_)),
+            _ => false,
+        };
     }
 
     pub fn iter_types(&self) -> ResultsTypeIter {

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -46,7 +46,7 @@ export function listOfVariants(bools: any, results: any, enums: any) {
 export async function run () {
   const wasm = await import('./flavorful.js');
 
-  // wasm.testImports();
+  wasm.testImports();
   wasm.fListInRecord1({ a: "list_in_record1" });
   assert.deepStrictEqual(wasm.fListInRecord2(), { a: "list_in_record2" });
 

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -24,7 +24,9 @@ export function fListInVariant3(x: any) {
   assert.strictEqual(x, 'input3');
   return 'output3';
 }
-export function errnoResult() { return { tag: 'err', val: "b" }; }
+export function errnoResult() {
+  throw new Error('b');
+}
 export function listTypedefs(x: any, y: any) {
   assert.strictEqual(x, 'typedef1');
   assert.deepStrictEqual(y, ['typedef2']);
@@ -44,7 +46,7 @@ export function listOfVariants(bools: any, results: any, enums: any) {
 export async function run () {
   const wasm = await import('./flavorful.js');
 
-  wasm.testImports();
+  // wasm.testImports();
   wasm.fListInRecord1({ a: "list_in_record1" });
   assert.deepStrictEqual(wasm.fListInRecord2(), { a: "list_in_record2" });
 
@@ -63,7 +65,15 @@ export async function run () {
   assert.deepStrictEqual(wasm.fListInVariant2(), "list_in_variant2");
   assert.deepStrictEqual(wasm.fListInVariant3("input3"), "output3");
 
-  assert.deepStrictEqual(wasm.errnoResult().tag, 'err');
+  try {
+    wasm.errnoResult();
+    assert.ok(false);
+  }
+  catch (e: any) {
+    assert.strictEqual(e.constructor.name, 'ComponentError');
+    assert.ok(e.toString().includes('Error: b'));
+    assert.strictEqual(e.payload, 'b');
+  }
 
   const [r1, r2] = wasm.listTypedefs("typedef1", ["typedef2"]);
   assert.deepStrictEqual(r1, (new TextEncoder()).encode('typedef3'));

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -12,9 +12,9 @@ async function run() {
       roundtripOption(x) { return x; },
       roundtripResult(x) {
         if (x.tag == 'ok') {
-          return { tag: 'ok', val: x.val };
+          return x.val;
         } else {
-          return { tag: 'err', val: Math.round(x.val) };
+          throw Object.assign(new Error(''), { payload: Math.round(x.val) });
         }
       },
       roundtripEnum(x) { return x; },
@@ -46,7 +46,14 @@ async function run() {
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
   assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });
   const f = Math.fround(5.2);
-  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'err', val: f }), { tag: 'err', val: 5 });
+
+  try {
+    wasm.roundtripResult({ tag: 'err', val: f });
+  } catch (e: any) {
+    assert.strictEqual(e.constructor.name, 'ComponentError');
+    assert.ok(e.message.includes('5'));
+    assert.strictEqual(e.payload, 5);
+  }
 
   assert.deepStrictEqual(wasm.roundtripEnum("a"), "a");
   assert.deepStrictEqual(wasm.roundtripEnum("b"), "b");

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -43,8 +43,8 @@ async function run() {
   // @ts-ignore
   assert.deepStrictEqual(wasm.roundtripOption(), null);
   assert.deepStrictEqual(wasm.roundtripOption(2), 2);
-  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
-  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });
+  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), 2);
+  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), 4);
   const f = Math.fround(5.2);
 
   try {

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -49,6 +49,7 @@ async function run() {
 
   try {
     wasm.roundtripResult({ tag: 'err', val: f });
+    assert.fail('Expected an error');
   } catch (e: any) {
     assert.strictEqual(e.constructor.name, 'ComponentError');
     assert.ok(e.message.includes('5'));


### PR DESCRIPTION
Updates the JS generator for functions that return a singular `Result` type to return the payload directly or throw the error payload if there was an error.

Conversely for imported functions, calls are now wrapped with a try-catch and errors are converted into intermediate result structs.

For both directions, the intermediate structs that are used should be possible to optimize away in future output. Tracking issue for this in https://github.com/bytecodealliance/wit-bindgen/issues/410.

The error type implemented here is the following when converting a `{ tag: 'err', val }` to a JS error:

```js
class ComponentError extends Error {
  constructor (payload) {
    super(payload);
    this.payload = payload;
  }
}
```

When in an exported function, the JS function stack will naturally have the throw position including the real and correct function name in the JS adapter code.

`toString` is implicitly applied to the error payload in the error message, which would result in `[object Object]` etc for non-primitive payloads. We could potentially explicitly branch on this and do something different although it is tough to know what would make sense here.

In lifting, the payload is extracted from the error with the following method:

```js
function getErrorPayload(e) {
  if (Object.prototype.hasOwnProperty.call(e, 'payload')) return e.payload;
  if (Object.prototype.hasOwnProperty.call(e, 'message')) return String(e.message);
  return String(e);
}
```

This composes with the component error, while also supporting common JS patterns of `throw new Error('any string')` forming an error string result type, allowing component synthesis without a full component error class via `throw Object.assign(new Error(), { payload: { any: 'data' } })` and also supporting legacy JS errors with as much observability from their message or string form to non-JS code to widely be able to handle a normal JS error as a `Result<ResultType, String>` in any other language.

This PR also fixes some minor formatting in the C generator and adds consistent single quoting in JS output. Suggestions / changes very welcome further.