### PR TITLE
gen-guest-c: weak attribute on post-return abi functions

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -761,7 +761,7 @@ impl InterfaceGenerator<'_> {
         if self.iface.guest_export_needs_post_return(func) {
             uwriteln!(
                 self.src.c_fns,
-                "__attribute__((export_name(\"cabi_post_{export_name}\")))"
+                "__attribute__((weak, export_name(\"cabi_post_{export_name}\")))"
             );
             uwrite!(self.src.c_fns, "void {import_name}_post_return(");
 

--- a/crates/test-helpers/macros/build.rs
+++ b/crates/test-helpers/macros/build.rs
@@ -294,10 +294,17 @@ fn read_interfaces(dir: &Path) -> ComponentInterfaces {
     println!("cargo:rerun-if-changed={}", imports.display());
     println!("cargo:rerun-if-changed={}", exports.display());
 
-    let import = Interface::parse_file(&imports).unwrap();
+    let import = match Interface::parse_file(&imports) {
+        Ok(import) => Some(import),
+        Err(_) => None,
+    };
     let export = Interface::parse_file(&exports).unwrap();
     ComponentInterfaces {
-        imports: [(import.name.clone(), import)].into_iter().collect(),
+        imports: if let Some(import) = import {
+            [(import.name.clone(), import)].into_iter().collect()
+        } else {
+            [].into_iter().collect()
+        },
         exports: Default::default(),
         default: Some(export),
     }

--- a/crates/test-helpers/macros/build.rs
+++ b/crates/test-helpers/macros/build.rs
@@ -303,7 +303,7 @@ fn read_interfaces(dir: &Path) -> ComponentInterfaces {
         imports: if let Some(import) = import {
             [(import.name.clone(), import)].into_iter().collect()
         } else {
-            [].into_iter().collect()
+            [].into()
         },
         exports: Default::default(),
         default: Some(export),

--- a/crates/test-helpers/macros/build.rs
+++ b/crates/test-helpers/macros/build.rs
@@ -294,17 +294,13 @@ fn read_interfaces(dir: &Path) -> ComponentInterfaces {
     println!("cargo:rerun-if-changed={}", imports.display());
     println!("cargo:rerun-if-changed={}", exports.display());
 
-    let import = match Interface::parse_file(&imports) {
-        Ok(import) => Some(import),
-        Err(_) => None,
+    let imports = match Interface::parse_file(&imports) {
+        Ok(import) => [(import.name.clone(), import)].into_iter().collect(),
+        Err(_) => [].into(),
     };
     let export = Interface::parse_file(&exports).unwrap();
     ComponentInterfaces {
-        imports: if let Some(import) = import {
-            [(import.name.clone(), import)].into_iter().collect()
-        } else {
-            [].into()
-        },
+        imports,
         exports: Default::default(),
         default: Some(export),
     }

--- a/tests/runtime/exports_only/exports.wit
+++ b/tests/runtime/exports_only/exports.wit
@@ -1,0 +1,1 @@
+thunk: func() -> string

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -13,5 +13,5 @@ strictEqual(result, 'test');
 // Verify the inlined file size does not regress
 const url = new URL('./exports_only.js', import.meta.url);
 const jsSource = await readFile(url);
-const max_size = 6360;
+const max_size = 6375;
 ok(jsSource.byteLength < max_size, `JS inlined bytelength ${jsSource.byteLength} is greater than ${max_size} bytes, at ${fileURLToPath(url)}`);

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -13,5 +13,5 @@ strictEqual(result, 'test');
 // Verify the inlined file size does not regress
 const url = new URL('./exports_only.js', import.meta.url);
 const jsSource = await readFile(url);
-const max_size = 6350;
+const max_size = 6360;
 ok(jsSource.byteLength < max_size, `JS inlined bytelength ${jsSource.byteLength} is greater than ${max_size} bytes, at ${fileURLToPath(url)}`);

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -1,0 +1,17 @@
+// Flags: --base64 --nodejs-compat
+// @ts-ignore
+import { ok, strictEqual } from 'assert';
+// @ts-ignore
+import { readFile } from 'fs/promises';
+// @ts-ignore
+import { fileURLToPath } from 'url';
+import { thunk } from './exports_only.js';
+
+const result = thunk();
+strictEqual(result, 'test');
+
+// Verify the inlined file size does not regress
+const url = new URL('./exports_only.js', import.meta.url);
+const jsSource = await readFile(url);
+const max_size = 6350;
+ok(jsSource.byteLength < max_size, `JS inlined bytelength ${jsSource.byteLength} is greater than ${max_size} bytes, at ${fileURLToPath(url)}`);

--- a/tests/runtime/exports_only/wasm.c
+++ b/tests/runtime/exports_only/wasm.c
@@ -1,0 +1,21 @@
+#include <exports_only.h>
+#include <stdio.h>
+
+__attribute__((weak, export_name("cabi_realloc")))
+void *cabi_realloc(void *ptr, size_t orig_size, size_t org_align, size_t new_size) {
+  return ptr;
+}
+
+__attribute__((weak, export_name("cabi_post_thunk")))
+void __wasm_export_exports_thunk_post_return(int32_t arg0) {
+}
+
+static char msg[] = "test";
+
+void exports_thunk(exports_only_string_t* ret) {
+  exports_only_string_t result = {
+    .ptr = &msg[0],
+    .len = sizeof(msg) - 1,
+  };
+  *ret = result;
+}


### PR DESCRIPTION
I previously missed adding the weak attribute on these post-return functions as well, which is useful if you want to override the deallocation in the C guest generator.