### PR TITLE
Fix some test-related issues

### DIFF
--- a/crates/gen-host-js/Cargo.toml
+++ b/crates/gen-host-js/Cargo.toml
@@ -20,3 +20,7 @@ base64 = "0.13.1"
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers' }
+
+[[test]]
+name = "runtime"
+required-features = ["clap"]

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -1,4 +1,4 @@
-// Flags: --base64 --nodejs-compat --valid-lifting-optimization
+// Flags: --nodejs-compat --valid-lifting-optimization
 // @ts-ignore
 import { ok, strictEqual } from 'assert';
 // @ts-ignore
@@ -13,6 +13,6 @@ strictEqual(result, 'test');
 // Verify the inlined file size does not regress
 const url = new URL('./exports_only.js', import.meta.url);
 const jsSource = await readFile(url);
-const max_size = 6442;
+const max_size = 1105;
 ok(jsSource.byteLength <= max_size, `JS inlined bytelength ${jsSource.byteLength} is greater than ${max_size} bytes, at ${fileURLToPath(url)}`);
 


### PR DESCRIPTION
More details in the commits below but this is required for me to locally get `cargo test -p wit-bindgen-gen-host-js --test runtime` working again.