### PR TITLE
Add the ability to skip bindings in Rust

### DIFF
--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -174,3 +174,22 @@ mod macro_name {
 
     jam!(Component);
 }
+
+mod skip {
+    wit_bindgen_guest_rust::generate!({
+        export_str["exports"]: "
+            foo: func()
+            bar: func()
+        ",
+        name: "baz",
+        skip: ["foo"],
+    });
+
+    struct Component;
+
+    impl exports::Exports for Component {
+        fn bar() {}
+    }
+
+    export_baz!(Component);
+}


### PR DESCRIPTION
This commit adds a `skip` attribute and CLI argument for skipping generation of bindings for a set of named functions. This can be useful when the generated bindings can't be used for a reason such as they're to high-level, instead allowing applications to manually define functions which work with the raw inputs of the canonical ABI.