### PR TITLE
gen-host-js: support direct ArrayBuffer for Uint8Array lists

### DIFF
--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -2508,10 +2508,17 @@ impl Bindgen for FunctionBindgen<'_> {
                     "const ptr{tmp} = {realloc}(0, 0, {align}, len{tmp} * {size});"
                 );
                 // TODO: this is the wrong endianness
-                uwriteln!(
-                    self.src.js,
-                    "const src{tmp} = new Uint8Array(val{tmp}, val{tmp}.byteOffset, len{tmp} * {size});",
-                );
+                if matches!(element, Type::U8) {
+                    uwriteln!(
+                        self.src.js,
+                        "const src{tmp} = new Uint8Array(val{tmp}.buffer || val{tmp}, val{tmp}.byteOffset, len{tmp} * {size});",
+                    );
+                } else {
+                    uwriteln!(
+                        self.src.js,
+                        "const src{tmp} = new Uint8Array(val{tmp}.buffer, val{tmp}.byteOffset, len{tmp} * {size});",
+                    );
+                }
                 uwriteln!(
                     self.src.js,
                     "(new Uint8Array({memory}.buffer, ptr{tmp}, len{tmp} * {size})).set(src{tmp});",

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -16,9 +16,9 @@ export async function loadWasm(path: string) {
 }
 
 // Export a WASI interface directly for instance imports
-export function log (bytes: Uint8Array) {
+export function log (bytes: Uint8Array | ArrayBuffer) {
   stdout.write(bytes);
 }
-export function logErr (bytes: Uint8Array) {
+export function logErr (bytes: Uint8Array | ArrayBuffer) {
   stderr.write(bytes);
 }

--- a/tests/runtime/lists/host.ts
+++ b/tests/runtime/lists/host.ts
@@ -106,7 +106,7 @@ async function run() {
   wasm.testImports();
   wasm.emptyListParam(new Uint8Array([]));
   wasm.emptyStringParam('');
-  wasm.listParam(new Uint8Array([1, 2, 3, 4]));
+  wasm.listParam(new Uint8Array([1, 2, 3, 4]).buffer);
   wasm.listParam2("foo");
   wasm.listParam3(["foo", "bar", "baz"]);
   wasm.listParam4([["foo", "bar"], ["baz"]]);


### PR DESCRIPTION
This adds support for the JS lowering of `list<u8>` to support either a `Uint8Array` or a direct `ArrayBuffer` as well.

Discovered when piping a fetch response array buffer to a component input, which I think should be easily supportable here without additional wrapping being needed.