### PR TITLE
host-gen-js: replace --load with threshold-based granular inlining

### DIFF
--- a/crates/bindgen-core/src/lib.rs
+++ b/crates/bindgen-core/src/lib.rs
@@ -245,6 +245,13 @@ impl Files {
         }
     }
 
+    pub fn get_size(&mut self, name: &str) -> Option<usize> {
+        match self.files.get(name) {
+            Some(data) => Some(data.len()),
+            None => None,
+        }
+    }
+
     pub fn remove(&mut self, name: &str) -> Option<Vec<u8>> {
         return self.files.remove(name);
     }

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -1,4 +1,4 @@
-// Flags: --valid-lifting-optimization
+// Flags: --valid-lifting-optimization --base64-cutoff=0
 // @ts-ignore
 import { ok, strictEqual } from 'assert';
 // @ts-ignore

--- a/tests/runtime/smoke/host.ts
+++ b/tests/runtime/smoke/host.ts
@@ -1,4 +1,4 @@
-// Flags: --no-nodejs-compat --load=base64 --compat --map testwasi=./helpers.js,imports=./host.js
+// Flags: --compat --map testwasi=./helpers.js,imports=./host.js --base64-cutoff=2500
 function assert(x: boolean, msg: string) {
   if (!x)
     throw new Error(msg);


### PR DESCRIPTION
Replaces the `--load` flag with a single option to determine base64 inlining - `--base64-cutoff=bytesize`. Disabling inling is available via `--base64-cutoff=0` and you can enforce it with a larger cutoff, which seems better to be explicit about size limits. It applies granularly per-core-wasm source so that the small trampoline modules can be inlined where appropriate.

The default `--base64-cutoff` is set to 2500 for relatively small inlining only.

For `--load=custom`. `--instantiation` was able to fulfill this asm.js wrapping use case via a new optional `instantiateWasm` argument to `instantiate` which defaults to `WebAssembly.instantiate`.