### PR TITLE
gen-host-js: make ComponentError string payload non-enumerable

### DIFF
--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -555,12 +555,10 @@ impl Js {
 
             Intrinsic::ComponentError => self.src.js_intrinsics("
                 class ComponentError extends Error {
-                    constructor (payload) {
-                        super(payload);
-                        Object.defineProperty(this, 'payload', {
-                            value: payload,
-                            enumerable: typeof payload !== 'string'
-                        });
+                    constructor (value) {
+                        const enumerable = typeof payload !== 'string';
+                        super(`${String(value)}${enumerable ? ' (see error.payload)' : ''}`);
+                        Object.defineProperty(this, 'payload', { value, enumerable });
                     }
                 }
             "),

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -557,7 +557,10 @@ impl Js {
                 class ComponentError extends Error {
                     constructor (payload) {
                         super(payload);
-                        this.payload = payload;
+                        Object.defineProperty(this, 'payload', {
+                            value: payload,
+                            enumerable: typeof payload !== 'string'
+                        });
                     }
                 }
             "),


### PR DESCRIPTION
This makes the `payload` property non-enumerable when it is a string, while keeping it enumerable when it is not a string. This way it doesn't show up twice in Node.js error stacks. Browser error logging remains identical both for thrown and logged error strings.

In addition, when the payload is not a string, we add an additional note - ` (see error.payload)` to the error message so that the message will look like:

```
ComponentError: [object Object] (see error.payload)
```

for object errors, while remaining enumerable so that error logging environments that do log the enumerable `payload` property for non-strings will be able to log the object as well.

For example, here's wit-bindgen error _strings_ before and after in Node.js.

Before:

```
file:///Users/gbedford/Projects/test/test.js:212
    throw new ComponentError(variant22.val);
          ^

ComponentError: failed to extract interface information from component

Caused by:
    magic header not detected: bad magic number (at offset 0x0)
    at generate (file:///Users/gbedford/Projects/test/test.js:212:11)
    at file:///Users/gbedford/Projects/test/test.js:28:34 {
  payload: 'failed to extract interface information from component\n' +
    '\n' +
    'Caused by:\n' +
    '    magic header not detected: bad magic number (at offset 0x0)'
}
```

After:

```
file:///Users/gbedford/Projects/test/test.js:212
    throw new ComponentError(variant22.val);
          ^

ComponentError: failed to extract interface information from component

Caused by:
    magic header not detected: bad magic number (at offset 0x0)
    at generate (file:///Users/gbedford/Projects/test/test.js:212:11)
    at file:///Users/gbedford/Projects/test/test.js:28:34
```

Node.js will display the object payload as enumerable otherwise for non strings.