### PR TITLE
gen-host-js: --nodejs-compat as the default

### DIFF
--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -61,6 +61,7 @@ pub struct Opts {
             long,
             short = 'I',
             conflicts_with = "compatibility",
+            conflicts_with = "no-compatibility",
             conflicts_with = "compat"
         )
     )]
@@ -72,15 +73,12 @@ pub struct Opts {
     /// component import specifiers to JS import specifiers.
     #[cfg_attr(feature = "clap", arg(long), clap(value_parser = maps_str_to_map))]
     pub map: Option<HashMap<String, String>>,
-    /// Enables all compat flags: --nodejs-compat, --tla-compat.
+    /// Enables all compat flags: --tla-compat.
     #[cfg_attr(feature = "clap", arg(long, short = 'c'))]
     pub compat: bool,
-    /// Enables compatibility in Node.js without a fetch global.
-    #[cfg_attr(
-        feature = "clap",
-        arg(long, group = "compatibility", conflicts_with = "compat")
-    )]
-    pub nodejs_compat: bool,
+    /// Disables compatibility in Node.js without a fetch global.
+    #[cfg_attr(feature = "clap", arg(long, group = "no-compatibility"))]
+    pub no_nodejs_compat: bool,
     /// Enables compatibility for JS environments without top-level await support
     /// via an async $init promise export to wait for instead.
     #[cfg_attr(feature = "clap", arg(long, group = "compatibility"))]
@@ -108,7 +106,6 @@ impl Opts {
         let mut gen = Js::default();
         gen.opts = self;
         if gen.opts.compat {
-            gen.opts.nodejs_compat = true;
             gen.opts.tla_compat = true;
         }
         Ok(Box::new(gen))
@@ -568,7 +565,7 @@ impl Js {
             "),
 
             Intrinsic::LoadWasm => match self.opts.load {
-                Load::Fetch => if self.opts.nodejs_compat {
+                Load::Fetch => if !self.opts.no_nodejs_compat {
                     self.src.js_intrinsics("
                         const isNode = typeof process !== 'undefined' && process.versions && process.versions.node;
                         let _fs;
@@ -585,7 +582,7 @@ impl Js {
                         const loadWasm = url => fetch(url).then(WebAssembly.compileStreaming);
                     ")
                 },
-                Load::Base64 => if self.opts.nodejs_compat {
+                Load::Base64 => if !self.opts.no_nodejs_compat {
                     self.src.js_intrinsics("
                         const loadWasm = str => WebAssembly.compile(typeof Buffer !== 'undefined' ? Buffer.from(str, 'base64') : Uint8Array.from(atob(str), b => b.charCodeAt(0)));
                     ")

--- a/tests/runtime/exports_only/host.ts
+++ b/tests/runtime/exports_only/host.ts
@@ -1,4 +1,4 @@
-// Flags: --nodejs-compat --valid-lifting-optimization
+// Flags: --valid-lifting-optimization
 // @ts-ignore
 import { ok, strictEqual } from 'assert';
 // @ts-ignore

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -1,4 +1,4 @@
-// Flags: --nodejs-compat --map testwasi=./helpers.js,imports=./host.js
+// Flags: --map testwasi=./helpers.js,imports=./host.js
 
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/smoke/host.ts
+++ b/tests/runtime/smoke/host.ts
@@ -1,4 +1,4 @@
-// Flags: --load=base64 --compat --map testwasi=./helpers.js,imports=./host.js
+// Flags: --no-nodejs-compat --load=base64 --compat --map testwasi=./helpers.js,imports=./host.js
 function assert(x: boolean, msg: string) {
   if (!x)
     throw new Error(msg);


### PR DESCRIPTION
It's a pretty common default I think to want to get JS that runs in as many places as possible.

Instead of explicitly providing `--nodejs-compat`, `--no-nodejs-compat` can be provided instead to remove the Node.js handling branches.

In future, doing this kind of compat adjustment while supporting forward compatibility could use a hidden flag option that logs a warning / deprecation.