### PR TITLE
gen-host-js: Fix typo in ComponentError constructor, -b short flag

### DIFF
--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -78,7 +78,7 @@ pub struct Opts {
     pub no_nodejs_compat: bool,
     /// Set the cutoff byte size for base64 inlining core Wasm in instantiation mode
     /// (set to 0 to disable all base64 inlining)
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = 5000))]
+    #[cfg_attr(feature = "clap", arg(long, short = 'b', default_value_t = 5000))]
     pub base64_cutoff: usize,
     /// Enables compatibility for JS environments without top-level await support
     /// via an async $init promise export to wait for instead.
@@ -574,7 +574,7 @@ impl Js {
             Intrinsic::ComponentError => self.src.js_intrinsics("
                 class ComponentError extends Error {
                     constructor (value) {
-                        const enumerable = typeof payload !== 'string';
+                        const enumerable = typeof value !== 'string';
                         super(`${String(value)}${enumerable ? ' (see error.payload)' : ''}`);
                         Object.defineProperty(this, 'payload', { value, enumerable });
                     }

--- a/crates/gen-host-js/src/lib.rs
+++ b/crates/gen-host-js/src/lib.rs
@@ -575,7 +575,7 @@ impl Js {
                 class ComponentError extends Error {
                     constructor (value) {
                         const enumerable = typeof value !== 'string';
-                        super(`${String(value)}${enumerable ? ' (see error.payload)' : ''}`);
+                        super(enumerable ? `${String(value)} (see error.payload)` : value);
                         Object.defineProperty(this, 'payload', { value, enumerable });
                     }
                 }


### PR DESCRIPTION
Missed this during a refactoring of https://github.com/bytecodealliance/wit-bindgen/pull/426. There's no error because of the use of `typeof` but the new enumerability path wasn't triggering at all.

This PR also adds a `-b` short flag for `--base64-cutoff`.