### PR TITLE
Implement the `wit-version` keyword.

### DIFF
--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -28,6 +28,8 @@ mod codegen_tests {
 mod strings {
     wit_bindgen_guest_rust::generate!({
         inline: "
+            wit-version \"0xa\"
+
             world not-used-name {
                 import cat: interface {
                     foo: func(x: string)
@@ -51,6 +53,8 @@ mod strings {
 mod raw_strings {
     wit_bindgen_guest_rust::generate!({
         inline: "
+            wit-version \"0xa\"
+
             world not-used-name {
                 import cat: interface {
                     foo: func(x: string)
@@ -78,6 +82,8 @@ mod prefix {
     mod bindings {
         wit_bindgen_guest_rust::generate!({
             inline: "
+                wit-version \"0xa\"
+
                 world baz {
                     export exports1: interface {
                         foo: func(x: string)
@@ -111,6 +117,8 @@ mod prefix {
 mod macro_name {
     wit_bindgen_guest_rust::generate!({
         inline: "
+            wit-version \"0xa\"
+
             world baz {
                 export exports2: interface {
                     foo: func(x: string)
@@ -134,6 +142,8 @@ mod macro_name {
 mod skip {
     wit_bindgen_guest_rust::generate!({
         inline: "
+            wit-version \"0xa\"
+
             world baz {
                 export exports: interface {
                     foo: func()

--- a/crates/wasi_snapshot_preview1/testwasi.wit
+++ b/crates/wasi_snapshot_preview1/testwasi.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface testwasi {
   log: func(bytes: list<u8>)
   log-err: func(bytes: list<u8>)

--- a/crates/wit-bindgen-demo/demo.wit
+++ b/crates/wit-bindgen-demo/demo.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world demo {
   import console: interface {
     log: func(msg: string)

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -16,6 +16,8 @@ pub struct WorldPrinter {
 impl WorldPrinter {
     /// Print the given WebAssembly interface to a string.
     pub fn print(&mut self, world: &World) -> Result<String> {
+        writeln!(&mut self.output, "wit-version \"0xa\"\n")?;
+
         for (name, import) in world.imports.iter() {
             writeln!(&mut self.output, "interface {name} {{")?;
             self.print_interface(import)?;

--- a/crates/wit-component/tests/components/adapt-empty-interface/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-empty-interface/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world new {
   import new: interface {
     thunk-that-is-not-called: func()

--- a/crates/wit-component/tests/components/adapt-empty-interface/world.wit
+++ b/crates/wit-component/tests/components/adapt-empty-interface/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-export-default/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-export-default/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world new {
   default export interface {
     entrypoint: func()

--- a/crates/wit-component/tests/components/adapt-export-default/world.wit
+++ b/crates/wit-component/tests/components/adapt-export-default/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-export-namespaced/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-export-namespaced/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface new {
   entrypoint: func()
 }

--- a/crates/wit-component/tests/components/adapt-export-namespaced/world.wit
+++ b/crates/wit-component/tests/components/adapt-export-namespaced/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world foo {}

--- a/crates/wit-component/tests/components/adapt-export-reallocs/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-export-reallocs/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     read: func(amt: u32) -> list<u8>

--- a/crates/wit-component/tests/components/adapt-export-reallocs/world.wit
+++ b/crates/wit-component/tests/components/adapt-export-reallocs/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-export-save-args/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-export-save-args/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   default export interface {
     entrypoint: func(nargs: u32)

--- a/crates/wit-component/tests/components/adapt-export-save-args/world.wit
+++ b/crates/wit-component/tests/components/adapt-export-save-args/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-inject-stack/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     get-two: func() -> (a: u32, b: u32)

--- a/crates/wit-component/tests/components/adapt-inject-stack/world.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-list-return/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-list-return/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     read: func() -> list<u8>

--- a/crates/wit-component/tests/components/adapt-list-return/world.wit
+++ b/crates/wit-component/tests/components/adapt-list-return/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-memory-simple/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-memory-simple/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     log: func(s: string)

--- a/crates/wit-component/tests/components/adapt-memory-simple/world.wit
+++ b/crates/wit-component/tests/components/adapt-memory-simple/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-missing-memory/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-missing-memory/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     log: func(s: string)

--- a/crates/wit-component/tests/components/adapt-missing-memory/world.wit
+++ b/crates/wit-component/tests/components/adapt-missing-memory/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-multiple/adapt-foo-world.wit
+++ b/crates/wit-component/tests/components/adapt-multiple/adapt-foo-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world new-foo-world {
   import other1: interface {
     foo: func()

--- a/crates/wit-component/tests/components/adapt-multiple/world.wit
+++ b/crates/wit-component/tests/components/adapt-multiple/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/adapt-preview1/adapt-wasi_snapshot_preview1-world.wit
+++ b/crates/wit-component/tests/components/adapt-preview1/adapt-wasi_snapshot_preview1-world.wit
@@ -1,6 +1,8 @@
 // This is the interface imported by the `adapt-*.wat` file which is used
 // to implement the `wasi_snapshot_preview1` interface.
 
+wit-version "0xa"
+
 interface my-wasi {
   random-get: func(size: u32) -> list<u8>
   proc-exit: func(code: u32)

--- a/crates/wit-component/tests/components/adapt-preview1/world.wit
+++ b/crates/wit-component/tests/components/adapt-preview1/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   import foo: interface {
     foo: func()

--- a/crates/wit-component/tests/components/adapt-unused/adapt-old-world.wit
+++ b/crates/wit-component/tests/components/adapt-unused/adapt-old-world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world brave-new-world {
   import new: interface {
     log: func(s: string)

--- a/crates/wit-component/tests/components/adapt-unused/world.wit
+++ b/crates/wit-component/tests/components/adapt-unused/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/default-export-sig-mismatch/world.wit
+++ b/crates/wit-component/tests/components/default-export-sig-mismatch/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   default export interface {
     a: func(x: string) -> string

--- a/crates/wit-component/tests/components/empty-module-import/world.wit
+++ b/crates/wit-component/tests/components/empty-module-import/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/empty/world.wit
+++ b/crates/wit-component/tests/components/empty/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/ensure-default-type-exports/world.wit
+++ b/crates/wit-component/tests/components/ensure-default-type-exports/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   type foo = u8
 

--- a/crates/wit-component/tests/components/export-sig-mismatch/world.wit
+++ b/crates/wit-component/tests/components/export-sig-mismatch/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   export foo: interface {
     a: func(x: string) -> string

--- a/crates/wit-component/tests/components/exports/world.wit
+++ b/crates/wit-component/tests/components/exports/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   default export interface {
     a: func()

--- a/crates/wit-component/tests/components/import-conflict/world.wit
+++ b/crates/wit-component/tests/components/import-conflict/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   a: func()
 }

--- a/crates/wit-component/tests/components/import-empty-interface/world.wit
+++ b/crates/wit-component/tests/components/import-empty-interface/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   import foo: interface {}
 }

--- a/crates/wit-component/tests/components/import-export/world.wit
+++ b/crates/wit-component/tests/components/import-export/world.wit
@@ -1,3 +1,4 @@
+wit-version "0xa"
 
 world my-world {
   import foo: interface {

--- a/crates/wit-component/tests/components/import-sig-mismatch/world.wit
+++ b/crates/wit-component/tests/components/import-sig-mismatch/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   import foo: interface {
     bar: func(s: string)

--- a/crates/wit-component/tests/components/imports/world.wit
+++ b/crates/wit-component/tests/components/imports/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   import bar: interface {
     record x {

--- a/crates/wit-component/tests/components/invalid-module-import/world.wit
+++ b/crates/wit-component/tests/components/invalid-module-import/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world foo {}

--- a/crates/wit-component/tests/components/lift-options/world.wit
+++ b/crates/wit-component/tests/components/lift-options/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface my-default {
   record r {
       s: string

--- a/crates/wit-component/tests/components/lower-options/world.wit
+++ b/crates/wit-component/tests/components/lower-options/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   record r {
       s: string

--- a/crates/wit-component/tests/components/missing-default-export/world.wit
+++ b/crates/wit-component/tests/components/missing-default-export/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   default export interface {
     a: func()

--- a/crates/wit-component/tests/components/missing-export/world.wit
+++ b/crates/wit-component/tests/components/missing-export/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world my-world {
   export foo: interface {
     a: func()

--- a/crates/wit-component/tests/components/missing-import-func/world.wit
+++ b/crates/wit-component/tests/components/missing-import-func/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   a: func()
 }

--- a/crates/wit-component/tests/components/missing-import/world.wit
+++ b/crates/wit-component/tests/components/missing-import/world.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/crates/wit-component/tests/components/no-realloc-required/world.wit
+++ b/crates/wit-component/tests/components/no-realloc-required/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   import foo: interface {
     log: func(s: string)

--- a/crates/wit-component/tests/components/post-return/world.wit
+++ b/crates/wit-component/tests/components/post-return/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   default export interface {
     a: func() -> string

--- a/crates/wit-component/tests/components/simple/world.wit
+++ b/crates/wit-component/tests/components/simple/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world foo {
   default export interface {
     type x = list<string>

--- a/crates/wit-component/tests/interfaces/default/world.wit
+++ b/crates/wit-component/tests/interfaces/default/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world default-world {
   default export interface {
     foo: func(a: u32)

--- a/crates/wit-component/tests/interfaces/empty/world.wit
+++ b/crates/wit-component/tests/interfaces/empty/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface empty {}
 
 world empty-world {

--- a/crates/wit-component/tests/interfaces/exports/world.wit
+++ b/crates/wit-component/tests/interfaces/exports/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   record my-struct {
     a: u32,

--- a/crates/wit-component/tests/interfaces/flags/world.wit
+++ b/crates/wit-component/tests/interfaces/flags/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   flags flag1 {
     b0,

--- a/crates/wit-component/tests/interfaces/floats/world.wit
+++ b/crates/wit-component/tests/interfaces/floats/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface floats {
   float32-param: func(x: float32)
 

--- a/crates/wit-component/tests/interfaces/import-and-export/world.wit
+++ b/crates/wit-component/tests/interfaces/import-and-export/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   foo: func()
 

--- a/crates/wit-component/tests/interfaces/integers/world.wit
+++ b/crates/wit-component/tests/interfaces/integers/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface integers {
   a1: func(x: u8)
 

--- a/crates/wit-component/tests/interfaces/lists/world.wit
+++ b/crates/wit-component/tests/interfaces/lists/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface lists {
   record other-record {
     a1: u32,

--- a/crates/wit-component/tests/interfaces/records/world.wit
+++ b/crates/wit-component/tests/interfaces/records/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface records {
   record empty {
   }

--- a/crates/wit-component/tests/interfaces/reference-out-of-order/world.wit
+++ b/crates/wit-component/tests/interfaces/reference-out-of-order/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   record r {
     s: string,

--- a/crates/wit-component/tests/interfaces/type-aliases/world.wit
+++ b/crates/wit-component/tests/interfaces/type-aliases/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   record foo {
   }

--- a/crates/wit-component/tests/interfaces/variants/world.wit
+++ b/crates/wit-component/tests/interfaces/variants/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface variants {
   enum e1 {
     a,

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -17,6 +17,23 @@ pub struct Document<'a> {
 
 impl<'a> Document<'a> {
     pub fn parse(lexer: &mut Tokenizer<'a>) -> Result<Document<'a>> {
+        match lexer.next()? {
+            Some((_span, Token::WitVersion)) => match lexer.next()? {
+                Some((span, Token::StrLit)) => {
+                    let wit_version = lexer.parse_str(span)?;
+                    if wit_version != "0xa" {
+                        return Err(Error {
+                            span,
+                            msg: format!("wit-version currently must be \"0xa\""),
+                        }
+                        .into());
+                    }
+                }
+                other => return Err(err_expected(lexer, "a string", other).into()),
+            },
+            other => return Err(err_expected(lexer, "`wit-version`", other).into()),
+        }
+
         let mut items = Vec::new();
         while lexer.clone().next()?.is_some() {
             let docs = parse_docs(lexer)?;

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -32,6 +32,8 @@ pub enum Token {
     Whitespace,
     Comment,
 
+    WitVersion,
+
     Equals,
     Comma,
     Colon,
@@ -253,6 +255,7 @@ impl<'a> Tokenizer<'a> {
                 }
                 let end = start + ch.len_utf8() + (remaining - self.chars.chars.as_str().len());
                 match &self.input[start..end] {
+                    "wit-version" => WitVersion,
                     "use" => Use,
                     "type" => Type,
                     "func" => Func,
@@ -524,6 +527,7 @@ impl Token {
         match self {
             Whitespace => "whitespace",
             Comment => "a comment",
+            WitVersion => "keyword `wit-version`",
             Equals => "'='",
             Comma => "','",
             Colon => "':'",

--- a/crates/wit-parser/tests/ui/comments.wit
+++ b/crates/wit-parser/tests/ui/comments.wit
@@ -5,6 +5,8 @@
 /* this too */ /* is a comment */
 /* this /* is /* a */ nested */ comment */
 
+wit-version "0xa"
+
 interface foo {
   type x = u32
 

--- a/crates/wit-parser/tests/ui/embedded.wit.md
+++ b/crates/wit-parser/tests/ui/embedded.wit.md
@@ -3,6 +3,10 @@
 containing stuff, and also some code blocks, wit and other.
 
 ```wit
+wit-version "0xa"
+```
+
+```wit
 interface foo {
 ```
 

--- a/crates/wit-parser/tests/ui/empty.wit
+++ b/crates/wit-parser/tests/ui/empty.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world dummy {} // TODO: should not be necessary

--- a/crates/wit-parser/tests/ui/functions.wit
+++ b/crates/wit-parser/tests/ui/functions.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface functions {
   f1: func()
   f2: func(a: u32)

--- a/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit
@@ -1,4 +1,7 @@
 // parse-fail
+
+wit-version "0xa"
+
 interface foo {
   type foo = bar
 }

--- a/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit.result
@@ -1,5 +1,5 @@
 no type named `bar`
-     --> tests/ui/parse-fail/alias-no-type.wit:3:14
+     --> tests/ui/parse-fail/alias-no-type.wit:6:14
       |
-    3 |   type foo = bar
+    6 |   type foo = bar
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/async.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/async.wit.result
@@ -1,5 +1,5 @@
 expected keyword `func`, found eof
      --> tests/ui/parse-fail/async.wit:3:1
       |
-    3 | 
+    5 | 
       | ^

--- a/crates/wit-parser/tests/ui/parse-fail/async1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/async1.wit.result
@@ -1,5 +1,5 @@
 expected keyword `func`, found '('
      --> tests/ui/parse-fail/async1.wit:2:9
       |
-    2 | a: async()
+    4 | a: async()
       |         ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-list.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-list.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type x = list<u32
 

--- a/crates/wit-parser/tests/ui/parse-fail/bad-list.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-list.wit.result
@@ -1,5 +1,5 @@
 expected '>', found keyword `type`
-     --> tests/ui/parse-fail/bad-list.wit:6:3
+     --> tests/ui/parse-fail/bad-list.wit:8:3
       |
-    6 |   type y = u32
+    8 |   type y = u32
       |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/cycle.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = foo
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle.wit.result
@@ -1,5 +1,5 @@
 type can recursively refer to itself
-     --> tests/ui/parse-fail/cycle.wit:4:8
+     --> tests/ui/parse-fail/cycle.wit:6:8
       |
-    4 |   type foo = foo
+    6 |   type foo = foo
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle2.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = bar
   type bar = foo

--- a/crates/wit-parser/tests/ui/parse-fail/cycle2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle2.wit.result
@@ -1,5 +1,5 @@
 type can recursively refer to itself
-     --> tests/ui/parse-fail/cycle2.wit:4:8
+     --> tests/ui/parse-fail/cycle2.wit:6:8
       |
-    4 |   type foo = bar
+    6 |   type foo = bar
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle3.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = bar
   type bar = option<foo>

--- a/crates/wit-parser/tests/ui/parse-fail/cycle3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle3.wit.result
@@ -1,5 +1,5 @@
 type can recursively refer to itself
-     --> tests/ui/parse-fail/cycle3.wit:4:8
+     --> tests/ui/parse-fail/cycle3.wit:6:8
       |
-    4 |   type foo = bar
+    6 |   type foo = bar
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle4.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = bar
   record bar { x: foo }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle4.wit.result
@@ -1,5 +1,5 @@
 type can recursively refer to itself
-     --> tests/ui/parse-fail/cycle4.wit:4:8
+     --> tests/ui/parse-fail/cycle4.wit:6:8
       |
-    4 |   type foo = bar
+    6 |   type foo = bar
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle5.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle5.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = bar
   type bar = list<foo>

--- a/crates/wit-parser/tests/ui/parse-fail/cycle5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle5.wit.result
@@ -1,5 +1,5 @@
 type can recursively refer to itself
-     --> tests/ui/parse-fail/cycle5.wit:4:8
+     --> tests/ui/parse-fail/cycle5.wit:6:8
       |
-    4 |   type foo = bar
+    6 |   type foo = bar
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/dangling-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/dangling-type.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type
 

--- a/crates/wit-parser/tests/ui/parse-fail/dangling-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/dangling-type.wit.result
@@ -1,5 +1,5 @@
 expected an identifier or string, found eof
-     --> tests/ui/parse-fail/dangling-type.wit:6:1
+     --> tests/ui/parse-fail/dangling-type.wit:8:1
       |
-    6 | 
+    8 | 
       | ^

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   foo: func()
   foo: func()

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit.result
@@ -1,5 +1,5 @@
 "foo" defined twice
-     --> tests/ui/parse-fail/duplicate-functions.wit:5:3
+     --> tests/ui/parse-fail/duplicate-functions.wit:7:3
       |
-    5 |   foo: func()
+    7 |   foo: func()
       |   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-interface.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-interface.wit
@@ -1,4 +1,6 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {}
 interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-interface.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-interface.wit.result
@@ -1,5 +1,5 @@
 interface foo defined twice
-     --> tests/ui/parse-fail/duplicate-interface.wit:4:11
+     --> tests/ui/parse-fail/duplicate-interface.wit:6:11
       |
-    4 | interface foo {}
+    6 | interface foo {}
       |           ^--

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = s32
   type foo = s32

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit.result
@@ -1,5 +1,5 @@
 type "foo" defined twice
-     --> tests/ui/parse-fail/duplicate-type.wit:5:8
+     --> tests/ui/parse-fail/duplicate-type.wit:7:8
       |
-    5 |   type foo = s32
+    7 |   type foo = s32
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-value.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-value.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   a: s32
   a: u32

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-value.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-value.wit.result
@@ -1,5 +1,5 @@
 "a" defined twice
-     --> tests/ui/parse-fail/duplicate-value.wit:5:3
+     --> tests/ui/parse-fail/duplicate-value.wit:7:3
       |
-    5 |   a: u32
+    7 |   a: u32
       |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/empty-enum.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-enum.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   enum t {}
 }

--- a/crates/wit-parser/tests/ui/parse-fail/empty-enum.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-enum.wit.result
@@ -1,5 +1,5 @@
 empty enum
-     --> tests/ui/parse-fail/empty-enum.wit:4:8
+     --> tests/ui/parse-fail/empty-enum.wit:6:8
       |
-    4 |   enum t {}
+    6 |   enum t {}
       |        ^

--- a/crates/wit-parser/tests/ui/parse-fail/empty-union.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-union.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   union t {}
 }

--- a/crates/wit-parser/tests/ui/parse-fail/empty-union.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-union.wit.result
@@ -1,5 +1,5 @@
 empty union
-     --> tests/ui/parse-fail/empty-union.wit:4:9
+     --> tests/ui/parse-fail/empty-union.wit:6:9
       |
-    4 |   union t {}
+    6 |   union t {}
       |         ^

--- a/crates/wit-parser/tests/ui/parse-fail/empty-variant1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-variant1.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   variant t {}
 }

--- a/crates/wit-parser/tests/ui/parse-fail/empty-variant1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/empty-variant1.wit.result
@@ -1,5 +1,5 @@
 empty variant
-     --> tests/ui/parse-fail/empty-variant1.wit:4:11
+     --> tests/ui/parse-fail/empty-variant1.wit:6:11
       |
-    4 |   variant t {}
+    6 |   variant t {}
       |           ^

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-md.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-md.wit.result
@@ -1,4 +1,4 @@
-expected `default`, `world` or `interface`, found keyword `type`
+expected `wit-version`, found keyword `type`
      --> tests/ui/parse-fail/invalid-md.md:6:1
       |
     6 | type foo = bar

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-toplevel.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-toplevel.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   abcd
 }

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-toplevel.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-toplevel.wit.result
@@ -1,5 +1,5 @@
 expected ':', found '}'
-     --> tests/ui/parse-fail/invalid-toplevel.wit:5:1
+     --> tests/ui/parse-fail/invalid-toplevel.wit:7:1
       |
-    5 | }
+    7 | }
       | ^

--- a/crates/wit-parser/tests/ui/parse-fail/keyword.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/keyword.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface kw {
   type option = u32
 }

--- a/crates/wit-parser/tests/ui/parse-fail/keyword.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/keyword.wit.result
@@ -1,5 +1,5 @@
 expected an identifier or string, found keyword `option`
-     --> tests/ui/parse-fail/keyword.wit:4:8
+     --> tests/ui/parse-fail/keyword.wit:6:8
       |
-    4 |   type option = u32
+    6 |   type option = u32
       |        ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/no-worlds.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/no-worlds.wit
@@ -1,1 +1,3 @@
 // parse-fail
+
+wit-version "0xa"

--- a/crates/wit-parser/tests/ui/parse-fail/two-worlds.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/two-worlds.wit
@@ -1,4 +1,6 @@
 // parse-fail
 
+wit-version "0xa"
+
 world a {}
 world b {}

--- a/crates/wit-parser/tests/ui/parse-fail/two-worlds.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/two-worlds.wit.result
@@ -1,5 +1,5 @@
 too many worlds defined
-     --> tests/ui/parse-fail/two-worlds.wit:4:7
+     --> tests/ui/parse-fail/two-worlds.wit:6:7
       |
-    4 | world b {}
+    6 | world b {}
       |       ^

--- a/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {
   type foo = bar
 }

--- a/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit.result
@@ -1,5 +1,5 @@
 no type named `bar`
-     --> tests/ui/parse-fail/undefined-typed.wit:4:14
+     --> tests/ui/parse-fail/undefined-typed.wit:6:14
       |
-    4 |   type foo = bar
+    6 |   type foo = bar
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 world foo {
   import bar: bar
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit.result
@@ -1,5 +1,5 @@
 bar not defined
-     --> tests/ui/parse-fail/unknown-interface.wit:4:15
+     --> tests/ui/parse-fail/unknown-interface.wit:6:15
       |
-    4 |   import bar: bar
+    6 |   import bar: bar
       |               ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-default1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default1.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 world foo {
   default export bar
 }

--- a/crates/wit-parser/tests/ui/parse-fail/world-default1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default1.wit.result
@@ -1,5 +1,5 @@
 bar not defined
-     --> tests/ui/parse-fail/world-default1.wit:4:18
+     --> tests/ui/parse-fail/world-default1.wit:6:18
       |
-    4 |   default export bar
+    6 |   default export bar
       |                  ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-default2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default2.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 world foo {
   default export interface {}
   default export interface {}

--- a/crates/wit-parser/tests/ui/parse-fail/world-default2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default2.wit.result
@@ -1,5 +1,5 @@
 more than one default
-     --> tests/ui/parse-fail/world-default2.wit:5:18
+     --> tests/ui/parse-fail/world-default2.wit:7:18
       |
-    5 |   default export interface {}
+    7 |   default export interface {}
       |                  ^--------

--- a/crates/wit-parser/tests/ui/parse-fail/world-default3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default3.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {}
 
 world foo {

--- a/crates/wit-parser/tests/ui/parse-fail/world-default3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-default3.wit.result
@@ -1,5 +1,5 @@
 more than one default
-     --> tests/ui/parse-fail/world-default3.wit:7:18
+     --> tests/ui/parse-fail/world-default3.wit:9:18
       |
-    7 |   default export foo
+    9 |   default export foo
       |                  ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-same-fields.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-same-fields.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 interface foo {}
 interface bar {}
 

--- a/crates/wit-parser/tests/ui/parse-fail/world-same-fields.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-same-fields.wit.result
@@ -1,5 +1,5 @@
 duplicate import foo
-     --> tests/ui/parse-fail/world-same-fields.wit:8:10
+     --> tests/ui/parse-fail/world-same-fields.wit:10:10
       |
-    8 |   import foo: bar
+   10 |   import foo: bar
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-same-fields2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-same-fields2.wit
@@ -1,5 +1,7 @@
 // parse-fail
 
+wit-version "0xa"
+
 world a {
   import foo: interface {}
   import foo: interface {}

--- a/crates/wit-parser/tests/ui/parse-fail/world-same-fields2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-same-fields2.wit.result
@@ -1,5 +1,5 @@
 duplicate import foo
-     --> tests/ui/parse-fail/world-same-fields2.wit:5:10
+     --> tests/ui/parse-fail/world-same-fields2.wit:7:10
       |
-    5 |   import foo: interface {}
+    7 |   import foo: interface {}
       |          ^--

--- a/crates/wit-parser/tests/ui/type-then-eof.wit
+++ b/crates/wit-parser/tests/ui/type-then-eof.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
   foo: func() -> string
 }

--- a/crates/wit-parser/tests/ui/types.wit
+++ b/crates/wit-parser/tests/ui/types.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface types {
   type t1 = u8
   type t2 = u16

--- a/crates/wit-parser/tests/ui/values.wit
+++ b/crates/wit-parser/tests/ui/values.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface values {
   a: s32
   b: tuple<>

--- a/crates/wit-parser/tests/ui/wasi.wit
+++ b/crates/wit-parser/tests/ui/wasi.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface wasi {
   enum clockid {
     // The clock measuring real time. Time value zero corresponds with

--- a/crates/wit-parser/tests/ui/world-default.wit
+++ b/crates/wit-parser/tests/ui/world-default.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {
     a: func()
   }

--- a/crates/wit-parser/tests/ui/worlds.wit
+++ b/crates/wit-parser/tests/ui/worlds.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface foo {}
 interface bar {}
 

--- a/tests/codegen/char.wit
+++ b/tests/codegen/char.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface chars {
   /// A function that accepts a character
   take-char: func(x: char)

--- a/tests/codegen/conventions.wit
+++ b/tests/codegen/conventions.wit
@@ -1,5 +1,7 @@
 // hello 🐱 world
 
+wit-version "0xa"
+
 interface conventions {
   kebab-case: func()
 

--- a/tests/codegen/empty.wit
+++ b/tests/codegen/empty.wit
@@ -1,1 +1,3 @@
+wit-version "0xa"
+
 world empty {}

--- a/tests/codegen/flags.wit
+++ b/tests/codegen/flags.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface flegs {
   flags flag1 {
     b0,

--- a/tests/codegen/floats.wit
+++ b/tests/codegen/floats.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface floats {
   float32-param: func(x: float32)
   float64-param: func(x: float64)

--- a/tests/codegen/integers.wit
+++ b/tests/codegen/integers.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface integers {
   a1: func(x: u8)
   a2: func(x: s8)

--- a/tests/codegen/lists.wit
+++ b/tests/codegen/lists.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface lists {
   list-u8-param: func(x: list<u8>)
   list-u16-param: func(x: list<u16>)

--- a/tests/codegen/many-arguments.wit
+++ b/tests/codegen/many-arguments.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface manyarg {
   many-args: func(
     a1: u64,

--- a/tests/codegen/multi-return.wit
+++ b/tests/codegen/multi-return.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface multi-return {
   mra: func()
   mrb: func() -> ()

--- a/tests/codegen/records.wit
+++ b/tests/codegen/records.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface records {
   tuple-arg: func(x: tuple<char, u32>)
   tuple-result: func() -> tuple<char, u32>

--- a/tests/codegen/simple-functions.wit
+++ b/tests/codegen/simple-functions.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface simple {
   f1: func()
   f2: func(a: u32)

--- a/tests/codegen/simple-lists.wit
+++ b/tests/codegen/simple-lists.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface simple-lists {
   simple-list1: func(l: list<u32>)
   simple-list2: func() -> list<u32>

--- a/tests/codegen/small-anonymous.wit
+++ b/tests/codegen/small-anonymous.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface anon {
   enum error {
     success,

--- a/tests/codegen/smoke-default.wit
+++ b/tests/codegen/smoke-default.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world the-world {
   default export interface {
     y: func()

--- a/tests/codegen/smoke-export.wit
+++ b/tests/codegen/smoke-export.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world the-world {
   export the-name: interface {
     y: func()

--- a/tests/codegen/smoke.wit
+++ b/tests/codegen/smoke.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 world the-world {
   import imports: interface {
     y: func()

--- a/tests/codegen/strings.wit
+++ b/tests/codegen/strings.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface strings {
   a: func(x: string)
   b: func() -> string

--- a/tests/codegen/unions.wit
+++ b/tests/codegen/unions.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface unions {
   /// A union of all of the integral types
   union all-integers {

--- a/tests/codegen/variants.wit
+++ b/tests/codegen/variants.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface variants {
   enum e1 {
       a,

--- a/tests/runtime/exports_only/world.wit
+++ b/tests/runtime/exports_only/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface exports {
   thunk: func() -> string
 }

--- a/tests/runtime/flavorful/world.wit
+++ b/tests/runtime/flavorful/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   record list-in-record1 { a: string }
   record list-in-record2 { a: string }

--- a/tests/runtime/invalid/world.wit
+++ b/tests/runtime/invalid/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   roundtrip-u8: func(a: u8) -> u8
   roundtrip-s8: func(a: s8) -> s8

--- a/tests/runtime/lists/world.wit
+++ b/tests/runtime/lists/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   empty-list-param: func(a: list<u8>)
   empty-string-param: func(a: string)

--- a/tests/runtime/many_arguments/world.wit
+++ b/tests/runtime/many_arguments/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   many-arguments: func(
     a1: u64,

--- a/tests/runtime/numbers/world.wit
+++ b/tests/runtime/numbers/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   roundtrip-u8: func(a: u8) -> u8
   roundtrip-s8: func(a: s8) -> s8

--- a/tests/runtime/records/world.wit
+++ b/tests/runtime/records/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   multiple-results: func() -> (a: u8, b: u16)
 

--- a/tests/runtime/results/world.wit
+++ b/tests/runtime/results/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   string-error: func(a: float32) -> result<float32, string>
 

--- a/tests/runtime/smoke/world.wit
+++ b/tests/runtime/smoke/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   thunk: func()
 }

--- a/tests/runtime/smw_functions/exports.wit
+++ b/tests/runtime/smw_functions/exports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 test-imports: func()
 
 f1: func()

--- a/tests/runtime/smw_functions/imports.wit
+++ b/tests/runtime/smw_functions/imports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 f1: func()
 f2: func(a: u32)
 f3: func(a: u32, b: u32)

--- a/tests/runtime/smw_lists/exports.wit
+++ b/tests/runtime/smw_lists/exports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 test-imports: func()
 
 f1: func(l: list<u32>)

--- a/tests/runtime/smw_lists/imports.wit
+++ b/tests/runtime/smw_lists/imports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 f1: func(l: list<u32>)
 f2: func() -> list<u32>
 // TODO: should re-enable when re-implemented

--- a/tests/runtime/smw_strings/exports.wit
+++ b/tests/runtime/smw_strings/exports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 test-imports: func()
 
 f1: func(s: string)

--- a/tests/runtime/smw_strings/imports.wit
+++ b/tests/runtime/smw_strings/imports.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 f1: func(s: string)
 f2: func() -> string
 // TODO: should re-enable when fixed

--- a/tests/runtime/strings/world.wit
+++ b/tests/runtime/strings/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   take-basic: func(s: string)
   return-unicode: func() -> string

--- a/tests/runtime/unions/world.wit
+++ b/tests/runtime/unions/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   /// A union of all of the integral types
   union all-integers {

--- a/tests/runtime/variants/world.wit
+++ b/tests/runtime/variants/world.wit
@@ -1,3 +1,5 @@
+wit-version "0xa"
+
 interface imports {
   roundtrip-option: func(a: option<float32>) -> option<u8>
   roundtrip-result: func(a: result<u32, float32>) -> result<float64, u8>


### PR DESCRIPTION
Implement the `wit-version` keyword, requiring the version string to be "0xa" for now. Once the language reaches a level of stability, this may be used to manage backwards-incompatible langauge changes.

This implements WebAssembly/component-model#126.

Opening as a draft for now, until it's clear how the component-model PR will be resolved.