### PR TITLE
Bump version of dependency crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,14 +88,14 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ${{ runner.tool_cache }}/wasm-tools
-        key: wasm-tools-bin-e15e768a346c30738103d372e8ccf442646628c9-${{ runner.os }}
+        key: wasm-tools-bin-56fc46b3fb6cd62fbcc78553bc1e4b3489877d7e-${{ runner.os }}
     - run: echo '${{ runner.tool_cache }}/wasm-tools/bin' >> $GITHUB_PATH
     - run: |
         cargo install \
           wasm-tools \
           --root '${{ runner.tool_cache }}/wasm-tools' \
           --git https://github.com/bytecodealliance/wasm-tools \
-          --rev e15e768a346c30738103d372e8ccf442646628c9 \
+          --rev 56fc46b3fb6cd62fbcc78553bc1e4b3489877d7e \
           --no-default-features \
           --features component
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,14 +88,13 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ${{ runner.tool_cache }}/wasm-tools
-        key: wasm-tools-bin-56fc46b3fb6cd62fbcc78553bc1e4b3489877d7e-${{ runner.os }}
+        key: wasm-tools-bin-1.0.15-${{ runner.os }}
     - run: echo '${{ runner.tool_cache }}/wasm-tools/bin' >> $GITHUB_PATH
     - run: |
         cargo install \
-          wasm-tools \
+          wasm-tools@1.0.15 \
           --root '${{ runner.tool_cache }}/wasm-tools' \
-          --git https://github.com/bytecodealliance/wasm-tools \
-          --rev 56fc46b3fb6cd62fbcc78553bc1e4b3489877d7e \
+          --locked \
           --no-default-features \
           --features component
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,16 +221,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -249,21 +249,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 
 [[package]]
 name = "cranelift-egraph"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-entity",
  "fxhash",
@@ -275,16 +275,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -294,16 +294,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
-dependencies = [
- "rayon",
-]
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -312,8 +309,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.90.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "0.91.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -321,7 +318,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-types",
 ]
 
@@ -502,6 +499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +636,16 @@ name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "ignore"
@@ -874,6 +890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69025b4a161879ba90719837c06621c3d73cffa147a000aeacf458f6a9572485"
+checksum = "91b2eab54204ea0117fe9a060537e0b07a4e72f7c7d182361ecc346cab2240e5"
 dependencies = [
  "fxhash",
  "log",
@@ -1223,7 +1245,7 @@ name = "test-helpers"
 version = "0.3.0"
 dependencies = [
  "test-helpers-macros",
- "wat 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wat",
  "wit-bindgen-core",
  "wit-component",
  "wit-parser",
@@ -1293,6 +1315,21 @@ checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -1397,10 +1434,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1419,6 +1471,17 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version_check"
@@ -1453,70 +1516,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64ac98d5d61192cc45c701b7e4bd0b9aff91e2edfc7a088406cfe2288581e2c"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.19.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.92.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
 dependencies = [
  "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdac7e1d98d70913ae3b4923dd7419c8ea7bdfd4c44a240a0ba305d929b7f191"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.94.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
-dependencies = [
- "indexmap",
+ "url",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.43"
+version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c093ddb9e6526cc59d93032b9be7a8d014cc997e8a9372f394c9624f820d209"
+checksum = "ae24500f9cc27a4b2b338e66693ff53c08b17cf920bdc81e402a09fe7a204eea"
 dependencies = [
  "anyhow",
- "wasmparser 0.94.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1533,7 +1563,7 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1542,22 +1572,22 @@ dependencies = [
  "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-runtime",
- "wat 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wat",
  "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "anyhow",
  "base64",
@@ -1575,8 +1605,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1586,13 +1616,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1605,14 +1635,14 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1623,8 +1653,8 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.18.0",
- "wasmparser 0.92.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1632,8 +1662,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1644,8 +1674,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1669,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "object",
  "once_cell",
@@ -1679,8 +1709,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "2.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "3.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1689,8 +1719,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "anyhow",
  "cc",
@@ -1715,53 +1745,34 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#0667a412d70c6b4d9f97502a351db54373c18c91"
+version = "4.0.0"
+source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.92.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wast"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
+checksum = "a2cbb59d4ac799842791fe7e806fa5dbbf6b5554d538e51cc8e176db6ff0ae34"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wast"
-version = "49.0.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
-dependencies = [
- "leb128",
- "memchr",
- "unicode-width",
- "wasm-encoder 0.19.1 (git+https://github.com/bytecodealliance/wasm-tools)",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
+checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
 dependencies = [
- "wast 49.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wat"
-version = "1.0.51"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
-dependencies = [
- "wast 49.0.0 (git+https://github.com/bytecodealliance/wasm-tools)",
+ "wast",
 ]
 
 [[package]]
@@ -1901,7 +1912,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
- "wat 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wat",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-c",
  "wit-bindgen-gen-guest-rust",
@@ -1948,7 +1959,7 @@ dependencies = [
  "clap",
  "heck",
  "test-helpers",
- "wasm-encoder 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-encoder",
  "wit-bindgen-core",
  "wit-component",
 ]
@@ -2085,23 +2096,24 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd2df9189898860bd8137e89c2bef51319a790e12bde9f78c0e2b5daab07aab"
 dependencies = [
  "anyhow",
  "bitflags",
  "indexmap",
  "log",
- "wasm-encoder 0.19.1 (git+https://github.com/bytecodealliance/wasm-tools)",
- "wasmparser 0.94.0 (git+https://github.com/bytecodealliance/wasm-tools)",
- "wat 1.0.51 (git+https://github.com/bytecodealliance/wasm-tools)",
+ "wasm-encoder",
+ "wasmparser",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#001e5fcb1d0bd753e4177c224f7d916e3cdbecbf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893834cffb239f88413eead7cf91862a6f24c2233afae15d7808256d8c58f91e"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-entity",
 ]
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -258,12 +258,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 
 [[package]]
 name = "cranelift-egraph"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-entity",
  "fxhash",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "serde",
 ]
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -295,12 +295,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 
 [[package]]
 name = "cranelift-native"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.91.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cfg-if",
 ]
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "anyhow",
  "base64",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1617,12 +1617,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "object",
  "once_cell",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "3.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "anyhow",
  "cc",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "4.0.0"
-source = "git+https://github.com/alexcrichton/wasmtime?branch=update-wasm-tools#ff73172efeeba921cb678b2dc280031cbef1bfb9"
+source = "git+https://github.com/bytecodealliance/wasmtime#b305f251fbee6c726a7237dda6a8346e21940040"
 dependencies = [
  "cranelift-entity",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,14 @@ clap = { version = "4.0.9", features = ["derive"] }
 env_logger = "0.9.1"
 indexmap = "1.9.1"
 
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", features = ["component-model"] }
-wasmtime-environ = { git = "https://github.com/bytecodealliance/wasmtime" }
-wasmprinter = "0.2.43"
-wasmparser = "0.94.0"
-wasm-encoder = "0.19.1"
-wat = "1.0.51"
+wasmtime = { git = 'https://github.com/alexcrichton/wasmtime', branch = 'update-wasm-tools', features = ["component-model"] }
+wasmtime-environ = { git = 'https://github.com/alexcrichton/wasmtime', branch = 'update-wasm-tools' }
+wasmprinter = "0.2.44"
+wasmparser = "0.95.0"
+wasm-encoder = "0.20.0"
+wat = "1.0.52"
+wit-parser = "0.3"
+wit-component = "0.3.1"
 
 wit-bindgen-core = { path = 'crates/bindgen-core', version = '0.3.0' }
 wit-bindgen-gen-guest-c = { path = 'crates/gen-guest-c', version = '0.3.0' }
@@ -42,8 +44,6 @@ wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', version = '0.3.0' }
 wit-bindgen-gen-rust-lib = { path = 'crates/gen-rust-lib', version = '0.3.0' }
 wit-bindgen-guest-rust = { path = 'crates/guest-rust', version = '0.3.0', default-features = false }
 wit-bindgen-host-wasmtime-rust = { path = 'crates/host-wasmtime-rust', version = '0.3.0' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
 wit-bindgen-rust-macro-shared = { path = 'crates/rust-macro-shared', version = '0.3.0' }
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ clap = { version = "4.0.9", features = ["derive"] }
 env_logger = "0.9.1"
 indexmap = "1.9.1"
 
-wasmtime = { git = 'https://github.com/alexcrichton/wasmtime', branch = 'update-wasm-tools', features = ["component-model"] }
-wasmtime-environ = { git = 'https://github.com/alexcrichton/wasmtime', branch = 'update-wasm-tools' }
+wasmtime = { git = 'https://github.com/bytecodealliance/wasmtime', features = ["component-model"] }
+wasmtime-environ = { git = 'https://github.com/bytecodealliance/wasmtime' }
 wasmprinter = "0.2.44"
 wasmparser = "0.95.0"
 wasm-encoder = "0.20.0"

--- a/crates/bindgen-core/src/lib.rs
+++ b/crates/bindgen-core/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 use std::fmt::{self, Write};
 use std::ops::Deref;
-use wit_component::ComponentInterfaces;
 use wit_parser::*;
 
 pub use wit_parser;
@@ -413,18 +412,18 @@ mod tests {
 }
 
 pub trait WorldGenerator {
-    fn generate(&mut self, name: &str, interfaces: &ComponentInterfaces, files: &mut Files) {
-        self.preprocess(name);
-        for (name, import) in interfaces.imports.iter() {
+    fn generate(&mut self, world: &World, files: &mut Files) {
+        self.preprocess(&world.name);
+        for (name, import) in world.imports.iter() {
             self.import(name, import, files);
         }
-        for (name, export) in interfaces.exports.iter() {
+        for (name, export) in world.exports.iter() {
             self.export(name, export, files);
         }
-        if let Some(iface) = &interfaces.default {
-            self.export_default(name, iface, files);
+        if let Some(iface) = &world.default {
+            self.export_default(&world.name, iface, files);
         }
-        self.finish(name, interfaces, files);
+        self.finish(world, files);
     }
 
     fn preprocess(&mut self, name: &str) {
@@ -434,7 +433,7 @@ pub trait WorldGenerator {
     fn import(&mut self, name: &str, iface: &Interface, files: &mut Files);
     fn export(&mut self, name: &str, iface: &Interface, files: &mut Files);
     fn export_default(&mut self, name: &str, iface: &Interface, files: &mut Files);
-    fn finish(&mut self, name: &str, interfaces: &ComponentInterfaces, files: &mut Files);
+    fn finish(&mut self, world: &World, files: &mut Files);
 }
 
 /// This is a possible replacement for the `Generator` trait above, currently

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -10,7 +10,7 @@ use wit_bindgen_core::wit_parser::abi::{
 use wit_bindgen_core::{
     uwrite, uwriteln, wit_parser::*, Files, InterfaceGenerator as _, Ns, WorldGenerator,
 };
-use wit_component::{ComponentInterfaces, StringEncoding};
+use wit_component::StringEncoding;
 
 #[derive(Default)]
 struct C {
@@ -119,10 +119,10 @@ impl WorldGenerator for C {
         gen.gen.src.append(&gen.src);
     }
 
-    fn finish(&mut self, name: &str, interfaces: &ComponentInterfaces, files: &mut Files) {
-        let linking_symbol = component_type_object::linking_symbol(name);
+    fn finish(&mut self, world: &World, files: &mut Files) {
+        let linking_symbol = component_type_object::linking_symbol(&world.name);
         self.include("<stdlib.h>");
-        let snake = name.to_snake_case();
+        let snake = world.name.to_snake_case();
         uwrite!(
             self.src.c_adapters,
             "
@@ -203,7 +203,7 @@ impl WorldGenerator for C {
             #define __BINDINGS_{0}_H
             #ifdef __cplusplus
             extern \"C\" {{",
-            name.to_shouty_snake_case(),
+            world.name.to_shouty_snake_case(),
         );
 
         // Deindent the extern C { declaration
@@ -284,7 +284,7 @@ impl WorldGenerator for C {
         files.push(&format!("{snake}.h"), h_str.as_bytes());
         files.push(
             &format!("{snake}_component_type.o",),
-            component_type_object::object(name, interfaces, self.opts.string_encoding)
+            component_type_object::object(world, self.opts.string_encoding)
                 .unwrap()
                 .as_slice(),
         );

--- a/crates/gen-guest-c/tests/codegen.rs
+++ b/crates/gen-guest-c/tests/codegen.rs
@@ -10,10 +10,10 @@ macro_rules! codegen_test {
             test_helpers::run_world_codegen_test(
                 "guest-c",
                 $test.as_ref(),
-                |name, interfaces, files| {
+                |world, files| {
                     wit_bindgen_gen_guest_c::Opts::default()
                         .build()
-                        .generate(name, interfaces, files)
+                        .generate(world, files)
                 },
                 verify,
             )

--- a/crates/gen-guest-teavm-java/src/lib.rs
+++ b/crates/gen-guest-teavm-java/src/lib.rs
@@ -10,11 +10,10 @@ use wit_bindgen_core::{
     wit_parser::{
         abi::{AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType},
         Case, Docs, Enum, Flags, FlagsRepr, Function, FunctionKind, Int, Interface, Record,
-        Result_, SizeAlign, Tuple, Type, TypeDefKind, TypeId, Union, Variant,
+        Result_, SizeAlign, Tuple, Type, TypeDefKind, TypeId, Union, Variant, World,
     },
     Files, InterfaceGenerator as _, Ns, WorldGenerator,
 };
-use wit_component::ComponentInterfaces;
 
 const IMPORTS: &str = "\
 import java.nio.charset.StandardCharsets;
@@ -113,9 +112,9 @@ impl WorldGenerator for TeaVmJava {
         gen.add_class();
     }
 
-    fn finish(&mut self, name: &str, interfaces: &ComponentInterfaces, files: &mut Files) {
-        let package = format!("wit_{}", name.to_snake_case());
-        let name = name.to_upper_camel_case();
+    fn finish(&mut self, world: &World, files: &mut Files) {
+        let package = format!("wit_{}", world.name.to_snake_case());
+        let name = world.name.to_upper_camel_case();
 
         let mut src = String::new();
 
@@ -132,7 +131,7 @@ impl WorldGenerator for TeaVmJava {
         );
 
         let component_type =
-            wit_component::metadata::encode(interfaces, wit_component::StringEncoding::UTF8)
+            wit_component::metadata::encode(world, wit_component::StringEncoding::UTF8)
                 .into_iter()
                 .map(|byte| format!("{byte:02x}"))
                 .collect::<Vec<_>>()

--- a/crates/gen-guest-teavm-java/tests/codegen.rs
+++ b/crates/gen-guest-teavm-java/tests/codegen.rs
@@ -10,12 +10,12 @@ macro_rules! codegen_test {
             test_helpers::run_world_codegen_test(
                 "guest-teavm-java",
                 $test.as_ref(),
-                |name, interfaces, files| {
+                |world, files| {
                     wit_bindgen_gen_guest_teavm_java::Opts {
                         generate_stub: true,
                     }
                     .build()
-                    .generate(name, interfaces, files)
+                    .generate(world, files)
                 },
                 verify,
             )

--- a/crates/gen-host-wasmtime-rust/src/lib.rs
+++ b/crates/gen-host-wasmtime-rust/src/lib.rs
@@ -9,7 +9,6 @@ use wit_bindgen_core::{
     WorldGenerator,
 };
 use wit_bindgen_gen_rust_lib::{FnSig, RustGenerator, TypeMode};
-use wit_component::ComponentInterfaces;
 
 #[derive(Default)]
 struct Wasmtime {
@@ -177,8 +176,8 @@ impl WorldGenerator for Wasmtime {
         self.src.push_str(&src);
     }
 
-    fn finish(&mut self, name: &str, _interfaces: &ComponentInterfaces, files: &mut Files) {
-        let camel = name.to_upper_camel_case();
+    fn finish(&mut self, world: &World, files: &mut Files) {
+        let camel = world.name.to_upper_camel_case();
         uwriteln!(self.src, "pub struct {camel} {{");
         for (name, (ty, _)) in self.exports.fields.iter() {
             uwriteln!(self.src, "{name}: {ty},");
@@ -265,7 +264,7 @@ impl WorldGenerator for Wasmtime {
             assert!(status.success());
         }
 
-        files.push(&format!("{name}.rs"), src.as_bytes());
+        files.push(&format!("{}.rs", world.name), src.as_bytes());
     }
 }
 

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -5,7 +5,6 @@ use std::fmt::Write;
 use wit_bindgen_core::{
     uwriteln, wit_parser, Files, InterfaceGenerator as _, Source, WorldGenerator,
 };
-use wit_component::ComponentInterfaces;
 use wit_parser::*;
 
 #[derive(Default)]
@@ -51,7 +50,7 @@ impl WorldGenerator for Markdown {
         gen.funcs();
     }
 
-    fn finish(&mut self, name: &str, _interfaces: &ComponentInterfaces, files: &mut Files) {
+    fn finish(&mut self, world: &World, files: &mut Files) {
         let parser = Parser::new(&self.src);
         let mut events = Vec::new();
         for event in parser {
@@ -69,8 +68,8 @@ impl WorldGenerator for Markdown {
         let mut html_output = String::new();
         html::push_html(&mut html_output, events.into_iter());
 
-        files.push(&format!("{name}.md"), self.src.as_bytes());
-        files.push(&format!("{name}.html"), html_output.as_bytes());
+        files.push(&format!("{}.md", world.name), self.src.as_bytes());
+        files.push(&format!("{}.html", world.name), html_output.as_bytes());
     }
 }
 

--- a/crates/rust-macro-shared/src/lib.rs
+++ b/crates/rust-macro-shared/src/lib.rs
@@ -8,7 +8,6 @@ use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
 use wit_bindgen_core::{wit_parser::World, Files, WorldGenerator};
-use wit_component::ComponentInterfaces;
 
 pub fn generate<F, O>(
     input: TokenStream,
@@ -21,9 +20,7 @@ where
     let input = syn::parse_macro_input!(input as Opts<F, O>);
     let mut gen = mkgen(input.opts);
     let mut files = Files::default();
-    let name = input.world.name.clone();
-    let interfaces = ComponentInterfaces::from(input.world);
-    gen.generate(&name, &interfaces, &mut files);
+    gen.generate(&input.world, &mut files);
 
     let (_, contents) = files.iter().next().unwrap();
 

--- a/crates/wit-bindgen-demo/src/lib.rs
+++ b/crates/wit-bindgen-demo/src/lib.rs
@@ -3,7 +3,6 @@ use std::sync::Once;
 use wit_bindgen_core::component::ComponentGenerator;
 use wit_bindgen_core::wit_parser::World;
 use wit_bindgen_core::{Files, WorldGenerator};
-use wit_component::ComponentInterfaces;
 
 wit_bindgen_guest_rust::generate!("demo.wit");
 
@@ -50,11 +49,9 @@ fn init() {
 
 fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Options) -> Result<()> {
     let world = World::parse("input", &wit)?;
-    let name = world.name.clone();
-    let interfaces = ComponentInterfaces::from(world);
 
     let gen_world = |mut gen: Box<dyn WorldGenerator>, files: &mut Files| {
-        gen.generate(&name, &interfaces, files);
+        gen.generate(&world, files);
     };
 
     // This generator takes a component as input as opposed to an `Interface`.
@@ -65,10 +62,10 @@ fn render(lang: demo::Lang, wit: &str, files: &mut Files, options: &demo::Option
     // interface and dummy module.  Finally this component is fed into the host
     // generator which gives us the files we want.
     let gen_component = |mut gen: Box<dyn ComponentGenerator>, files: &mut Files| {
-        let dummy = test_helpers::dummy_module(&interfaces);
+        let dummy = test_helpers::dummy_module(&world);
         let wasm = wit_component::ComponentEncoder::default()
             .module(&dummy)?
-            .interfaces(interfaces.clone(), wit_component::StringEncoding::UTF8)?
+            .world(world.clone(), wit_component::StringEncoding::UTF8)?
             .encode()?;
         wit_bindgen_core::component::generate(&mut *gen, "input", &wasm, files)
     };

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 use std::path::{Path, PathBuf};
 use wit_bindgen_core::component::ComponentGenerator;
 use wit_bindgen_core::{wit_parser, Files, WorldGenerator};
-use wit_component::ComponentInterfaces;
 use wit_parser::World;
 
 /// Helper for passing VERSION to opt.
@@ -193,9 +192,7 @@ fn gen_world(
     opts: WorldOpt,
     files: &mut Files,
 ) -> Result<()> {
-    let name = opts.wit.name.clone();
-    let interfaces = ComponentInterfaces::from(opts.wit);
-    generator.generate(&name, &interfaces, files);
+    generator.generate(&opts.wit, files);
     Ok(())
 }
 

--- a/tests/runtime/invalid/host.rs
+++ b/tests/runtime/invalid/host.rs
@@ -3,7 +3,7 @@ wit_bindgen_host_wasmtime_rust::generate!("../../tests/runtime/invalid/world.wit
 use anyhow::{Context, Result};
 use imports::*;
 use wasmtime::component::{Component, Linker};
-use wasmtime::{Engine, Store, Trap};
+use wasmtime::{Engine, Store};
 
 #[derive(Default)]
 pub struct MyImports;
@@ -108,15 +108,16 @@ fn run(wasm: &str) -> Result<()> {
 
     return Ok(());
 
-    fn assert_err(result: Result<(), anyhow::Error>, err: &str) -> Result<()> {
+    fn assert_err(result: Result<()>, err: &str) -> Result<()> {
         match result {
             Ok(()) => anyhow::bail!("export didn't trap"),
-            Err(e) => match e.downcast_ref::<Trap>() {
-                Some(e) if e.to_string().contains(err) => Ok(()),
-                Some(_) | None => {
+            Err(e) => {
+                if format!("{e:?}").contains(err) {
+                    Ok(())
+                } else {
                     Err(e).with_context(|| format!("expected trap containing \"{}\"", err))
                 }
-            },
+            }
         }
     }
 }

--- a/tests/runtime/results/host.rs
+++ b/tests/runtime/results/host.rs
@@ -127,11 +127,7 @@ fn run(wasm: &str) -> anyhow::Result<()> {
     ));
     let e = exports.record_error(&mut store, 1.0);
     assert!(e.is_err());
-    assert!(e
-        .err()
-        .unwrap()
-        .to_string()
-        .starts_with("a somewhat ergonomic trap\nwasm backtrace:\n"));
+    assert!(format!("{:?}", e.err().unwrap()).contains("a somewhat ergonomic trap"));
 
     let (exports, mut store) = create()?;
     assert!(exports.record_error(&mut store, 2.0)?.is_ok());
@@ -149,22 +145,14 @@ fn run(wasm: &str) -> anyhow::Result<()> {
     ));
     let e = exports.variant_error(&mut store, 2.0);
     assert!(e.is_err());
-    assert!(e
-        .err()
-        .unwrap()
-        .to_string()
-        .starts_with("my very own trap\nwasm backtrace:\n"));
+    assert!(format!("{:?}", e.err().unwrap()).contains("my very own trap"));
 
     let (exports, mut store) = create()?;
     assert_eq!(exports.empty_error(&mut store, 0)?, Err(()));
 
     let e = exports.empty_error(&mut store, 1);
     assert!(e.is_err());
-    assert!(e
-        .err()
-        .unwrap()
-        .to_string()
-        .starts_with("outer result trap\nwasm backtrace:\n"));
+    assert!(format!("{:?}", e.err().unwrap()).contains("outer result trap"));
 
     let (exports, mut store) = create()?;
     assert_eq!(exports.empty_error(&mut store, 2)?, Ok(2));


### PR DESCRIPTION
This commit updates this repository to published versions of the `wasm-tools` family of crates. Additionally Wasmtime is updated with the same upstream versions of the `wasm-tools` crates. Put together this updates everything to the most recent version of the component model with optional URLs encoded and an updated version of Wasmtime.

Part of this transition is the removal of
`wit_component::ComponentInterfaces` which is plumbed through as part of this commit.