### PR TITLE
gen-guest-c: define OK constant for scalar enum results

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -237,7 +237,9 @@ impl WorldGenerator for C {
             );
         }
         if self.result_enums {
-            uwriteln!(h_str, "
+            uwriteln!(
+                h_str,
+                "
                 #define {}_RESULT_OK -1",
                 snake.to_uppercase()
             );

--- a/tests/runtime/flavorful/host.rs
+++ b/tests/runtime/flavorful/host.rs
@@ -4,7 +4,9 @@ use wit_bindgen_host_wasmtime_rust::Result as HostResult;
 wit_bindgen_host_wasmtime_rust::generate!("../../tests/runtime/flavorful/world.wit");
 
 #[derive(Default)]
-pub struct MyImports;
+pub struct MyImports {
+    errored: bool
+}
 
 impl imports::Imports for MyImports {
     fn f_list_in_record1(&mut self, ty: imports::ListInRecord1) -> Result<()> {
@@ -57,10 +59,14 @@ impl imports::Imports for MyImports {
     }
 
     fn errno_result(&mut self) -> HostResult<(), imports::MyErrno> {
+        if self.errored {
+            return Ok(());
+        }
         imports::MyErrno::A.to_string();
         format!("{:?}", imports::MyErrno::A);
         fn assert_error<T: std::error::Error>() {}
         assert_error::<imports::MyErrno>();
+        self.errored = true;
         Err(imports::MyErrno::B)?
     }
 

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -24,8 +24,12 @@ export function fListInVariant3(x: any) {
   assert.strictEqual(x, 'input3');
   return 'output3';
 }
+let firstErr = true;
 export function errnoResult() {
-  throw new Error('b');
+  if (firstErr) {
+    firstErr = false;
+    throw new Error('b');
+  }
 }
 export function listTypedefs(x: any, y: any) {
   assert.strictEqual(x, 'typedef1');

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -63,6 +63,8 @@ void flavorful_test_imports() {
 
   assert(imports_errno_result() == IMPORTS_MY_ERRNO_B);
 
+  assert(imports_errno_result() == IMPORTS_RESULT_MY_ERRNO_OK);
+
   {
     flavorful_string_t a;
     flavorful_string_set(&a, "typedef1");

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -43,6 +43,8 @@ impl Flavorful for Component {
         fn assert_error<T: std::error::Error>() {}
         assert_error::<MyErrno>();
 
+        assert!(errno_result().is_ok());
+
         let (a, b) = list_typedefs("typedef1", &["typedef2"]);
         assert_eq!(a, b"typedef3");
         assert_eq!(b.len(), 1);


### PR DESCRIPTION
Defines a new `WORLD_RESULT_OK` constant in the case where there is scalar enum result flattening.

It may make sense to have dedicated helper functions for the particular enum types being returned, but this should cover the use case for now at least. The result structs are also still being generated although unused.

Also fixes some whitespace handling.