### PR TITLE
gen-guest-c: c strings pass by value

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -1394,23 +1394,13 @@ impl InterfaceGenerator<'_> {
 
     fn free(&mut self, ty: &Type, expr: &str) {
         if self.is_string(ty) {
-            self.src.c_helpers("free(");
-            if expr.chars().nth(0).unwrap() == '&' {
-                self.src.c_helpers(&expr[1..]);
-            } else {
-                self.src.c_helpers(expr);
-            }
-            self.src.c_helpers(".ptr");
-            self.src.c_helpers(");\n");
+            uwriteln!(self.src.c_helpers, "free({expr}.ptr);");
         } else {
             let prev = mem::take(&mut self.src.h_helpers);
             self.print_namespace(SourceType::HHelpers);
             self.print_ty_name(SourceType::HHelpers, ty);
-            let name = mem::replace(&mut self.src.h_helpers, prev);
-            self.src.c_helpers(&name);
-            self.src.c_helpers("_free(");
-            self.src.c_helpers(expr);
-            self.src.c_helpers(");\n");
+            let name = mem::replace(&mut self.src.h_helpers, prev).to_string();
+            uwriteln!(self.src.c_helpers, "{name}_free({expr});");
         }
     }
 }

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -6,7 +6,7 @@
 void flavorful_test_imports() {
   {
     imports_list_in_record1_t a;
-    flavorful_string_set(&a.a, "list_in_record1");
+    a.a = flavorful_string("list_in_record1");
     imports_f_list_in_record1(&a);
 
     imports_list_in_record2_t b;
@@ -17,7 +17,7 @@ void flavorful_test_imports() {
 
   {
     imports_list_in_record3_t a, b;
-    flavorful_string_set(&a.a, "list_in_record3 input");
+    a.a = flavorful_string("list_in_record3 input");
     imports_f_list_in_record3(&a, &b);
     assert(memcmp(b.a.ptr, "list_in_record3 output", b.a.len) == 0);
     imports_list_in_record3_free(&b);
@@ -25,7 +25,7 @@ void flavorful_test_imports() {
 
   {
     imports_list_in_record4_t a, b;
-    flavorful_string_set(&a.a, "input4");
+    a.a = flavorful_string("input4");
     imports_f_list_in_record4(&a, &b);
     assert(memcmp(b.a.ptr, "result4", b.a.len) == 0);
     imports_list_in_record4_free(&b);
@@ -36,11 +36,11 @@ void flavorful_test_imports() {
     imports_list_in_variant1_v2_t b;
     imports_list_in_variant1_v3_t c;
     a.is_some = true;
-    flavorful_string_set(&a.val, "foo");
+    a.val = flavorful_string("foo");
     b.is_err = true;
-    flavorful_string_set(&b.val.err, "bar");
+    b.val.err = flavorful_string("bar");
     c.tag = 0;
-    flavorful_string_set(&c.val.f0, "baz");
+    c.val.f0 = flavorful_string("baz");
     imports_f_list_in_variant1(&a, &b, &c);
   }
 
@@ -48,32 +48,30 @@ void flavorful_test_imports() {
     flavorful_string_t a;
     assert(imports_f_list_in_variant2(&a));
     assert(memcmp(a.ptr, "list_in_variant2", a.len) == 0);
-    flavorful_string_free(&a);
+    flavorful_string_free(a);
   }
 
   {
     imports_list_in_variant3_t a;
     a.is_some = true;
-    flavorful_string_set(&a.val, "input3");
+    a.val = flavorful_string("input3");
     flavorful_string_t b;
     assert(imports_f_list_in_variant3(&a, &b));
     assert(memcmp(b.ptr, "output3", b.len) == 0);
-    flavorful_string_free(&b);
+    flavorful_string_free(b);
   }
 
   assert(imports_errno_result() == IMPORTS_MY_ERRNO_B);
 
   {
-    flavorful_string_t a;
-    flavorful_string_set(&a, "typedef1");
-    flavorful_string_t b_str;
-    flavorful_string_set(&b_str, "typedef2");
+    flavorful_string_t a = flavorful_string("typedef1");
+    flavorful_string_t b_str = flavorful_string("typedef2");
     imports_list_typedef3_t b;
     b.ptr = &b_str;
     b.len = 1;
     imports_list_typedef2_t c;
     imports_list_typedef3_t d;
-    imports_list_typedefs(&a, &b, &c, &d);
+    imports_list_typedefs(a, &b, &c, &d);
 
     assert(memcmp(c.ptr, "typedef3", c.len) == 0);
     assert(d.len == 1);
@@ -132,19 +130,19 @@ void flavorful_f_list_in_record1(flavorful_list_in_record1_t *a) {
 }
 
 void flavorful_f_list_in_record2(flavorful_list_in_record2_t *ret0) {
-  flavorful_string_dup(&ret0->a, "list_in_record2");
+  ret0->a = flavorful_string_dup("list_in_record2");
 }
 
 void flavorful_f_list_in_record3(flavorful_list_in_record3_t *a, flavorful_list_in_record3_t *ret0) {
   assert(memcmp(a->a.ptr, "list_in_record3 input", a->a.len) == 0);
   flavorful_list_in_record3_free(a);
-  flavorful_string_dup(&ret0->a, "list_in_record3 output");
+  ret0->a = flavorful_string_dup("list_in_record3 output");
 }
 
 void flavorful_f_list_in_record4(flavorful_list_in_alias_t *a, flavorful_list_in_alias_t *ret0) {
   assert(memcmp(a->a.ptr, "input4", a->a.len) == 0);
   flavorful_list_in_alias_free(a);
-  flavorful_string_dup(&ret0->a, "result4");
+  ret0->a = flavorful_string_dup("result4");
 }
 
 void flavorful_f_list_in_variant1(flavorful_list_in_variant1_v1_t *a, flavorful_list_in_variant1_v2_t *b, flavorful_list_in_variant1_v3_t *c) {
@@ -162,7 +160,7 @@ void flavorful_f_list_in_variant1(flavorful_list_in_variant1_v1_t *a, flavorful_
 }
 
 bool flavorful_f_list_in_variant2(flavorful_string_t *ret0) {
-  flavorful_string_dup(ret0, "list_in_variant2");
+  *ret0 = flavorful_string_dup("list_in_variant2");
   return true;
 }
 
@@ -170,7 +168,7 @@ bool flavorful_f_list_in_variant3(flavorful_list_in_variant3_t *a, flavorful_str
   assert(a->is_some);
   assert(memcmp(a->val.ptr, "input3", a->val.len) == 0);
   flavorful_list_in_variant3_free(a);
-  flavorful_string_dup(ret0, "output3");
+  *ret0 = flavorful_string_dup("output3");
   return true;
 }
 
@@ -178,9 +176,9 @@ flavorful_my_errno_t flavorful_errno_result(void) {
   return FLAVORFUL_MY_ERRNO_B;
 }
 
-void flavorful_list_typedefs(flavorful_list_typedef_t *a, flavorful_list_typedef3_t *c, flavorful_list_typedef2_t *ret0, flavorful_list_typedef3_t *ret1) {
-  assert(memcmp(a->ptr, "typedef1", a->len) == 0);
-  flavorful_list_typedef_free(a);
+void flavorful_list_typedefs(flavorful_list_typedef_t a, flavorful_list_typedef3_t *c, flavorful_list_typedef2_t *ret0, flavorful_list_typedef3_t *ret1) {
+  assert(memcmp(a.ptr, "typedef1", a.len) == 0);
+  flavorful_string_free(a);
 
   assert(c->len == 1);
   assert(memcmp(c->ptr[0].ptr, "typedef2", c->ptr[0].len) == 0);
@@ -192,5 +190,5 @@ void flavorful_list_typedefs(flavorful_list_typedef_t *a, flavorful_list_typedef
 
   ret1->ptr = malloc(sizeof(flavorful_string_t));
   ret1->len = 1;
-  flavorful_string_dup(&ret1->ptr[0], "typedef4");
+  ret1->ptr[0] = flavorful_string_dup("typedef4");
 }

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -21,9 +21,8 @@ void lists_test_imports() {
   }
 
   {
-    lists_string_t a;
-    lists_string_set(&a, "");
-    imports_empty_string_param(&a);
+    lists_string_t a = lists_string("");
+    imports_empty_string_param(a);
   }
 
   {
@@ -47,16 +46,16 @@ void lists_test_imports() {
   }
 
   {
-    lists_string_t a;
-    lists_string_set(&a, "foo");
-    imports_list_param2(&a);
+    lists_string_t a = lists_string("foo");
+    imports_list_param2(a);
   }
 
   {
-    lists_string_t list[3];
-    lists_string_set(&list[0], "foo");
-    lists_string_set(&list[1], "bar");
-    lists_string_set(&list[2], "baz");
+    lists_string_t list[3] = {
+      lists_string("foo"),
+      lists_string("bar"),
+      lists_string("baz")
+    };
     imports_list_string_t a;
     a.ptr = list;
     a.len = 3;
@@ -64,11 +63,13 @@ void lists_test_imports() {
   }
 
   {
-    lists_string_t list1[2];
-    lists_string_t list2[1];
-    lists_string_set(&list1[0], "foo");
-    lists_string_set(&list1[1], "bar");
-    lists_string_set(&list2[0], "baz");
+    lists_string_t list1[2] = {
+      lists_string("foo"),
+      lists_string("bar")
+    };
+    lists_string_t list2[1] = {
+      lists_string("baz")
+    };
     imports_list_list_string_t a;
     a.ptr[0].len = 2;
     a.ptr[0].ptr = list1;
@@ -91,7 +92,7 @@ void lists_test_imports() {
     imports_list_result2(&a);
     assert(a.len == 6);
     assert(memcmp(a.ptr, "hello!", 6) == 0);
-    lists_string_free(&a);
+    lists_string_free(a);
   }
 
   {
@@ -130,29 +131,29 @@ void lists_test_imports() {
   }
 
   {
-    lists_string_t a, b;
-    lists_string_set(&a, "x");
-    imports_string_roundtrip(&a, &b);
+    lists_string_t a = lists_string("x");
+    lists_string_t b;
+    imports_string_roundtrip(a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_string_free(&b);
+    lists_string_free(b);
 
-    lists_string_set(&a, "");
-    imports_string_roundtrip(&a, &b);
+    a = lists_string("");
+    imports_string_roundtrip(a, &b);
     assert(b.len == a.len);
-    lists_string_free(&b);
+    lists_string_free(b);
 
-    lists_string_set(&a, "hello");
-    imports_string_roundtrip(&a, &b);
-    assert(b.len == a.len);
-    assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_string_free(&b);
-
-    lists_string_set(&a, "hello ⚑ world");
-    imports_string_roundtrip(&a, &b);
+    a = lists_string("hello");
+    imports_string_roundtrip(a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_string_free(&b);
+    lists_string_free(b);
+
+    a = lists_string("hello ⚑ world");
+    imports_string_roundtrip(a, &b);
+    assert(b.len == a.len);
+    assert(memcmp(b.ptr, a.ptr, a.len) == 0);
+    lists_string_free(b);
   }
 
   {
@@ -232,8 +233,8 @@ void lists_empty_list_param(lists_list_u8_t *a) {
   assert(a->len == 0);
 }
 
-void lists_empty_string_param(lists_string_t *a) {
-  assert(a->len == 0);
+void lists_empty_string_param(lists_string_t a) {
+  assert(a.len == 0);
 }
 
 void lists_empty_list_result(lists_list_u8_t *ret0) {
@@ -255,11 +256,11 @@ void lists_list_param(lists_list_u8_t *a) {
   lists_list_u8_free(a);
 }
 
-void lists_list_param2(lists_string_t *a) {
-  assert(a->len == 3);
-  assert(a->ptr[0] == 'f');
-  assert(a->ptr[1] == 'o');
-  assert(a->ptr[2] == 'o');
+void lists_list_param2(lists_string_t a) {
+  assert(a.len == 3);
+  assert(a.ptr[0] == 'f');
+  assert(a.ptr[1] == 'o');
+  assert(a.ptr[2] == 'o');
   lists_string_free(a);
 }
 
@@ -317,21 +318,21 @@ void lists_list_result(lists_list_u8_t *ret0) {
 }
 
 void lists_list_result2(lists_string_t *ret0) {
-  lists_string_dup(ret0, "hello!");
+  *ret0 = lists_string_dup("hello!");
 }
 
 void lists_list_result3(lists_list_string_t *ret0) {
   ret0->len = 2;
   ret0->ptr = malloc(2 * sizeof(lists_string_t));
 
-  lists_string_dup(&ret0->ptr[0], "hello,");
-  lists_string_dup(&ret0->ptr[1], "world!");
+  ret0->ptr[0] = lists_string_dup("hello,");
+  ret0->ptr[1] = lists_string_dup("world!");
 }
 
 void lists_list_roundtrip(lists_list_u8_t *a, lists_list_u8_t *ret0) {
   *ret0 = *a;
 }
 
-void lists_string_roundtrip(lists_string_t *a, lists_string_t *ret0) {
-  *ret0 = *a;
+void lists_string_roundtrip(lists_string_t a, lists_string_t *ret0) {
+  *ret0 = a;
 }

--- a/tests/runtime/strings/wasm_utf16.c
+++ b/tests/runtime/strings/wasm_utf16.c
@@ -6,29 +6,28 @@
 
 char16_t STR_BUFFER[500];
 
-void assert_str(strings_string_t* str, char16_t* expected) {
+void assert_str(strings_string_t str, char16_t* expected) {
   size_t expected_len = 0;
   while (expected[expected_len])
     expected_len++;
-  assert(str->len == expected_len);
-  assert(memcmp(str->ptr, expected, expected_len * 2) == 0);
+  assert(str.len == expected_len);
+  assert(memcmp(str.ptr, expected, expected_len * 2) == 0);
 }
 
 void strings_test_imports() {
-  strings_string_t str1;
-  strings_string_set(&str1, u"latin utf16");
-  imports_take_basic(&str1);
+  strings_string_t str1 = strings_string(u"latin utf16");
+  imports_take_basic(str1);
 
   strings_string_t str2;
   imports_return_unicode(&str2);
-  assert_str(&str2, u"🚀🚀🚀 𠈄𓀀");
-  strings_string_free(&str2);
+  assert_str(str2, u"🚀🚀🚀 𠈄𓀀");
+  strings_string_free(str2);
 }
 
-void strings_roundtrip(strings_string_t *str, strings_string_t *ret) {
-  assert(str->len > 0);
-  ret->len = str->len;
+void strings_roundtrip(strings_string_t str, strings_string_t *ret) {
+  assert(str.len > 0);
+  ret->len = str.len;
   ret->ptr = malloc(ret->len * 2);
-  memcpy(ret->ptr, str->ptr, 2 * ret->len);
+  memcpy(ret->ptr, str.ptr, 2 * ret->len);
   strings_string_free(str);
 }


### PR DESCRIPTION
This is an exploratory PR to see if it might be worth considering a value struct pattern for strings and possibly other two value struct types like lists, optionals and results when passed as parameters.

In theory this avoids memory operations, but I'm not sure how much benefit there really is. See the test changes for what this means in the APIs, it does feel slightly cleaner to me though.

Feedback very welcome, I can explore this path further / drop it as makes sense.