### PR TITLE
bug: multiple ret areas

### DIFF
--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -16,11 +16,18 @@ void flavorful_test_imports() {
   }
 
   {
-    imports_list_in_record3_t a, b;
-    flavorful_string_set(&a.a, "list_in_record3 input");
-    imports_f_list_in_record3(&a, &b);
-    assert(memcmp(b.a.ptr, "list_in_record3 output", b.a.len) == 0);
-    imports_list_in_record3_free(&b);
+    imports_list_in_record3_t a;
+    a.a.is_some = true;
+    a.b.is_some = false;
+    a.c.is_some = false;
+    a.d.is_some = false;
+    a.e.is_some = false;
+    a.f.is_some = false;
+    flavorful_string_set(&a.a.val, "list_in_record3 input");
+    imports_result_list_in_record3_u32_t ret;
+    imports_f_list_in_record3(&a, &ret);
+    assert(memcmp(ret.val.ok.a.val.ptr, "list_in_record3 output", ret.val.ok.a.val.len) == 0);
+    imports_list_in_record3_free(&ret.val.ok);
   }
 
   {

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -19,9 +19,13 @@ impl Flavorful for Component {
 
         assert_eq!(
             f_list_in_record3(ListInRecord3Param {
-                a: "list_in_record3 input"
-            })
-            .a,
+                a: Some("list_in_record3 input"),
+                b: None,
+                c: None,
+                d: None,
+                e: None,
+                f: None,
+            }).unwrap().a.unwrap(),
             "list_in_record3 output"
         );
 

--- a/tests/runtime/flavorful/world.wit
+++ b/tests/runtime/flavorful/world.wit
@@ -1,13 +1,20 @@
 interface imports {
   record list-in-record1 { a: string }
   record list-in-record2 { a: string }
-  record list-in-record3 { a: string }
+  record list-in-record3 {
+    a: option<string>,
+    b: option<list<u8>>,
+    c: option<string>,
+    d: option<u32>,
+    e: option<string>,
+    f: option<string>,
+  }
   record list-in-record4 { a: string }
   type list-in-alias = list-in-record4
 
   f-list-in-record1: func(a: list-in-record1)
   f-list-in-record2: func() -> list-in-record2
-  f-list-in-record3: func(a: list-in-record3) -> list-in-record3
+  f-list-in-record3: func(a: list-in-record3) -> result<_, u32>
   f-list-in-record4: func(a: list-in-alias) -> list-in-alias
 
   type list-in-variant1-v1 = option<string>

--- a/tests/runtime/flavorful/world.wit
+++ b/tests/runtime/flavorful/world.wit
@@ -14,7 +14,7 @@ interface imports {
 
   f-list-in-record1: func(a: list-in-record1)
   f-list-in-record2: func() -> list-in-record2
-  f-list-in-record3: func(a: list-in-record3) -> result<_, u32>
+  f-list-in-record3: func(a: list-in-record3) -> result<list-in-record3, u32>
   f-list-in-record4: func(a: list-in-alias) -> list-in-alias
 
   type list-in-variant1-v1 = option<string>


### PR DESCRIPTION
This demonstrates a bug, where for an imported function with a big enough record and result return, multiple ret areas end up being defined in that function.

Test case included demonstrating the issue, with a fix for the C generator case, but not the Rust host yet.

Guidance would be appreciated if this seems like the right sort of track to fix or not.