### PR TITLE
gen-guest-c: scalar enum result -> bool return, ok & err ptrs

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -895,11 +895,11 @@ impl InterfaceGenerator<'_> {
             }
             self.print_ty(SourceType::HFns, ty);
             self.src.h_fns(" *");
-            let name: String = if single_ret {
+            let name: String = if single_ret || result_rets && i == 0 {
                 "ret".into()
             } else if result_rets {
-                assert!(i < 2);
-                (if i == 0 { "ok" } else { "err" }).into()
+                assert!(i == 1);
+                "err".into()
             } else {
                 format!("ret{}", i)
             };

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -1480,7 +1480,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
     }
 
     fn check_all_retptrs_written(&self) {
-        // assert!(self.ret_store_cnt == self.sig.retptrs.len());
+        assert!(self.ret_store_cnt == self.sig.retptrs.len());
     }
 }
 

--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -897,15 +897,15 @@ impl InterfaceGenerator<'_> {
             }
             self.print_ty(SourceType::HFns, ty);
             self.src.h_fns(" *");
-            let name: String = if single_ret {
-                "ret".into()
-            } else if result_rets {
+            let name: String = if result_rets {
                 assert!(i <= 1);
                 if i == 0 && result_rets_has_ok_type {
                     "ret".into()
                 } else {
                     "err".into()
                 }
+            } else if single_ret {
+                "ret".into()
             } else {
                 format!("ret{}", i)
             };

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -61,9 +61,16 @@ void flavorful_test_imports() {
     flavorful_string_free(&b);
   }
 
-  assert(imports_errno_result() == IMPORTS_MY_ERRNO_B);
+  {
+    imports_my_errno_t errno;
+    assert(imports_errno_result(&errno));
+    assert(errno == IMPORTS_MY_ERRNO_B);
+  }
 
-  assert(imports_errno_result() == IMPORTS_RESULT_MY_ERRNO_OK);
+  {
+    imports_my_errno_t errno;
+    assert(imports_errno_result(&errno) == 0);
+  }
 
   {
     flavorful_string_t a;
@@ -176,8 +183,9 @@ bool flavorful_f_list_in_variant3(flavorful_list_in_variant3_t *a, flavorful_str
   return true;
 }
 
-flavorful_my_errno_t flavorful_errno_result(void) {
-  return FLAVORFUL_MY_ERRNO_B;
+bool flavorful_errno_result(flavorful_my_errno_t *err) {
+  *err = FLAVORFUL_MY_ERRNO_B;
+  return true;
 }
 
 void flavorful_list_typedefs(flavorful_list_typedef_t *a, flavorful_list_typedef3_t *c, flavorful_list_typedef2_t *ret0, flavorful_list_typedef3_t *ret1) {

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -19,24 +19,25 @@ void variants_test_imports() {
 
   {
     imports_result_u32_float32_t a;
-    imports_result_float64_u8_t b;
+    double b_ok;
+    uint8_t b_err;
 
     a.is_err = false;
     a.val.ok = 2;
-    imports_roundtrip_result(&a, &b);
-    assert(!b.is_err);
-    assert(b.val.ok == 2.0);
+    bool is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
+    assert(!is_err);
+    assert(b_ok == 2.0);
 
     a.val.ok = 4;
-    imports_roundtrip_result(&a, &b);
-    assert(!b.is_err);
-    assert(b.val.ok == 4);
+    is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
+    assert(!is_err);
+    assert(b_ok == 4);
 
     a.is_err = true;
     a.val.err = 5.3;
-    imports_roundtrip_result(&a, &b);
-    assert(b.is_err);
-    assert(b.val.err == 5);
+    is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
+    assert(is_err);
+    assert(b_err == 5);
   }
 
   assert(imports_roundtrip_enum(IMPORTS_E1_A) == IMPORTS_E1_A);
@@ -148,12 +149,13 @@ bool variants_roundtrip_option(variants_option_float32_t *a, uint8_t *ret0) {
   return a->is_some;
 }
 
-void variants_roundtrip_result(variants_result_u32_float32_t *a, variants_result_float64_u8_t *ret0) {
-  ret0->is_err = a->is_err;
+bool variants_roundtrip_result(variants_result_u32_float32_t *a, double *ok, uint8_t *err) {
   if (a->is_err) {
-    ret0->val.err = a->val.err;
+    *err = a->val.err;
+    return true;
   } else {
-    ret0->val.ok = a->val.ok;
+    *ok = a->val.ok;
+    return false;
   }
 }
 


### PR DESCRIPTION
This updates the result error enum handling to return a boolean instead of a flattened enum, with two possible return pointers - one for the success value and one for the error value.

It does seem slightly higher bandwidth in comparison to what we had before, in that there are three values and three writes instead of two values and two writes now.

I'm going to test out this diff in the js-compute-runtime bindings work, and see how noisy it looks.

The alternative is to completely unflatten the result and just have the double pointer situation from result -> ok / err pointer writes... still somewhat on the fence between the two approaches.

Fixes https://github.com/bytecodealliance/wit-bindgen/issues/449.