### PR TITLE
gen-guest-c: switch result boolean to indicate success

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -62,7 +62,7 @@ struct CSig {
 enum Scalar {
     Void,
     OptionBool(Type),
-    Result(bool),
+    ResultBool(bool),
     Type(Type),
 }
 
@@ -410,7 +410,7 @@ impl Return {
                 if let Some(err) = r.err {
                     self.retptrs.push(err);
                 }
-                self.scalar = Some(Scalar::Result(has_ok_type));
+                self.scalar = Some(Scalar::ResultBool(has_ok_type));
                 return;
             }
 
@@ -864,7 +864,7 @@ impl InterfaceGenerator<'_> {
         match &ret.scalar {
             None | Some(Scalar::Void) => self.src.h_fns("void"),
             Some(Scalar::OptionBool(_id)) => self.src.h_fns("bool"),
-            Some(Scalar::Result(has_ok_type)) => {
+            Some(Scalar::ResultBool(has_ok_type)) => {
                 result_rets = true;
                 result_rets_has_ok_type = *has_ok_type;
                 self.src.h_fns("bool");
@@ -2168,7 +2168,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         );
                         results.push(option_ret);
                     }
-                    Some(Scalar::Result(has_ok_type)) => {
+                    Some(Scalar::ResultBool(has_ok_type)) => {
                         let result_ty = self
                             .gen
                             .type_string(func.results.iter_types().next().unwrap());
@@ -2205,7 +2205,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         };
                         assert!(ret_iter.next().is_none());
                         uwrite!(self.src, "");
-                        uwriteln!(self.src, "{ret}.is_err =  {}({args});", self.sig.name);
+                        uwriteln!(self.src, "{ret}.is_err = !{}({args});", self.sig.name);
 
                         if let Some(err_name) = err_name {
                             uwriteln!(
@@ -2253,7 +2253,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         self.src.push_str(&variant);
                         self.src.push_str(".is_some;\n");
                     }
-                    Some(Scalar::Result(has_ok_type)) => {
+                    Some(Scalar::ResultBool(has_ok_type)) => {
                         assert_eq!(operands.len(), 1);
                         let variant = &operands[0];
                         assert!(self.sig.retptrs.len() <= 2);
@@ -2265,7 +2265,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         }
                         uwriteln!(
                             self.src,
-                            "   return 0;
+                            "   return 1;
                             }} else {{"
                         );
                         if self.sig.retptrs.len() == 2 {
@@ -2275,7 +2275,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         }
                         uwriteln!(
                             self.src,
-                            "   return 1;
+                            "   return 0;
                             }}"
                         );
                     }

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -63,13 +63,13 @@ void flavorful_test_imports() {
 
   {
     imports_my_errno_t errno;
-    assert(imports_errno_result(&errno));
+    assert(!imports_errno_result(&errno));
     assert(errno == IMPORTS_MY_ERRNO_B);
   }
 
   {
     imports_my_errno_t errno;
-    assert(imports_errno_result(&errno) == 0);
+    assert(imports_errno_result(&errno));
   }
 
   {
@@ -185,7 +185,7 @@ bool flavorful_f_list_in_variant3(flavorful_list_in_variant3_t *a, flavorful_str
 
 bool flavorful_errno_result(flavorful_my_errno_t *err) {
   *err = FLAVORFUL_MY_ERRNO_B;
-  return true;
+  return false;
 }
 
 void flavorful_list_typedefs(flavorful_list_typedef_t *a, flavorful_list_typedef3_t *c, flavorful_list_typedef2_t *ret0, flavorful_list_typedef3_t *ret1) {

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -24,19 +24,16 @@ void variants_test_imports() {
 
     a.is_err = false;
     a.val.ok = 2;
-    bool is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
-    assert(!is_err);
+    assert(imports_roundtrip_result(&a, &b_ok, &b_err));
     assert(b_ok == 2.0);
 
     a.val.ok = 4;
-    is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
-    assert(!is_err);
+    assert(imports_roundtrip_result(&a, &b_ok, &b_err));
     assert(b_ok == 4);
 
     a.is_err = true;
     a.val.err = 5.3;
-    is_err = imports_roundtrip_result(&a, &b_ok, &b_err);
-    assert(is_err);
+    assert(!imports_roundtrip_result(&a, &b_ok, &b_err));
     assert(b_err == 5);
   }
 
@@ -152,10 +149,10 @@ bool variants_roundtrip_option(variants_option_float32_t *a, uint8_t *ret0) {
 bool variants_roundtrip_result(variants_result_u32_float32_t *a, double *ok, uint8_t *err) {
   if (a->is_err) {
     *err = a->val.err;
-    return true;
+    return false;
   } else {
     *ok = a->val.ok;
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/bytecodealliance/wit-bindgen/commit/d47b6c53613f1fd3f927cce5116f9a53fcc1b1c5 - it's quite confusing having the `true` value for a result function mean failure when using booleans as opposed to code returns.

This PR reverses that so that the return boolean indicates success, and a `false` check means failure rather.