### PR TITLE
gen-guest-c: flatten optional params into nullable pointers

### DIFF
--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -41,7 +41,7 @@ void flavorful_test_imports() {
     flavorful_string_set(&b.val.err, "bar");
     c.tag = 0;
     flavorful_string_set(&c.val.f0, "baz");
-    imports_f_list_in_variant1(&a, &b, &c);
+    imports_f_list_in_variant1(&a.val, &b, &c);
   }
 
   {
@@ -56,7 +56,7 @@ void flavorful_test_imports() {
     a.is_some = true;
     flavorful_string_set(&a.val, "input3");
     flavorful_string_t b;
-    assert(imports_f_list_in_variant3(&a, &b));
+    assert(imports_f_list_in_variant3(&a.val, &b));
     assert(memcmp(b.ptr, "output3", b.len) == 0);
     flavorful_string_free(&b);
   }
@@ -156,10 +156,10 @@ void flavorful_f_list_in_record4(flavorful_list_in_alias_t *a, flavorful_list_in
   flavorful_string_dup(&ret0->a, "result4");
 }
 
-void flavorful_f_list_in_variant1(flavorful_list_in_variant1_v1_t *a, flavorful_list_in_variant1_v2_t *b, flavorful_list_in_variant1_v3_t *c) {
-  assert(a->is_some);
-  assert(memcmp(a->val.ptr, "foo", a->val.len) == 0);
-  flavorful_list_in_variant1_v1_free(a);
+void flavorful_f_list_in_variant1(flavorful_string_t *maybe_a, flavorful_list_in_variant1_v2_t *b, flavorful_list_in_variant1_v3_t *c) {
+  assert(maybe_a != NULL);
+  assert(memcmp(maybe_a->ptr, "foo", maybe_a->len) == 0);
+  flavorful_string_free(maybe_a);
 
   assert(b->is_err);
   assert(memcmp(b->val.err.ptr, "bar", b->val.err.len) == 0);
@@ -175,11 +175,11 @@ bool flavorful_f_list_in_variant2(flavorful_string_t *ret0) {
   return true;
 }
 
-bool flavorful_f_list_in_variant3(flavorful_list_in_variant3_t *a, flavorful_string_t *ret0) {
-  assert(a->is_some);
-  assert(memcmp(a->val.ptr, "input3", a->val.len) == 0);
-  flavorful_list_in_variant3_free(a);
-  flavorful_string_dup(ret0, "output3");
+bool flavorful_f_list_in_variant3(flavorful_string_t *maybe_a, flavorful_string_t *ret) {
+  assert(maybe_a != NULL);
+  assert(memcmp(maybe_a->ptr, "input3", maybe_a->len) == 0);
+  flavorful_string_free(maybe_a);
+  flavorful_string_dup(ret, "output3");
   return true;
 }
 

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -3,16 +3,12 @@
 
 void variants_test_imports() {
   {
-    imports_option_float32_t a;
+    float a = 1;
     uint8_t r;
-    a.is_some = true;
-    a.val = 1;
     assert(imports_roundtrip_option(&a, &r) && r == 1);
     assert(r == 1);
-    a.is_some = false;
-    assert(!imports_roundtrip_option(&a, &r));
-    a.is_some = true;
-    a.val = 2;
+    assert(!imports_roundtrip_option(NULL, &r));
+    a = 2;
     assert(imports_roundtrip_option(&a, &r) && r == 2);
   }
 
@@ -120,12 +116,10 @@ void variants_test_imports() {
   }
 
   {
-    imports_option_typedef_t a;
-    a.is_some = false;
     bool b = false;
     imports_result_typedef_t c;
     c.is_err = true;
-    imports_variant_typedefs(&a, b, &c);
+    imports_variant_typedefs(NULL, b, &c);
   }
 
   {
@@ -139,11 +133,11 @@ void variants_test_imports() {
   }
 }
 
-bool variants_roundtrip_option(variants_option_float32_t *a, uint8_t *ret0) {
-  if (a->is_some) {
-    *ret0 = a->val;
+bool variants_roundtrip_option(float *a, uint8_t *ret0) {
+  if (a) {
+    *ret0 = *a;
   }
-  return a->is_some;
+  return a != NULL;
 }
 
 bool variants_roundtrip_result(variants_result_u32_float32_t *a, double *ok, uint8_t *err) {
@@ -172,6 +166,6 @@ void variants_variant_zeros(variants_zeros_t *a, variants_zeros_t *b) {
   *b = *a;
 }
 
-void variants_variant_typedefs(variants_option_typedef_t *a, variants_bool_typedef_t b, variants_result_typedef_t *c) {
+void variants_variant_typedefs(uint32_t *a, variants_bool_typedef_t b, variants_result_typedef_t *c) {
 }
 


### PR DESCRIPTION
This implements https://github.com/bytecodealliance/wit-bindgen/issues/451 as described in that issue, permitting optional parameters to functions to instead be passed as nullable pointers.

The implementation prefixes the parameter name with a `maybe_` prefix to ensure there is some visibility in the interface this is happening.

Note this is done for all types including primitive types as being represented in this way.