### PR TITLE
gen-guest-rust, gen-gueste-c: Support multiple `RetArea`s in a single function.

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -1552,12 +1552,12 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.src,
                 "\
                     __attribute__((aligned({})))
-                    uint8_t ret_area[{}];
+                    uint8_t ret_area_{ptr}[{}];
                 ",
                 align,
                 size,
             );
-            uwriteln!(self.src, "int32_t {} = (int32_t) &ret_area;", ptr);
+            uwriteln!(self.src, "int32_t {} = (int32_t) &ret_area_{ptr};", ptr);
         } else {
             self.gen.gen.return_pointer_area_size = self.gen.gen.return_pointer_area_size.max(size);
             self.gen.gen.return_pointer_area_align =

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -772,8 +772,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.src,
                 "
                     #[repr(align({align}))]
-                    struct RetArea([u8; {size}]);
-                    let mut ret_area = core::mem::MaybeUninit::<RetArea>::uninit();
+                    struct RetArea{tmp}([u8; {size}]);
+                    let mut ret_area = core::mem::MaybeUninit::<RetArea{tmp}>::uninit();
                     let ptr{tmp} = ret_area.as_mut_ptr() as i32;
                 ",
             );

--- a/tests/codegen/ret-areas.wit
+++ b/tests/codegen/ret-areas.wit
@@ -1,0 +1,14 @@
+// This test generates multiple `RetArea` structs.
+
+interface tcp {
+  type ipv6-socket-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16, u16, u16>
+
+  connect: func(
+      local-address: ipv6-socket-address,
+      remote-address: ipv6-socket-address,
+  ) -> tuple<u32, u32>
+}
+
+world wasi {
+  import tcp: tcp
+}


### PR DESCRIPTION
Add a suffix to the generated `RetArea`/`ret_area` declarations so that there are multiple occurrences in the same scope, they don't collide.