### PR TITLE
Fix bindings generation for bare function exports

### DIFF
--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -327,6 +327,9 @@ impl InterfaceGenerator<'_> {
             uwrite!(
                 self.src,
                 "
+                    #[allow(unused_imports)]
+                    use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
+
                     #[repr(align({align}))]
                     struct _RetArea([u8; {size}]);
                     static mut _RET_AREA: _RetArea = _RetArea([0; {size}]);
@@ -347,9 +350,6 @@ impl InterfaceGenerator<'_> {
             "
                 #[allow(clippy::all)]
                 pub mod {snake} {{
-                    #[allow(unused_imports)]
-                    use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
-
                     {module}
                 }}
             "

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -528,11 +528,7 @@ impl InterfaceGenerator<'_> {
             macro_src.push_str(") {\n");
 
             // Finish out the macro here
-            uwrite!(
-                macro_src,
-                "{prefix}{module_name}::post_return_{name_snake}::<$t>(",
-                prefix = self.gen.opts.macro_call_prefix.as_deref().unwrap_or("")
-            );
+            uwrite!(macro_src, "{prefix}post_return_{name_snake}::<$t>(");
             for param in params.iter() {
                 uwrite!(macro_src, "{param},");
             }

--- a/tests/codegen/just-export.wit
+++ b/tests/codegen/just-export.wit
@@ -1,0 +1,3 @@
+default world foo {
+  export generate: func(name: string, wit: list<u8>) -> result<list<tuple<string, list<u8>>>, string>
+}


### PR DESCRIPTION
Move around a `use` statement