### PR TITLE
gen-host-js: fix ts compilation bug in newer ts versions

### DIFF
--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -2,6 +2,7 @@
 import { readFile } from 'node:fs/promises';
 // @ts-ignore
 import { argv, stdout, stderr } from 'node:process';
+// @ts-ignore
 import { Buffer } from 'node:buffer';
 
 // This is a helper function used from `host.ts` test in the `tests/runtime/*`

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { readFile } from 'node:fs/promises';
 // @ts-ignore
-import { argv, stdout, stderr } from 'node:process';
+import { argv, stdout, stderr, Buffer } from 'node:process';
 
 // This is a helper function used from `host.ts` test in the `tests/runtime/*`
 // directory to pass as the `instantiateCore` argument to the `instantiate`

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -17,8 +17,8 @@ export async function loadWasm(path: string) {
 
 // Export a WASI interface directly for instance imports
 export function log (bytes: Uint8Array | ArrayBuffer) {
-  stdout.write(bytes);
+  stdout.write(Buffer.from(bytes));
 }
 export function logErr (bytes: Uint8Array | ArrayBuffer) {
-  stderr.write(bytes);
+  stderr.write(Buffer.from(bytes));
 }

--- a/crates/gen-host-js/tests/helpers.ts
+++ b/crates/gen-host-js/tests/helpers.ts
@@ -1,7 +1,8 @@
 // @ts-ignore
 import { readFile } from 'node:fs/promises';
 // @ts-ignore
-import { argv, stdout, stderr, Buffer } from 'node:process';
+import { argv, stdout, stderr } from 'node:process';
+import { Buffer } from 'node:buffer';
 
 // This is a helper function used from `host.ts` test in the `tests/runtime/*`
 // directory to pass as the `instantiateCore` argument to the `instantiate`

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -42,9 +42,9 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     }
 
     let (cmd, args) = if cfg!(windows) {
-        ("cmd.exe", &["/c", "npx.cmd"] as &[&str])
+        ("cmd.exe", &["/c", "node_modules/.bin/tsc.cmd"] as &[&str])
     } else {
-        ("npx", &[] as &[&str])
+        ("node_modules/.bin/tsc", &[] as &[&str])
     };
 
     fs::copy(ts, dir.join("host.ts")).unwrap();
@@ -74,7 +74,6 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     test_helpers::run_command(
         Command::new(cmd)
             .args(args)
-            .arg("tsc")
             .arg("--project")
             .arg(&config),
     );

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -42,9 +42,9 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     }
 
     let (cmd, args) = if cfg!(windows) {
-        ("cmd.exe", &["/c", "node_modules/.bin/tsc.cmd"] as &[&str])
+        ("cmd.exe", &["/c", "npx.cmd"] as &[&str])
     } else {
-        ("node_modules/.bin/tsc", &[] as &[&str])
+        ("npx", &[] as &[&str])
     };
 
     fs::copy(ts, dir.join("host.ts")).unwrap();
@@ -71,7 +71,13 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     )
     .unwrap();
 
-    test_helpers::run_command(Command::new(cmd).args(args).arg("--project").arg(&config));
+    test_helpers::run_command(
+        Command::new(cmd)
+            .args(args)
+            .arg("tsc")
+            .arg("--project")
+            .arg(&config),
+    );
 
     fs::write(dir.join("package.json"), "{\"type\":\"module\"}").unwrap();
     let mut path = Vec::new();

--- a/crates/gen-host-js/tests/runtime.rs
+++ b/crates/gen-host-js/tests/runtime.rs
@@ -71,12 +71,7 @@ fn execute(name: &str, lang: &str, wasm: &Path, ts: &Path) {
     )
     .unwrap();
 
-    test_helpers::run_command(
-        Command::new(cmd)
-            .args(args)
-            .arg("--project")
-            .arg(&config),
-    );
+    test_helpers::run_command(Command::new(cmd).args(args).arg("--project").arg(&config));
 
     fs::write(dir.join("package.json"), "{\"type\":\"module\"}").unwrap();
     let mut path = Vec::new();


### PR DESCRIPTION
This fixes a TS compilation bug that was coming up. An alternative could be to check in the package lock to ensure consistent tsx versioning.