### PR TITLE
Fixes for `cabi_realloc` when new_size = 0

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -418,14 +418,15 @@ impl C {
         // Note that these intrinsics are declared as `weak` so they can be
         // overridden from some other symbol.
         self.src.c_fns(
-            "
-                __attribute__((weak, export_name(\"cabi_realloc\")))
-                void *cabi_realloc(void *ptr, size_t orig_size, size_t org_align, size_t new_size) {
+            r#"
+                __attribute__((weak, export_name("cabi_realloc")))
+                void *cabi_realloc(void *ptr, size_t old_size, size_t align, size_t new_size) {
+                    if (new_size == 0) return (void*) align;
                     void *ret = realloc(ptr, new_size);
                     if (!ret) abort();
                     return ret;
                 }
-            ",
+            "#,
         );
     }
 }

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -32,6 +32,7 @@ pub mod rt {
             layout = Layout::from_size_align_unchecked(new_len, align);
             alloc::alloc(layout)
         } else {
+            debug_assert_ne!(new_len, 0, "non-zero old_len requires non-zero new_len!");
             layout = Layout::from_size_align_unchecked(old_len, align);
             alloc::realloc(old_ptr, layout, new_len)
         };

--- a/tests/runtime/strings.rs
+++ b/tests/runtime/strings.rs
@@ -29,6 +29,7 @@ fn run() -> Result<()> {
 
 fn run_test(exports: Strings, store: &mut Store<crate::Wasi<MyImports>>) -> Result<()> {
     exports.call_test_imports(&mut *store)?;
+    assert_eq!(exports.call_return_empty(&mut *store)?, "");
     assert_eq!(exports.call_roundtrip(&mut *store, "str")?, "str");
     assert_eq!(
         exports.call_roundtrip(&mut *store, "🚀🚀🚀 𠈄𓀀")?,

--- a/tests/runtime/strings/wasm_utf16.c
+++ b/tests/runtime/strings/wasm_utf16.c
@@ -25,6 +25,10 @@ void strings_test_imports() {
   strings_string_free(&str2);
 }
 
+void strings_return_empty(strings_string_t *ret) {
+  strings_string_dup(ret, u""); // Exercise cabi_realloc new_size = 0
+}
+
 void strings_roundtrip(strings_string_t *str, strings_string_t *ret) {
   assert(str->len > 0);
   ret->len = str->len;

--- a/tests/runtime/strings/world.wit
+++ b/tests/runtime/strings/world.wit
@@ -7,5 +7,6 @@ default world strings {
   import imports: self.imports
 
   export test-imports: func()
+  export return-empty: func() -> string
   export roundtrip: func(s: string) -> string
 }


### PR DESCRIPTION
* gen-guest-c: Fix cabi_realloc behavior when new_size is zero (Fixes #462)
* guest-rust: Add an assert to cabi_realloc (Fixes #464)