### PR TITLE
refactor: remove unused `return_multiple` bool from `Return` struct

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -45,9 +45,8 @@ impl Opts {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Return {
-    return_multiple: bool,
     scalar: Option<Scalar>,
     retptrs: Vec<Type>,
 }
@@ -862,11 +861,7 @@ impl InterfaceGenerator<'_> {
                 name: String::from("INVALID"),
                 sig: String::from("INVALID"),
                 params: Vec::new(),
-                ret: Return {
-                    return_multiple: false,
-                    scalar: None,
-                    retptrs: Vec::new(),
-                },
+                ret: Return::default(),
                 retptrs: Vec::new(),
             };
             for (i, result) in sig.results.iter().enumerate() {
@@ -1027,11 +1022,7 @@ impl InterfaceGenerator<'_> {
     }
 
     fn classify_ret(&mut self, func: &Function) -> Return {
-        let mut ret = Return {
-            return_multiple: false,
-            scalar: None,
-            retptrs: Vec::new(),
-        };
+        let mut ret = Return::default();
         match func.results.len() {
             0 => ret.scalar = Some(Scalar::Void),
             1 => {
@@ -1039,7 +1030,6 @@ impl InterfaceGenerator<'_> {
                 ret.return_single(self.resolve, ty, ty);
             }
             _ => {
-                ret.return_multiple = true;
                 ret.retptrs.extend(func.results.iter_types().cloned());
             }
         }


### PR DESCRIPTION
The `return-multiple` field in `Return` was never used. This PR removes it and adds `Default` trait impl to Return to simplify a bit. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>