### PR TITLE
Fix rust generator guest  import error in `no_std` build

### DIFF
--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -368,12 +368,6 @@ impl InterfaceGenerator<'_> {
         self.src.push_str("#[allow(clippy::all)]\n");
         let params = self.print_signature(func, param_mode, &sig);
         self.src.push_str("{\n");
-        self.src.push_str(
-            "
-                #[allow(unused_imports)]
-                use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
-            ",
-        );
         self.src.push_str("unsafe {\n");
 
         let mut f = FunctionBindgen::new(self, params);

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -327,9 +327,6 @@ impl InterfaceGenerator<'_> {
             uwrite!(
                 self.src,
                 "
-                    #[allow(unused_imports)]
-                    use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
-
                     #[repr(align({align}))]
                     struct _RetArea([u8; {size}]);
                     static mut _RET_AREA: _RetArea = _RetArea([0; {size}]);
@@ -350,6 +347,7 @@ impl InterfaceGenerator<'_> {
             "
                 #[allow(clippy::all)]
                 pub mod {snake} {{
+                    use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
                     {module}
                 }}
             "

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -347,6 +347,7 @@ impl InterfaceGenerator<'_> {
             "
                 #[allow(clippy::all)]
                 pub mod {snake} {{
+                    #[allow(unused_imports)]
                     use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
                     {module}
                 }}


### PR DESCRIPTION
error snapshot
```
    |
100 |     pub fn generate_native_address(seed: &[u8]) -> Vec<u8> {
    |                                                    ^^^ not found in this scope
    |
help: consider importing one of these items
    |
3   |     use alloc::vec::Vec;
    |
3   |     use crate::Vec;
    |
3   |     use rune_std::vec::Vec;
    |
3   |     use wit_bindgen_guest_rust::rt::vec::Vec;
    |
```
adds
```
#[allow(unused_imports)]
use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
```
in the beginning of the mod generation, remove it from ending