### PR TITLE
Implement record, variant, etc. for the markdown backend.

### DIFF
--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -180,7 +180,7 @@ impl InterfaceGenerator<'_> {
                     f = func.name.to_snake_case(),
                     p = name.to_snake_case(),
                 ));
-                self.print_ty(ty, false);
+                self.print_ty(ty);
                 self.push_str("\n");
             }
         }
@@ -194,7 +194,7 @@ impl InterfaceGenerator<'_> {
                     f = func.name.to_snake_case(),
                     p = "result",
                 ));
-                self.print_ty(ty, false);
+                self.print_ty(ty);
                 self.push_str("\n");
             }
         }
@@ -206,7 +206,7 @@ impl InterfaceGenerator<'_> {
         self.gen.src.push_str(s);
     }
 
-    fn print_ty(&mut self, ty: &Type, skip_name: bool) {
+    fn print_ty(&mut self, ty: &Type) {
         match ty {
             Type::Bool => self.push_str("`bool`"),
             Type::U8 => self.push_str("`u8`"),
@@ -223,122 +223,57 @@ impl InterfaceGenerator<'_> {
             Type::String => self.push_str("`string`"),
             Type::Id(id) => {
                 let ty = &self.resolve.types[*id];
-                if !skip_name {
-                    if let Some(name) = &ty.name {
-                        self.push_str("[`");
-                        self.push_str(name);
-                        self.push_str("`](#");
-                        self.push_str(&name.to_snake_case());
-                        self.push_str(")");
-                        return;
-                    }
+                if let Some(name) = &ty.name {
+                    self.push_str("[`");
+                    self.push_str(name);
+                    self.push_str("`](#");
+                    self.push_str(&name.to_snake_case());
+                    self.push_str(")");
+                    return;
                 }
                 match &ty.kind {
-                    TypeDefKind::Type(t) => self.print_ty(t, false),
+                    TypeDefKind::Type(t) => self.print_ty(t),
                     TypeDefKind::Tuple(t) => {
                         self.push_str("(");
                         for (i, t) in t.types.iter().enumerate() {
                             if i > 0 {
                                 self.push_str(", ");
                             }
-                            self.print_ty(t, false);
+                            self.print_ty(t);
                         }
                         self.push_str(")");
                     }
-                    TypeDefKind::Record(record) => {
-                        self.push_str("record { ");
-                        let mut first = true;
-                        for field in &record.fields {
-                            if first {
-                                first = false;
-                            } else {
-                                self.push_str(", ");
-                            }
-                            self.push_str(&field.name);
-                            self.push_str(": ");
-                            self.print_ty(&field.ty, false);
-                        }
-                        self.push_str(" }");
-                    }
-                    TypeDefKind::Variant(variant) => {
-                        self.push_str("variant { ");
-                        let mut first = true;
-                        for field in &variant.cases {
-                            if first {
-                                first = false;
-                            } else {
-                                self.push_str(", ");
-                            }
-                            self.push_str(&field.name);
-                            self.push_str(": ");
-                            if let Some(ty) = &field.ty {
-                                self.print_ty(ty, false);
-                            } else {
-                                self.push_str("_");
-                            }
-                        }
-                        self.push_str(" }");
-                    }
-                    TypeDefKind::Union(union) => {
-                        self.push_str("union { ");
-                        let mut first = true;
-                        for case in &union.cases {
-                            if first {
-                                first = false;
-                            } else {
-                                self.push_str(", ");
-                            }
-                            self.print_ty(&case.ty, false);
-                        }
-                        self.push_str(" }");
-                    }
-                    TypeDefKind::Enum(enum_) => {
-                        self.push_str("enum { ");
-                        let mut first = true;
-                        for case in &enum_.cases {
-                            if first {
-                                first = false;
-                            } else {
-                                self.push_str(", ");
-                            }
-                            self.push_str(&case.name);
-                        }
-                        self.push_str(" }");
-                    }
-                    TypeDefKind::Flags(flags) => {
-                        self.push_str("flags { ");
-                        let mut first = true;
-                        for flag in &flags.flags {
-                            if first {
-                                first = false;
-                            } else {
-                                self.push_str(", ");
-                            }
-                            self.push_str(&flag.name);
-                        }
-                        self.push_str(" }");
+                    TypeDefKind::Record(_)
+                    | TypeDefKind::Flags(_)
+                    | TypeDefKind::Enum(_)
+                    | TypeDefKind::Variant(_)
+                    | TypeDefKind::Union(_) => {
+                        // These types are always named, so we will have
+                        // printed the name above, so we don't need to print
+                        // the contents.
+                        assert!(ty.name.is_some());
                     }
                     TypeDefKind::Option(t) => {
                         self.push_str("option<");
-                        self.print_ty(t, false);
+                        self.print_ty(t);
                         self.push_str(">");
                     }
                     TypeDefKind::Result(r) => match (r.ok, r.err) {
                         (Some(ok), Some(err)) => {
                             self.push_str("result<");
-                            self.print_ty(&ok, false);
+                            self.print_ty(&ok);
                             self.push_str(", ");
-                            self.print_ty(&err, false);
+                            self.print_ty(&err);
                             self.push_str(">");
                         }
                         (None, Some(err)) => {
                             self.push_str("result<_, ");
-                            self.print_ty(&err, false);
+                            self.print_ty(&err);
                             self.push_str(">");
                         }
                         (Some(ok), None) => {
                             self.push_str("result<");
-                            self.print_ty(&ok, false);
+                            self.print_ty(&ok);
                             self.push_str(">");
                         }
                         (None, None) => {
@@ -347,13 +282,13 @@ impl InterfaceGenerator<'_> {
                     },
                     TypeDefKind::List(t) => {
                         self.push_str("list<");
-                        self.print_ty(t, false);
+                        self.print_ty(t);
                         self.push_str(">");
                     }
                     TypeDefKind::Future(t) => match t {
                         Some(t) => {
                             self.push_str("future<");
-                            self.print_ty(t, false);
+                            self.print_ty(t);
                             self.push_str(">");
                         }
                         None => {
@@ -363,19 +298,19 @@ impl InterfaceGenerator<'_> {
                     TypeDefKind::Stream(s) => match (s.element, s.end) {
                         (Some(element), Some(end)) => {
                             self.push_str("stream<");
-                            self.print_ty(&element, false);
+                            self.print_ty(&element);
                             self.push_str(", ");
-                            self.print_ty(&end, false);
+                            self.print_ty(&end);
                             self.push_str(">");
                         }
                         (None, Some(end)) => {
                             self.push_str("stream<_, ");
-                            self.print_ty(&end, false);
+                            self.print_ty(&end);
                             self.push_str(">");
                         }
                         (Some(element), None) => {
                             self.push_str("stream<");
-                            self.print_ty(&element, false);
+                            self.print_ty(&element);
                             self.push_str(">");
                         }
                         (None, None) => {
@@ -446,7 +381,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 format!("{}::{}", name, field.name),
                 format!("#{}.{}", name.to_snake_case(), field.name.to_snake_case()),
             );
-            self.print_ty(&field.ty, false);
+            self.print_ty(&field.ty);
             self.gen.src.indent(1);
             self.push_str("\n\n");
             self.docs(&field.docs);
@@ -471,7 +406,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 format!("{}::{}", name, i),
                 format!("#{}.{}", name.to_snake_case(), i),
             );
-            self.print_ty(ty, false);
+            self.print_ty(ty);
             self.push_str("\n");
         }
     }
@@ -519,7 +454,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             );
             if let Some(ty) = &case.ty {
                 self.push_str(": ");
-                self.print_ty(ty, false);
+                self.print_ty(ty);
             }
             self.gen.src.indent(1);
             self.push_str("\n\n");
@@ -543,7 +478,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 .hrefs
                 .insert(format!("{name}::{i}"), format!("#{snake}.{i}"));
             self.push_str(": ");
-            self.print_ty(&case.ty, false);
+            self.print_ty(&case.ty);
             self.gen.src.indent(1);
             self.push_str("\n\n");
             self.docs(&case.docs);
@@ -579,7 +514,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     fn type_option(&mut self, id: TypeId, name: &str, payload: &Type, docs: &Docs) {
         self.print_type_header(name);
         self.push_str("option<");
-        self.print_ty(payload, false);
+        self.print_ty(payload);
         self.push_str(">");
         self.print_type_info(id, docs);
     }
@@ -589,19 +524,19 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         match (result.ok, result.err) {
             (Some(ok), Some(err)) => {
                 self.push_str("result<");
-                self.print_ty(&ok, false);
+                self.print_ty(&ok);
                 self.push_str(", ");
-                self.print_ty(&err, false);
+                self.print_ty(&err);
                 self.push_str(">");
             }
             (None, Some(err)) => {
                 self.push_str("result<_, ");
-                self.print_ty(&err, false);
+                self.print_ty(&err);
                 self.push_str(">");
             }
             (Some(ok), None) => {
                 self.push_str("result<");
-                self.print_ty(&ok, false);
+                self.print_ty(&ok);
                 self.push_str(">");
             }
             (None, None) => {
@@ -613,7 +548,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
 
     fn type_alias(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
         self.print_type_header(name);
-        self.print_ty(ty, true);
+        self.print_ty(ty);
         self.push_str("\n\n");
         self.print_type_info(id, docs);
         self.push_str("\n");

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -245,12 +245,78 @@ impl InterfaceGenerator<'_> {
                         }
                         self.push_str(")");
                     }
-                    TypeDefKind::Record(_)
-                    | TypeDefKind::Flags(_)
-                    | TypeDefKind::Enum(_)
-                    | TypeDefKind::Variant(_)
-                    | TypeDefKind::Union(_) => {
-                        unreachable!()
+                    TypeDefKind::Record(record) => {
+                        self.push_str("record { ");
+                        let mut first = true;
+                        for field in &record.fields {
+                            if first {
+                                first = false;
+                            } else {
+                                self.push_str(", ");
+                            }
+                            self.push_str(&field.name);
+                            self.push_str(": ");
+                            self.print_ty(&field.ty, false);
+                        }
+                        self.push_str(" }");
+                    }
+                    TypeDefKind::Variant(variant) => {
+                        self.push_str("variant { ");
+                        let mut first = true;
+                        for field in &variant.cases {
+                            if first {
+                                first = false;
+                            } else {
+                                self.push_str(", ");
+                            }
+                            self.push_str(&field.name);
+                            self.push_str(": ");
+                            if let Some(ty) = &field.ty {
+                                self.print_ty(ty, false);
+                            } else {
+                                self.push_str("_");
+                            }
+                        }
+                        self.push_str(" }");
+                    }
+                    TypeDefKind::Union(union) => {
+                        self.push_str("union { ");
+                        let mut first = true;
+                        for case in &union.cases {
+                            if first {
+                                first = false;
+                            } else {
+                                self.push_str(", ");
+                            }
+                            self.print_ty(&case.ty, false);
+                        }
+                        self.push_str(" }");
+                    }
+                    TypeDefKind::Enum(enum_) => {
+                        self.push_str("enum { ");
+                        let mut first = true;
+                        for case in &enum_.cases {
+                            if first {
+                                first = false;
+                            } else {
+                                self.push_str(", ");
+                            }
+                            self.push_str(&case.name);
+                        }
+                        self.push_str(" }");
+                    }
+                    TypeDefKind::Flags(flags) => {
+                        self.push_str("flags { ");
+                        let mut first = true;
+                        for flag in &flags.flags {
+                            if first {
+                                first = false;
+                            } else {
+                                self.push_str(", ");
+                            }
+                            self.push_str(&flag.name);
+                        }
+                        self.push_str(" }");
                     }
                     TypeDefKind::Option(t) => {
                         self.push_str("option<");


### PR DESCRIPTION
Implement basic markdown printing for record, variant, union, enum, and flags types.