### PR TITLE
Teach guest Rust how to qualify `Vec` and `String` for `no_std`.

### DIFF
--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -492,6 +492,14 @@ impl InterfaceGenerator<'_> {
 
         self.push_str(" {\n");
 
+        uwrite!(
+            self.src,
+            "
+                #[allow(unused_imports)]
+                use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
+            "
+        );
+
         // Finish out the macro-generated export implementation.
         macro_src.push_str(" {\n");
         let prefix = format!(

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -604,6 +604,14 @@ impl<'a> RustGenerator<'a> for InterfaceGenerator<'a> {
         self.gen.opts.raw_strings
     }
 
+    fn vec_name(&self) -> &'static str {
+        "wit_bindgen_guest_rust::rt::vec::Vec"
+    }
+
+    fn string_name(&self) -> &'static str {
+        "wit_bindgen_guest_rust::rt::string::String"
+    }
+
     fn default_param_mode(&self) -> TypeMode {
         self.default_param_mode
     }

--- a/crates/gen-guest-rust/tests/codegen_no_std.rs
+++ b/crates/gen-guest-rust/tests/codegen_no_std.rs
@@ -1,0 +1,176 @@
+//! Like `codegen_tests` in codegen.rs, but with no_std.
+
+#![no_std]
+#![allow(unused_macros)]
+
+extern crate alloc;
+
+mod codegen_tests {
+    macro_rules! codegen_test {
+        ($id:ident $name:tt $test:tt) => {
+            mod $id {
+                wit_bindgen_guest_rust::generate!({
+                    path: $test,
+                    world: $name,
+                    no_std,
+                });
+
+                #[test]
+                fn works() {}
+
+                mod unchecked {
+                    wit_bindgen_guest_rust::generate!({
+                        path: $test,
+                        world: $name,
+                        unchecked,
+                        no_std,
+                    });
+
+                    #[test]
+                    fn works() {}
+                }
+            }
+
+        };
+    }
+    test_helpers::codegen_tests!("*.wit");
+}
+
+mod strings {
+    use alloc::string::String;
+
+    wit_bindgen_guest_rust::generate!({
+        inline: "
+            default world not-used-name {
+                import cat: interface {
+                    foo: func(x: string)
+                    bar: func() -> string
+                }
+            }
+        ",
+    });
+
+    #[allow(dead_code)]
+    fn test() {
+        // Test the argument is `&str`.
+        cat::foo("hello");
+
+        // Test the return type is `String`.
+        let _t: String = cat::bar();
+    }
+}
+
+/// Like `strings` but with raw_strings`.
+mod raw_strings {
+    use alloc::vec::Vec;
+
+    wit_bindgen_guest_rust::generate!({
+        inline: "
+            default world not-used-name {
+                import cat: interface {
+                    foo: func(x: string)
+                    bar: func() -> string
+                }
+            }
+        ",
+        raw_strings,
+    });
+
+    #[allow(dead_code)]
+    fn test() {
+        // Test the argument is `&[u8]`.
+        cat::foo(b"hello");
+
+        // Test the return type is `Vec<u8>`.
+        let _t: Vec<u8> = cat::bar();
+    }
+}
+
+// This is a static compilation test to ensure that
+// export bindings can go inside of another mod/crate
+// and still compile.
+mod prefix {
+    use alloc::{
+        format,
+        string::{String, ToString},
+    };
+
+    mod bindings {
+        wit_bindgen_guest_rust::generate!({
+            inline: "
+                default world baz {
+                    export exports1: interface {
+                        foo: func(x: string)
+                        bar: func() -> string
+                    }
+                }
+            ",
+            macro_call_prefix: "bindings::"
+        });
+
+        pub(crate) use export_baz;
+    }
+
+    struct Component;
+
+    impl bindings::exports1::Exports1 for Component {
+        fn foo(x: String) {
+            let _ = format!("foo: {}", x);
+        }
+
+        fn bar() -> String {
+            "bar".to_string()
+        }
+    }
+
+    bindings::export_baz!(Component);
+}
+
+// This is a static compilation test to check that
+// the export macro name can be overridden.
+mod macro_name {
+    use alloc::{format, string::String};
+
+    wit_bindgen_guest_rust::generate!({
+        inline: "
+            default world baz {
+                export exports2: interface {
+                    foo: func(x: string)
+                }
+            }
+        ",
+        export_macro_name: "jam"
+    });
+
+    struct Component;
+
+    impl exports2::Exports2 for Component {
+        fn foo(x: String) {
+            let _ = format!("foo: {}", x);
+        }
+    }
+
+    jam!(Component);
+}
+
+mod skip {
+    wit_bindgen_guest_rust::generate!({
+        inline: "
+            default world baz {
+                export exports: interface {
+                    foo: func()
+                    bar: func()
+                }
+            }
+        ",
+        skip: ["foo"],
+    });
+
+    struct Component;
+
+    impl exports::Exports for Component {
+        fn bar() {}
+    }
+
+    export_baz!(Component);
+}

--- a/crates/gen-guest-rust/tests/codegen_no_std.rs
+++ b/crates/gen-guest-rust/tests/codegen_no_std.rs
@@ -48,6 +48,7 @@ mod strings {
                 }
             }
         ",
+        no_std,
     });
 
     #[allow(dead_code)]
@@ -74,6 +75,7 @@ mod raw_strings {
             }
         ",
         raw_strings,
+        no_std,
     });
 
     #[allow(dead_code)]
@@ -105,7 +107,8 @@ mod prefix {
                     }
                 }
             ",
-            macro_call_prefix: "bindings::"
+            macro_call_prefix: "bindings::",
+            no_std,
         });
 
         pub(crate) use export_baz;
@@ -139,7 +142,8 @@ mod macro_name {
                 }
             }
         ",
-        export_macro_name: "jam"
+        export_macro_name: "jam",
+        no_std,
     });
 
     struct Component;
@@ -164,6 +168,7 @@ mod skip {
             }
         ",
         skip: ["foo"],
+        no_std,
     });
 
     struct Component;

--- a/crates/gen-rust-lib/src/lib.rs
+++ b/crates/gen-rust-lib/src/lib.rs
@@ -21,6 +21,12 @@ pub trait RustGenerator<'a> {
         true
     }
 
+    /// Return the fully-qualified name for the `Vec` type to use.
+    fn vec_name(&self) -> &'static str;
+
+    /// Return the fully-qualified name for the `String` type to use.
+    fn string_name(&self) -> &'static str;
+
     /// Return true iff the generator should use `&[u8]` instead of `&str` in bindings.
     fn use_raw_strings(&self) -> bool {
         false
@@ -181,9 +187,10 @@ pub trait RustGenerator<'a> {
                 }
                 TypeMode::Owned => {
                     if self.use_raw_strings() {
-                        self.push_str("Vec<u8>")
+                        self.push_str(self.vec_name());
+                        self.push_str("::<u8>");
                     } else {
-                        self.push_str("String")
+                        self.push_str(self.string_name());
                     }
                 }
             },
@@ -317,13 +324,15 @@ pub trait RustGenerator<'a> {
                 if self.resolve().all_bits_valid(ty) {
                     self.print_borrowed_slice(false, ty, lt);
                 } else {
-                    self.push_str("Vec<");
+                    self.push_str(self.vec_name());
+                    self.push_str("::<");
                     self.print_ty(ty, mode);
                     self.push_str(">");
                 }
             }
             TypeMode::Owned => {
-                self.push_str("Vec<");
+                self.push_str(self.vec_name());
+                self.push_str("::<");
                 self.print_ty(ty, mode);
                 self.push_str(">");
             }


### PR DESCRIPTION
The Rust generator emits `use` declarations for `Vec` and `String` inside function bodies which usually works, but doesn't work when When `Vec` and `String` appear as return types. This teaches the Rust guest generator how to fully qualify `Vec` and `String` so that they always work, even in `no_std` mode when they aren't in scope by default.