### PR TITLE
fix Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,11 +48,22 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
+
     - uses: actions/setup-java@v3
       with:
-        java-version: '18'
+        java-version: '19'
         distribution: 'adopt'
+
+    # As of this writing, the above Java/Maven combo isn't working on Windows, so we install them manually:
+    - run: |
+        curl https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip -LO
+        unzip openjdk-19.0.2_windows-x64_bin.zip
+        curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz -L | tar xzvf -
+        PATH=`pwd`/jdk-19.0.2/bin:`pwd`/apache-maven-3.9.0/bin:$PATH cargo test --workspace
+      if : matrix.os == 'windows-latest'
     - run: cargo test --workspace
+      if : matrix.os != 'windows-latest'
+
     - run: cargo build
     - run: cargo build --no-default-features
     - run: cargo build --no-default-features --features rust


### PR DESCRIPTION
The same Java and Maven versions that work on Linux and Mac have suddenly starting failing on Windows, so we now manually install a known good version for that platform.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>