### PR TITLE
disable Java tests on Windows

### DIFF
--- a/crates/gen-guest-teavm-java/tests/codegen.rs
+++ b/crates/gen-guest-teavm-java/tests/codegen.rs
@@ -1,5 +1,3 @@
-use heck::{ToSnakeCase, ToUpperCamelCase};
-use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -24,7 +22,22 @@ macro_rules! codegen_test {
 }
 test_helpers::codegen_tests!("*.wit");
 
+// TODO: As of this writing, Maven has started failing to resolve dependencies on Windows in the GitHub action,
+// apparently unrelated to any code changes we've made.  Until we've either resolved the problem or developed a
+// workaround, we're disabling the tests.
+//
+// See https://github.com/bytecodealliance/wit-bindgen/issues/495 for more information.
+#[cfg(windows)]
+fn verify(_dir: &Path, _name: &str) {
+    _ = mvn;
+    _ = pom_xml;
+}
+
+#[cfg(unix)]
 fn verify(dir: &Path, name: &str) {
+    use heck::{ToSnakeCase, ToUpperCamelCase};
+    use std::fs;
+
     let java_dir = &dir.join("src/main/java");
     let snake = name.to_snake_case();
     let package_dir = &java_dir.join(format!("wit_{snake}"));

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -206,6 +206,12 @@ fn tests(name: &str) -> Result<Vec<PathBuf>> {
         result.push(component_path);
     }
 
+    // TODO: As of this writing, Maven has started failing to resolve dependencies on Windows in the GitHub action,
+    // apparently unrelated to any code changes we've made.  Until we've either resolved the problem or developed a
+    // workaround, we're disabling the tests.
+    //
+    // See https://github.com/bytecodealliance/wit-bindgen/issues/495 for more information.
+    #[cfg(unix)]
     #[cfg(feature = "teavm-java")]
     if !java.is_empty() {
         use heck::*;


### PR DESCRIPTION
Per #495, Maven has started failing to resolve dependencies on Windows in the GitHub action, although it works fine on Mac, Linux, and also (locally) on Windows.  For the time being, I'm disabling these tests so the failures are not a distraction while we determine a proper solution.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>