### PR TITLE
Prepare CI/automation for releasing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    name: Build wasm-tools
+    name: Build wit-bindgen
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/wit-bindgen-cli-')
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build
+on:
+  push:
+    tags:
+  pull_request:
+    branches:
+    - main
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build wasm-tools
+    runs-on: ${{ matrix.os }}
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/wit-bindgen-cli-')
+    strategy:
+      matrix:
+        include:
+        - build: x86_64-linux
+          os: ubuntu-latest
+        - build: x86_64-macos
+          os: macos-latest
+        - build: aarch64-macos
+          os: macos-latest
+          target: aarch64-apple-darwin
+        - build: x86_64-windows
+          os: windows-latest
+        - build: aarch64-linux
+          os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - run: rustup update stable --no-self-update && rustup default stable
+    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v4.0.0
+      with:
+        name: ${{ matrix.build }}
+    - run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
+    - run: $CENTOS cargo build --release
+    - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: bins-${{ matrix.build }}
+        path: dist
+
+    - uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/') && github.repository == 'bytecodealliance/wit-bindgen'
+      with:
+        files: "dist/*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+publish
 static
 package-lock.json
 node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 name = "test-rust-wasm"
 version = "0.3.0"
 dependencies = [
- "wit-bindgen-guest-rust",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ name = "wasi_snapshot_preview1"
 version = "0.0.0"
 dependencies = [
  "wasi",
- "wit-bindgen-guest-rust",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1627,6 +1627,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.3.0"
+dependencies = [
+ "bitflags",
+ "wit-bindgen-guest-rust-macro",
+]
+
+[[package]]
 name = "wit-bindgen-cli"
 version = "0.3.0"
 dependencies = [
@@ -1674,9 +1682,9 @@ dependencies = [
  "clap",
  "heck",
  "test-helpers",
+ "wit-bindgen",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
- "wit-bindgen-guest-rust",
  "wit-component",
 ]
 
@@ -1708,14 +1716,6 @@ version = "0.3.0"
 dependencies = [
  "heck",
  "wit-bindgen-core",
-]
-
-[[package]]
-name = "wit-bindgen-guest-rust"
-version = "0.3.0"
-dependencies = [
- "bitflags",
- "wit-bindgen-guest-rust-macro",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "codegen-macro"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "heck",
  "ignore",
@@ -1063,7 +1063,7 @@ version = "0.1.0"
 
 [[package]]
 name = "test-helpers"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "codegen-macro",
  "wasm-encoder",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "test-rust-wasm"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-cli"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [workspace]
@@ -13,7 +13,6 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.0"
 
 [workspace.dependencies]
 anyhow = "1.0.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ wit-bindgen-gen-guest-rust = { path = "crates/gen-guest-rust", version = "0.3.0"
 wit-bindgen-gen-guest-teavm-java = { path = 'crates/gen-guest-teavm-java', version = '0.3.0' }
 wit-bindgen-gen-markdown = { path = 'crates/gen-markdown', version = '0.3.0' }
 wit-bindgen-gen-rust-lib = { path = 'crates/gen-rust-lib', version = '0.3.0' }
-wit-bindgen-guest-rust = { path = 'crates/guest-rust', version = '0.3.0', default-features = false }
+wit-bindgen = { path = 'crates/guest-rust', version = '0.3.0', default-features = false }
 wit-bindgen-rust-macro-shared = { path = 'crates/rust-macro-shared', version = '0.3.0' }
 
 [[bin]]

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+platform=$1
+target=$2
+
+rm -rf tmp
+mkdir tmp
+mkdir -p dist
+
+tag=dev
+if [[ $GITHUB_REF == refs/tags/wit-bindgen-cli-* ]]; then
+  tag=v${GITHUB_REF:26}
+fi
+
+bin_pkgname=wit-bindgen-$tag-$platform
+
+mkdir tmp/$bin_pkgname
+cp LICENSE README.md tmp/$bin_pkgname
+
+fmt=tar
+if [ "$platform" = "x86_64-windows" ]; then
+  cp target/release/wit-bindgen.exe tmp/$bin_pkgname
+  fmt=zip
+elif [ "$target" = "" ]; then
+  cp target/release/wit-bindgen tmp/$bin_pkgname
+else
+  cp target/$target/release/wit-bindgen tmp/$bin_pkgname
+fi
+
+
+mktarball() {
+  dir=$1
+  if [ "$fmt" = "tar" ]; then
+    tar czvf dist/$dir.tar.gz -C tmp $dir
+  else
+    # Note that this runs on Windows, and it looks like GitHub Actions doesn't
+    # have a `zip` tool there, so we use something else
+    (cd tmp && 7z a ../dist/$dir.zip $dir/)
+  fi
+}
+
+mktarball $bin_pkgname

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates git
+
+ENV PATH=$PATH:/rust/bin
+ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+
+RUN yum install -y git gcc
+
+ENV PATH=$PATH:/rust/bin

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -1,0 +1,381 @@
+//! Helper script to manage versions in this repository for various crates.
+//!
+//! Three subcommands:
+//!
+//! * `./publish diff wit-bindgen-core` - shows a git diff for the
+//!   wit-bindgen-core crate from the last tagged version to now. Useful for
+//!   figuring out if a major version bump is needed or not.
+//!
+//! * `./publish bump crate1:major crate2:minor ...` - performs a major or minor
+//!   version bump of the crates specified. All crates not mentioned here
+//!   which transitively depend on these crates are minor-bumped.
+//!
+//! * `./publish publish` - attempts to publish all crates. Only publishes if
+//!   their current version isn't already published. Will add wasmtime
+//!   publication group automatically. A git tag is created for all published
+//!   crates.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::os::unix::prelude::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+// Crates we care about publishing sorted topologically.
+const CRATES_TO_PUBLISH: &[&str] = &[
+    "wit-bindgen-core",
+    "wit-bindgen-gen-rust-lib",
+    "wit-bindgen-gen-guest-c",
+    "wit-bindgen-gen-guest-rust",
+    "wit-bindgen-gen-guest-teavm-java",
+    "wit-bindgen-gen-markdown",
+    "wit-bindgen-guest-rust-macro",
+    "wit-bindgen",
+    "wit-bindgen-cli",
+];
+
+#[derive(Clone)]
+struct Crate {
+    manifest: PathBuf,
+    name: String,
+    version: String,
+    // Only set by `bump_version` if the crate was actually updated to get a new
+    // version.
+    new_version: Option<String>,
+    publish: bool,
+}
+
+fn main() {
+    let mut crates = Vec::new();
+    crates.push(read_crate("./Cargo.toml".as_ref()));
+    find_crates("crates".as_ref(), &mut crates);
+
+    let pos = CRATES_TO_PUBLISH
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (*c, i))
+        .collect::<HashMap<_, _>>();
+    crates.sort_by_key(|krate| pos.get(&krate.name[..]));
+
+    match &env::args().nth(1).expect("must have one argument")[..] {
+        "bump" => {
+            let bumps = env::args()
+                .skip(2)
+                .map(|s| {
+                    if let Some(s) = s.strip_suffix(":major") {
+                        (s.to_string(), true)
+                    } else if let Some(s) = s.strip_suffix(":minor") {
+                        (s.to_string(), false)
+                    } else {
+                        panic!("unknown: {}", s);
+                    }
+                })
+                .collect::<Vec<_>>();
+            for (i, mut krate) in crates.clone().into_iter().enumerate() {
+                bump_version(&mut krate, &mut crates, &bumps);
+                crates[i] = krate;
+            }
+            // update the lock file
+            assert!(Command::new("cargo")
+                .arg("fetch")
+                .status()
+                .unwrap()
+                .success());
+        }
+
+        "publish" => {
+            // We have so many crates to publish we're frequently either
+            // rate-limited or we run into issues where crates can't publish
+            // successfully because they're waiting on the index entries of
+            // previously-published crates to propagate. This means we try to
+            // publish in a loop and we remove crates once they're successfully
+            // published. Failed-to-publish crates get enqueued for another try
+            // later on.
+            for _ in 0..5 {
+                crates.retain(|krate| !publish(krate));
+
+                if crates.is_empty() {
+                    break;
+                }
+
+                println!(
+                    "{} crates failed to publish, waiting for a bit to retry",
+                    crates.len(),
+                );
+                thread::sleep(Duration::from_secs(20));
+            }
+
+            assert!(crates.is_empty(), "failed to publish all crates");
+
+            println!("");
+            println!("===================================================================");
+            println!("");
+            println!("Don't forget to push tags for this release!");
+            println!("");
+            println!("    $ git push --tags");
+        }
+
+        "diff" => {
+            let krate = env::args().nth(2).unwrap();
+            let krate = crates.iter().find(|c| c.name == krate).unwrap();
+            Command::new("git")
+                .arg("diff")
+                .arg(format!("{}-{}..HEAD", krate.name, krate.version))
+                .arg("--")
+                .arg(krate.manifest.parent().unwrap())
+                .exec();
+        }
+
+        s => panic!("unknown command: {}", s),
+    }
+}
+
+// Recursively looks for `Cargo.toml` in `dir`
+fn find_crates(dir: &Path, dst: &mut Vec<Crate>) {
+    if dir.join("Cargo.toml").exists() {
+        let krate = read_crate(&dir.join("Cargo.toml"));
+        if !krate.publish || CRATES_TO_PUBLISH.iter().any(|c| krate.name == *c) {
+            dst.push(krate);
+        } else {
+            panic!("failed to find {:?} in whitelist or blacklist", krate.name);
+        }
+    }
+
+    for entry in dir.read_dir().unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_dir() {
+            find_crates(&entry.path(), dst);
+        }
+    }
+}
+
+fn read_crate(manifest: &Path) -> Crate {
+    let mut name = None;
+    let mut version = None;
+    let mut publish = true;
+    for line in fs::read_to_string(manifest).unwrap().lines() {
+        if name.is_none() && line.starts_with("name = \"") {
+            name = Some(
+                line.replace("name = \"", "")
+                    .replace("\"", "")
+                    .trim()
+                    .to_string(),
+            );
+        }
+        if version.is_none() && line.starts_with("version = \"") {
+            version = Some(
+                line.replace("version = \"", "")
+                    .replace("\"", "")
+                    .trim()
+                    .to_string(),
+            );
+        }
+        if line.starts_with("publish = false") {
+            publish = false;
+        }
+    }
+    let name = name.unwrap();
+    let version = version.unwrap();
+    Crate {
+        manifest: manifest.to_path_buf(),
+        name,
+        version,
+        publish,
+        new_version: None,
+    }
+}
+
+fn bump_version(krate: &mut Crate, crates: &mut [Crate], bumps: &[(String, bool)]) {
+    let contents = fs::read_to_string(&krate.manifest).unwrap();
+
+    let next_version = |target: &Crate| -> String {
+        // If this crate is publishable then if it's explicitly requested on the
+        // command line we bump the version. Otherwise we also force a version
+        // bump if it's the same as this `krate` requested originally for this
+        // function. This forced bump will be thrown away if no other
+        // dependencies get updated.
+        if CRATES_TO_PUBLISH.contains(&&target.name[..]) {
+            if let Some((_, major)) = bumps.iter().find(|(s, _)| *s == target.name) {
+                return bump(&target.version, !*major);
+            }
+            if target.name == krate.name {
+                return bump(&target.version, true);
+            }
+        }
+
+        // Prefer the `new_version`, if set, over the old version. The new
+        // version will be updated by this point since crates are sorted
+        // topologically.
+        target.new_version.clone().unwrap_or(target.version.clone())
+    };
+
+    let mut new_manifest = String::new();
+    let mut is_deps = false;
+    let mut updated_deps = false;
+    for line in contents.lines() {
+        let mut rewritten = false;
+        if !is_deps && line.starts_with("version =") {
+            if CRATES_TO_PUBLISH.contains(&&krate.name[..]) {
+                new_manifest.push_str(&line.replace(&krate.version, &next_version(krate)));
+                rewritten = true;
+            }
+        }
+
+        is_deps = if line.starts_with("[") {
+            line.contains("dependencies")
+        } else {
+            is_deps
+        };
+
+        for other in crates.iter() {
+            // If `other` isn't a published crate then it's not going to get a
+            // bumped version so we don't need to update anything in the
+            // manifest.
+            if !other.publish {
+                continue;
+            }
+            if !is_deps || !line.starts_with(&format!("{} ", other.name)) {
+                continue;
+            }
+            if !line.contains(&other.version) && !line.contains("workspace = true") {
+                if !line.contains("version =") || !krate.publish {
+                    continue;
+                }
+                panic!(
+                    "{:?} has a dep on {} but doesn't list version {}",
+                    krate.manifest, other.name, other.version
+                );
+            }
+            let next = next_version(other);
+            if next != other.version {
+                rewritten = true;
+                updated_deps = true;
+                new_manifest.push_str(&line.replace(&other.version, &next));
+            }
+            break;
+        }
+        if !rewritten {
+            new_manifest.push_str(line);
+        }
+        new_manifest.push_str("\n");
+    }
+
+    // Only actually rewrite the manifest if this crate was explicitly requested
+    // to get bumped or one of its dependencies changed, otherwise nothing
+    // changed about it.
+    if updated_deps || bumps.iter().any(|(s, _)| *s == krate.name) {
+        let new = next_version(krate);
+        println!("bump `{}` {} => {}", krate.name, krate.version, new,);
+        fs::write(&krate.manifest, new_manifest).unwrap();
+        krate.new_version = Some(new);
+    }
+}
+
+/// Performs a major version bump increment on the semver version `version`.
+///
+/// This function will perform a semver-major-version bump on the `version`
+/// specified. This is used to calculate the next version of a crate in this
+/// repository since we're currently making major version bumps for all our
+/// releases. This may end up getting tweaked as we stabilize crates and start
+/// doing more minor/patch releases, but for now this should do the trick.
+fn bump(version: &str, patch_bump: bool) -> String {
+    let mut iter = version.split('.').map(|s| s.parse::<u32>().unwrap());
+    let major = iter.next().expect("major version");
+    let minor = iter.next().expect("minor version");
+    let patch = iter.next().expect("patch version");
+
+    if patch_bump {
+        return format!("{}.{}.{}", major, minor, patch + 1);
+    }
+    if major != 0 {
+        format!("{}.0.0", major + 1)
+    } else if minor != 0 {
+        format!("0.{}.0", minor + 1)
+    } else {
+        format!("0.0.{}", patch + 1)
+    }
+}
+
+fn publish(krate: &Crate) -> bool {
+    if !CRATES_TO_PUBLISH.iter().any(|s| *s == krate.name) {
+        return true;
+    }
+
+    // First make sure the crate isn't already published at this version. This
+    // script may be re-run and there's no need to re-attempt previous work.
+    let output = Command::new("curl")
+        .arg(&format!("https://crates.io/api/v1/crates/{}", krate.name))
+        .output()
+        .expect("failed to invoke `curl`");
+    if output.status.success()
+        && String::from_utf8_lossy(&output.stdout)
+            .contains(&format!("\"newest_version\":\"{}\"", krate.version))
+    {
+        println!(
+            "skip publish {} because {} is latest version",
+            krate.name, krate.version,
+        );
+        return true;
+    }
+
+    let status = Command::new("cargo")
+        .arg("publish")
+        .current_dir(krate.manifest.parent().unwrap())
+        .status()
+        .expect("failed to run cargo");
+    if !status.success() {
+        println!("FAIL: failed to publish `{}`: {}", krate.name, status);
+        return false;
+    }
+
+    let status = Command::new("git")
+        .arg("tag")
+        .arg(format!("{}-{}", krate.name, krate.version))
+        .status()
+        .expect("failed to run git");
+    if !status.success() {
+        panic!("FAIL: failed to tag: {}", status);
+    }
+
+    // After we've published then make sure that the `wasmtime-publish` group is
+    // added to this crate for future publications. If it's already present
+    // though we can skip the `cargo owner` modification.
+    let output = Command::new("curl")
+        .arg(&format!(
+            "https://crates.io/api/v1/crates/{}/owners",
+            krate.name
+        ))
+        .output()
+        .expect("failed to invoke `curl`");
+    if output.status.success()
+        && String::from_utf8_lossy(&output.stdout).contains("wasmtime-publish")
+    {
+        println!(
+            "wasmtime-publish already listed as an owner of {}",
+            krate.name
+        );
+        return true;
+    }
+
+    // Note that the status is ignored here. This fails most of the time because
+    // the owner is already set and present, so we only want to add this to
+    // crates which haven't previously been published.
+    let status = Command::new("cargo")
+        .arg("owner")
+        .arg("-a")
+        .arg("github:bytecodealliance:wasmtime-publish")
+        .arg(&krate.name)
+        .status()
+        .expect("failed to run cargo");
+    if !status.success() {
+        panic!(
+            "FAIL: failed to add wasmtime-publish as owner `{}`: {}",
+            krate.name, status
+        );
+    }
+
+    true
+}

--- a/crates/bindgen-core/Cargo.toml
+++ b/crates/bindgen-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-core"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/gen-guest-c/Cargo.toml
+++ b/crates/gen-guest-c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-gen-guest-c"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/gen-guest-rust/Cargo.toml
+++ b/crates/gen-guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-gen-guest-rust"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/gen-guest-rust/Cargo.toml
+++ b/crates/gen-guest-rust/Cargo.toml
@@ -16,5 +16,5 @@ heck = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-wit-bindgen-guest-rust = { path = '../guest-rust' }
+wit-bindgen = { path = '../guest-rust' }
 test-helpers = { path = '../test-helpers' }

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -343,7 +343,7 @@ impl InterfaceGenerator<'_> {
                 self.src,
                 "
                     #[allow(unused_imports)]
-                    use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
+                    use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
 
                     #[repr(align({align}))]
                     struct _RetArea([u8; {size}]);
@@ -387,7 +387,7 @@ impl InterfaceGenerator<'_> {
         self.src.push_str(
             "
                 #[allow(unused_imports)]
-                use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
+                use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
             ",
         );
         self.src.push_str("unsafe {\n");
@@ -496,7 +496,7 @@ impl InterfaceGenerator<'_> {
             self.src,
             "
                 #[allow(unused_imports)]
-                use wit_bindgen_guest_rust::rt::{{alloc, vec::Vec, string::String}};
+                use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
             "
         );
 
@@ -613,11 +613,11 @@ impl<'a> RustGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn vec_name(&self) -> &'static str {
-        "wit_bindgen_guest_rust::rt::vec::Vec"
+        "wit_bindgen::rt::vec::Vec"
     }
 
     fn string_name(&self) -> &'static str {
-        "wit_bindgen_guest_rust::rt::string::String"
+        "wit_bindgen::rt::string::String"
     }
 
     fn default_param_mode(&self) -> TypeMode {
@@ -668,8 +668,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn type_flags(&mut self, _id: TypeId, name: &str, flags: &Flags, docs: &Docs) {
-        self.src
-            .push_str("wit_bindgen_guest_rust::bitflags::bitflags! {\n");
+        self.src.push_str("wit_bindgen::bitflags::bitflags! {\n");
         self.rustdoc(docs);
         let repr = RustFlagsRepr::new(flags);
         self.src.push_str(&format!(
@@ -944,7 +943,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
             Instruction::I64FromU64 | Instruction::I64FromS64 => {
                 let s = operands.pop().unwrap();
-                results.push(format!("wit_bindgen_guest_rust::rt::as_i64({})", s));
+                results.push(format!("wit_bindgen::rt::as_i64({})", s));
             }
             Instruction::I32FromChar
             | Instruction::I32FromU8
@@ -954,16 +953,16 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::I32FromU32
             | Instruction::I32FromS32 => {
                 let s = operands.pop().unwrap();
-                results.push(format!("wit_bindgen_guest_rust::rt::as_i32({})", s));
+                results.push(format!("wit_bindgen::rt::as_i32({})", s));
             }
 
             Instruction::F32FromFloat32 => {
                 let s = operands.pop().unwrap();
-                results.push(format!("wit_bindgen_guest_rust::rt::as_f32({})", s));
+                results.push(format!("wit_bindgen::rt::as_f32({})", s));
             }
             Instruction::F64FromFloat64 => {
                 let s = operands.pop().unwrap();
-                results.push(format!("wit_bindgen_guest_rust::rt::as_f64({})", s));
+                results.push(format!("wit_bindgen::rt::as_f64({})", s));
             }
             Instruction::Float32FromF32
             | Instruction::Float64FromF64
@@ -1428,7 +1427,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str("}\n");
                 results.push(result);
                 self.push_str(&format!(
-                    "wit_bindgen_guest_rust::rt::dealloc({base}, ({len} as usize) * {size}, {align});\n",
+                    "wit_bindgen::rt::dealloc({base}, ({len} as usize) * {size}, {align});\n",
                 ));
             }
 
@@ -1561,14 +1560,14 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
             Instruction::GuestDeallocate { size, align } => {
                 self.push_str(&format!(
-                    "wit_bindgen_guest_rust::rt::dealloc({}, {}, {});\n",
+                    "wit_bindgen::rt::dealloc({}, {}, {});\n",
                     operands[0], size, align
                 ));
             }
 
             Instruction::GuestDeallocateString => {
                 self.push_str(&format!(
-                    "wit_bindgen_guest_rust::rt::dealloc({}, ({}) as usize, 1);\n",
+                    "wit_bindgen::rt::dealloc({}, ({}) as usize, 1);\n",
                     operands[0], operands[1],
                 ));
             }
@@ -1621,7 +1620,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     self.push_str("\n}\n");
                 }
                 self.push_str(&format!(
-                    "wit_bindgen_guest_rust::rt::dealloc({base}, ({len} as usize) * {size}, {align});\n",
+                    "wit_bindgen::rt::dealloc({base}, ({len} as usize) * {size}, {align});\n",
                 ));
             }
         }

--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -4,13 +4,13 @@ mod codegen_tests {
     macro_rules! codegen_test {
         ($id:ident $name:tt $test:tt) => {
             mod $id {
-                wit_bindgen_guest_rust::generate!($name in $test);
+                wit_bindgen::generate!($name in $test);
 
                 #[test]
                 fn works() {}
 
                 mod unchecked {
-                    wit_bindgen_guest_rust::generate!({
+                    wit_bindgen::generate!({
                         path: $test,
                         world: $name,
                         unchecked,
@@ -27,7 +27,7 @@ mod codegen_tests {
 }
 
 mod strings {
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world not-used-name {
                 import cat: interface {
@@ -50,7 +50,7 @@ mod strings {
 
 /// Like `strings` but with raw_strings`.
 mod raw_strings {
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world not-used-name {
                 import cat: interface {
@@ -77,7 +77,7 @@ mod raw_strings {
 // and still compile.
 mod prefix {
     mod bindings {
-        wit_bindgen_guest_rust::generate!({
+        wit_bindgen::generate!({
             inline: "
                 default world baz {
                     export exports1: interface {
@@ -110,7 +110,7 @@ mod prefix {
 // This is a static compilation test to check that
 // the export macro name can be overridden.
 mod macro_name {
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world baz {
                 export exports2: interface {
@@ -133,7 +133,7 @@ mod macro_name {
 }
 
 mod skip {
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world baz {
                 export exports: interface {

--- a/crates/gen-guest-rust/tests/codegen_no_std.rs
+++ b/crates/gen-guest-rust/tests/codegen_no_std.rs
@@ -9,7 +9,7 @@ mod codegen_tests {
     macro_rules! codegen_test {
         ($id:ident $name:tt $test:tt) => {
             mod $id {
-                wit_bindgen_guest_rust::generate!({
+                wit_bindgen::generate!({
                     path: $test,
                     world: $name,
                     no_std,
@@ -19,7 +19,7 @@ mod codegen_tests {
                 fn works() {}
 
                 mod unchecked {
-                    wit_bindgen_guest_rust::generate!({
+                    wit_bindgen::generate!({
                         path: $test,
                         world: $name,
                         unchecked,
@@ -39,7 +39,7 @@ mod codegen_tests {
 mod strings {
     use alloc::string::String;
 
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world not-used-name {
                 import cat: interface {
@@ -65,7 +65,7 @@ mod strings {
 mod raw_strings {
     use alloc::vec::Vec;
 
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world not-used-name {
                 import cat: interface {
@@ -98,7 +98,7 @@ mod prefix {
     };
 
     mod bindings {
-        wit_bindgen_guest_rust::generate!({
+        wit_bindgen::generate!({
             inline: "
                 default world baz {
                     export exports1: interface {
@@ -134,7 +134,7 @@ mod prefix {
 mod macro_name {
     use alloc::{format, string::String};
 
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world baz {
                 export exports2: interface {
@@ -158,7 +158,7 @@ mod macro_name {
 }
 
 mod skip {
-    wit_bindgen_guest_rust::generate!({
+    wit_bindgen::generate!({
         inline: "
             default world baz {
                 export exports: interface {

--- a/crates/gen-guest-teavm-java/Cargo.toml
+++ b/crates/gen-guest-teavm-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-gen-guest-teavm-java"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/gen-markdown/Cargo.toml
+++ b/crates/gen-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-gen-markdown"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/gen-rust-lib/Cargo.toml
+++ b/crates/gen-rust-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-gen-rust-lib"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/guest-rust-macro/Cargo.toml
+++ b/crates/guest-rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-guest-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [lib]

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wit-bindgen-guest-rust"
+name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version.workspace = true
 edition.workspace = true

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/test-helpers/Cargo.toml
+++ b/crates/test-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-helpers"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 publish = false
 

--- a/crates/test-helpers/codegen-macro/Cargo.toml
+++ b/crates/test-helpers/codegen-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codegen-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 publish = false
 

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-wit-bindgen-guest-rust = { path = "../guest-rust" }
+wit-bindgen = { path = "../guest-rust" }
 
 [features]
 unchecked = []

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-rust-wasm"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 publish = false
 

--- a/crates/wasi_snapshot_preview1/Cargo.toml
+++ b/crates/wasi_snapshot_preview1/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 wasi = "0.11.0"
-wit-bindgen-guest-rust = { workspace = true, default-features = false, features = ["macros"] }
+wit-bindgen = { workspace = true, default-features = false, features = ["macros"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasi_snapshot_preview1/Cargo.toml
+++ b/crates/wasi_snapshot_preview1/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasi_snapshot_preview1"
 version = "0.0.0"
 edition.workspace = true
+publish = false
 
 [dependencies]
 wasi = "0.11.0"

--- a/crates/wasi_snapshot_preview1/src/lib.rs
+++ b/crates/wasi_snapshot_preview1/src/lib.rs
@@ -18,7 +18,7 @@
 use std::arch::wasm32::unreachable;
 use wasi::*;
 
-wit_bindgen_guest_rust::generate!("testwasi");
+wit_bindgen::generate!("testwasi");
 
 #[no_mangle]
 pub extern "C" fn environ_get(environ: *mut *mut u8, environ_buf: *mut u8) -> Errno {

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/flavorful");
+wit_bindgen::generate!("world" in "../../tests/runtime/flavorful");
 
 use exports::*;
 

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/lists");
+wit_bindgen::generate!("world" in "../../tests/runtime/lists");
 
 struct Component;
 

--- a/tests/runtime/many_arguments/wasm.rs
+++ b/tests/runtime/many_arguments/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/many_arguments");
+wit_bindgen::generate!("world" in "../../tests/runtime/many_arguments");
 
 struct Component;
 

--- a/tests/runtime/numbers/wasm.rs
+++ b/tests/runtime/numbers/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/numbers");
+wit_bindgen::generate!("world" in "../../tests/runtime/numbers");
 
 use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
 

--- a/tests/runtime/records/wasm.rs
+++ b/tests/runtime/records/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/records");
+wit_bindgen::generate!("world" in "../../tests/runtime/records");
 
 use exports::*;
 

--- a/tests/runtime/results/wasm.rs
+++ b/tests/runtime/results/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/results");
+wit_bindgen::generate!("world" in "../../tests/runtime/results");
 
 struct Exports;
 

--- a/tests/runtime/smoke/wasm.rs
+++ b/tests/runtime/smoke/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/smoke");
+wit_bindgen::generate!("world" in "../../tests/runtime/smoke");
 
 struct Exports;
 

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/unions");
+wit_bindgen::generate!("world" in "../../tests/runtime/unions");
 
 use exports::*;
 

--- a/tests/runtime/variants/wasm.rs
+++ b/tests/runtime/variants/wasm.rs
@@ -1,4 +1,4 @@
-wit_bindgen_guest_rust::generate!("world" in "../../tests/runtime/variants");
+wit_bindgen::generate!("world" in "../../tests/runtime/variants");
 
 use exports::*;
 


### PR DESCRIPTION
This commit prepares this repository for starting the publication process to crates.io and binary releases. Now that we're intending to enter an era of more stability around WIT and the component model binary format it seems prudent to have releases of this repository to assist others with integrating the tooling into their workflows. At this time this includes:

* Tags will be published when necessary to represent versions of `wit-bindgen`. All crates are managed separately with different versions and publication of one crate doesn't necessarily imply one of the other. All publishes will update the CLI version though.
* A script has been added to make managing versions a bit easier in this repository. (`ci/publish.rs`)
* Tags will have a GitHub release made with prebuilt binaries of the `wit-bindgen` binary. 
* The Rust guest embedding is now named `wit-bindgen` as a crate name instead of `wit-bindgen-gen-guest-rust`.

Once this is sorted out I plan on doing a trial run with an 0.3.0 release of all the fiddly bits here.