### PR TITLE
Add `#[doc(hidden)]` to `__WIT_BINDGEN_COMPONENT_TYPE`.

### DIFF
--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -255,6 +255,7 @@ impl WorldGenerator for RustWasm {
         let component_type =
             wit_component::metadata::encode(resolve, world, wit_component::StringEncoding::UTF8)
                 .unwrap();
+        self.src.push_str("#[doc(hidden)]");
         self.src.push_str(&format!(
             "pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; {}] = ",
             component_type.len()


### PR DESCRIPTION
Add `#[doc(hidden)]` to `__WIT_BINDGEN_COMPONENT_TYPE` so that it doesn't show up in rustdo documentation for the generated bindings.