### PR TITLE
Standardize on world selection throughout tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0fe225a32528b42a7037add1b5ed1dff83288f21a067007b34565ce87fc2c7"
+checksum = "a84965789410bf21087f5a352703142f77b9b4d1478764c3f33a1ea8c7101f40"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = "1.9.1"
 wasm-encoder = "0.24.0"
 wasm-metadata = "0.2.0"
 wat = "1.0.59"
-wit-parser = "0.6.0"
+wit-parser = "0.6.1"
 wit-component = "0.7.0"
 
 wit-bindgen-core = { path = 'crates/bindgen-core', version = '0.3.0' }

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -135,11 +135,6 @@ fn parse_wit(path: &Path) -> (Resolve, WorldId) {
             )
             .unwrap()
     };
-    let world = resolve.packages[pkg]
-        .documents
-        .iter()
-        .filter_map(|(_, doc)| resolve.documents[*doc].default_world)
-        .next()
-        .expect("no `default world` found");
+    let world = resolve.select_world(pkg, None).unwrap();
     (resolve, world)
 }

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use std::path::PathBuf;
 use std::str;
@@ -142,44 +142,7 @@ fn gen_world(
             &Default::default(),
         )?
     };
-    let world = match &opts.world {
-        Some(world) => {
-            let mut parts = world.splitn(2, '.');
-            let doc = parts.next().unwrap();
-            let world = parts.next();
-            let doc = *resolve.packages[pkg]
-                .documents
-                .get(doc)
-                .ok_or_else(|| anyhow!("no document named `{doc}` in package"))?;
-            match world {
-                Some(name) => *resolve.documents[doc]
-                    .worlds
-                    .get(name)
-                    .ok_or_else(|| anyhow!("no world named `{name}` in document"))?,
-                None => resolve.documents[doc]
-                    .default_world
-                    .ok_or_else(|| anyhow!("no default world in document"))?,
-            }
-        }
-        None => {
-            if resolve.packages[pkg].documents.is_empty() {
-                bail!("no documents found in package")
-            }
-
-            let mut unique_default_world = None;
-            for (_name, doc) in &resolve.documents {
-                if let Some(default_world) = doc.default_world {
-                    if unique_default_world.is_some() {
-                        bail!("multiple default worlds found in package, specify which to bind with `--world` argument")
-                    } else {
-                        unique_default_world = Some(default_world);
-                    }
-                }
-            }
-
-            unique_default_world.ok_or_else(|| anyhow!("no default world in package"))?
-        }
-    };
+    let world = resolve.select_world(pkg, opts.world.as_deref())?;
     generator.generate(&resolve, world, files);
     Ok(())
 }

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -76,12 +76,7 @@ fn tests(name: &str) -> Result<Vec<PathBuf>> {
 
     let mut resolve = Resolve::new();
     let (pkg, _files) = resolve.push_dir(&dir).unwrap();
-    let world = resolve.packages[pkg]
-        .documents
-        .iter()
-        .filter_map(|(_, doc)| resolve.documents[*doc].default_world)
-        .next()
-        .expect("no default world found");
+    let world = resolve.select_world(pkg, None).unwrap();
 
     let mut rust = Vec::new();
     let mut c = Vec::new();


### PR DESCRIPTION
This updates to use `Resolve::select_world` which was added to `wit-parser` from #494.