### PR TITLE
Make the Rust bindings friendlier for ahead-of-time generation.

### DIFF
--- a/crates/gen-guest-rust/tests/codegen.rs
+++ b/crates/gen-guest-rust/tests/codegen.rs
@@ -8,17 +8,6 @@ mod codegen_tests {
 
                 #[test]
                 fn works() {}
-
-                mod unchecked {
-                    wit_bindgen::generate!({
-                        path: $test,
-                        world: $name,
-                        unchecked,
-                    });
-
-                    #[test]
-                    fn works() {}
-                }
             }
 
         };

--- a/crates/gen-guest-rust/tests/codegen_no_std.rs
+++ b/crates/gen-guest-rust/tests/codegen_no_std.rs
@@ -1,7 +1,13 @@
 //! Like `codegen_tests` in codegen.rs, but with no_std.
+//!
+//! We use `std_feature` and don't enable the "std" feature.
 
 #![no_std]
 #![allow(unused_macros)]
+
+// This test expects `"std"` to be absent.
+#[cfg(feature = "std")]
+fn std_enabled() -> CompileError;
 
 extern crate alloc;
 
@@ -12,23 +18,11 @@ mod codegen_tests {
                 wit_bindgen::generate!({
                     path: $test,
                     world: $name,
-                    no_std,
+                    std_feature,
                 });
 
                 #[test]
                 fn works() {}
-
-                mod unchecked {
-                    wit_bindgen::generate!({
-                        path: $test,
-                        world: $name,
-                        unchecked,
-                        no_std,
-                    });
-
-                    #[test]
-                    fn works() {}
-                }
             }
 
         };
@@ -48,7 +42,7 @@ mod strings {
                 }
             }
         ",
-        no_std,
+        std_feature,
     });
 
     #[allow(dead_code)]
@@ -75,7 +69,7 @@ mod raw_strings {
             }
         ",
         raw_strings,
-        no_std,
+        std_feature,
     });
 
     #[allow(dead_code)]
@@ -108,7 +102,7 @@ mod prefix {
                 }
             ",
             macro_call_prefix: "bindings::",
-            no_std,
+            std_feature,
         });
 
         pub(crate) use export_baz;
@@ -143,7 +137,7 @@ mod macro_name {
             }
         ",
         export_macro_name: "jam",
-        no_std,
+        std_feature,
     });
 
     struct Component;
@@ -168,7 +162,7 @@ mod skip {
             }
         ",
         skip: ["foo"],
-        no_std,
+        std_feature,
     });
 
     struct Component;

--- a/crates/gen-rust-lib/src/lib.rs
+++ b/crates/gen-rust-lib/src/lib.rs
@@ -16,8 +16,9 @@ pub trait RustGenerator<'a> {
     fn resolve(&self) -> &'a Resolve;
     fn path_to_interface(&self, interface: InterfaceId) -> Option<String>;
 
-    /// Return true iff the generator can use `std` features in its output.
-    fn use_std(&self) -> bool {
+    /// Return true iff the generator should qualify uses of `std` features with
+    /// `#[cfg(feature = "std")]` in its output.
+    fn std_feature(&self) -> bool {
         true
     }
 
@@ -577,11 +578,12 @@ pub trait RustGenerator<'a> {
                 self.push_str("write!(f, \"{:?}\", self)\n");
                 self.push_str("}\n");
                 self.push_str("}\n");
-                if self.use_std() {
-                    self.push_str("impl std::error::Error for ");
-                    self.push_str(&name);
-                    self.push_str("{}\n");
+                if self.std_feature() {
+                    self.push_str("#[cfg(feature = \"std\")]");
                 }
+                self.push_str("impl std::error::Error for ");
+                self.push_str(&name);
+                self.push_str("{}\n");
             }
         }
     }
@@ -726,14 +728,15 @@ pub trait RustGenerator<'a> {
                 self.push_str("}\n");
                 self.push_str("\n");
 
-                if self.use_std() {
-                    self.push_str("impl");
-                    self.print_generics(lt);
-                    self.push_str(" std::error::Error for ");
-                    self.push_str(&name);
-                    self.print_generics(lt);
-                    self.push_str(" {}\n");
+                if self.std_feature() {
+                    self.push_str("#[cfg(feature = \"std\")]");
                 }
+                self.push_str("impl");
+                self.print_generics(lt);
+                self.push_str(" std::error::Error for ");
+                self.push_str(&name);
+                self.print_generics(lt);
+                self.push_str(" {}\n");
             }
         }
     }
@@ -898,11 +901,12 @@ pub trait RustGenerator<'a> {
             self.push_str("}\n");
             self.push_str("}\n");
             self.push_str("\n");
-            if self.use_std() {
-                self.push_str("impl std::error::Error for ");
-                self.push_str(&name);
-                self.push_str("{}\n");
+            if self.std_feature() {
+                self.push_str("#[cfg(feature = \"std\")]");
             }
+            self.push_str("impl std::error::Error for ");
+            self.push_str(&name);
+            self.push_str("{}\n");
         } else {
             self.print_rust_enum_debug(
                 id,

--- a/crates/guest-rust-macro/src/lib.rs
+++ b/crates/guest-rust-macro/src/lib.rs
@@ -57,8 +57,7 @@ impl Parse for Config {
                         }
                         source = Some(Source::Inline(s.value()));
                     }
-                    Opt::Unchecked => opts.unchecked = true,
-                    Opt::NoStd => opts.no_std = true,
+                    Opt::UseStdFeature => opts.std_feature = true,
                     Opt::RawStrings => opts.raw_strings = true,
                     Opt::MacroExport => opts.macro_export = true,
                     Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
@@ -138,8 +137,7 @@ impl Config {
 }
 
 mod kw {
-    syn::custom_keyword!(unchecked);
-    syn::custom_keyword!(no_std);
+    syn::custom_keyword!(std_feature);
     syn::custom_keyword!(raw_strings);
     syn::custom_keyword!(macro_export);
     syn::custom_keyword!(macro_call_prefix);
@@ -154,8 +152,7 @@ enum Opt {
     World(syn::LitStr),
     Path(syn::LitStr),
     Inline(syn::LitStr),
-    Unchecked,
-    NoStd,
+    UseStdFeature,
     RawStrings,
     MacroExport,
     MacroCallPrefix(syn::LitStr),
@@ -178,12 +175,9 @@ impl Parse for Opt {
             input.parse::<kw::world>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::World(input.parse()?))
-        } else if l.peek(kw::unchecked) {
-            input.parse::<kw::unchecked>()?;
-            Ok(Opt::Unchecked)
-        } else if l.peek(kw::no_std) {
-            input.parse::<kw::no_std>()?;
-            Ok(Opt::NoStd)
+        } else if l.peek(kw::std_feature) {
+            input.parse::<kw::std_feature>()?;
+            Ok(Opt::UseStdFeature)
         } else if l.peek(kw::raw_strings) {
             input.parse::<kw::raw_strings>()?;
             Ok(Opt::RawStrings)

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [dependencies]
 wit-bindgen = { path = "../guest-rust" }
 
-[features]
-unchecked = []
-
 [lib]
 test = false
 doctest = false


### PR DESCRIPTION
In place of `no_std`, add a `std_feature` option, which tells the code generator to add `#[cfg(feature = "std")]` to any use of `std`. This allows the same bindings support either std or no-std depending on the cargo flags in the crate using them.

And, in place of `unchecked`, use `#[cfg(not(debug_assertion))]`, so that we automatically disable checks in release builds. That said, dsabling checks in release builds isn't essential here; if we want to keep those on, I could add a new cargo feature for the checks to be controlled by.

This way we can have a bindings crate with one copy of the generated output that works across std and no_std, and disables checks in release builds.
