### PR TITLE
Handle interface names that collide with Rust keywords.

### DIFF
--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -373,7 +373,7 @@ impl InterfaceGenerator<'_> {
 
     fn finish_append_submodule(mut self, name: &str) {
         let module = self.finish();
-        let snake = name.to_snake_case();
+        let snake = to_rust_ident(name);
         uwriteln!(
             self.gen.src,
             "

--- a/tests/codegen/keywords-in-interfaces-and-worlds.wit
+++ b/tests/codegen/keywords-in-interfaces-and-worlds.wit
@@ -1,0 +1,9 @@
+default world trait {
+  import continue: interface {
+    break: func()
+  }
+
+  export match: interface {
+    return: func()
+  }
+}


### PR DESCRIPTION
Use `to_rust_ident` for interface names, and add a test for a world and interface with names that collide with Rust keywords.

Fixes #507.