### PR TITLE
Fix using Rust types in owned and borrowed contexts

### DIFF
--- a/crates/gen-guest-c/src/lib.rs
+++ b/crates/gen-guest-c/src/lib.rs
@@ -1115,21 +1115,7 @@ impl InterfaceGenerator<'_> {
                 let ty = &self.resolve.types[*id];
                 match &ty.name {
                     Some(name) => {
-                        match ty.owner {
-                            TypeOwner::Interface(owner) => {
-                                self.src.print(
-                                    stype,
-                                    &self.gen.interface_names[&owner].to_snake_case(),
-                                );
-                                self.src.print(stype, "_");
-                            }
-                            TypeOwner::World(owner) => {
-                                self.src
-                                    .print(stype, &self.resolve.worlds[owner].name.to_snake_case());
-                                self.src.print(stype, "_");
-                            }
-                            TypeOwner::None => {}
-                        }
+                        self.print_owner_namespace(stype, *id);
 
                         self.src.print(stype, &name.to_snake_case());
                         self.src.print(stype, "_t");
@@ -1145,6 +1131,25 @@ impl InterfaceGenerator<'_> {
                         }
                     },
                 }
+            }
+        }
+    }
+
+    fn print_owner_namespace(&mut self, stype: SourceType, id: TypeId) {
+        let ty = &self.resolve.types[id];
+        match ty.owner {
+            TypeOwner::Interface(owner) => {
+                self.src
+                    .print(stype, &self.gen.interface_names[&owner].to_snake_case());
+                self.src.print(stype, "_");
+            }
+            TypeOwner::World(owner) => {
+                self.src
+                    .print(stype, &self.resolve.worlds[owner].name.to_snake_case());
+                self.src.print(stype, "_");
+            }
+            TypeOwner::None => {
+                self.print_namespace(stype);
             }
         }
     }
@@ -1456,6 +1461,9 @@ impl InterfaceGenerator<'_> {
             Type::String => {
                 self.src.h_helpers(&self.gen.world.to_snake_case());
                 self.src.h_helpers("_");
+            }
+            Type::Id(id) => {
+                self.print_owner_namespace(SourceType::HHelpers, *id);
             }
             _ => {
                 self.print_namespace(SourceType::HHelpers);

--- a/crates/gen-rust-lib/src/lib.rs
+++ b/crates/gen-rust-lib/src/lib.rs
@@ -38,7 +38,6 @@ pub trait RustGenerator<'a> {
     fn types_mut(&mut self) -> &mut Types;
     fn print_borrowed_slice(&mut self, mutbl: bool, ty: &Type, lifetime: &'static str);
     fn print_borrowed_str(&mut self, lifetime: &'static str);
-    fn default_param_mode(&self) -> TypeMode;
 
     fn rustdoc(&mut self, docs: &Docs) {
         let docs = match &docs.contents {
@@ -207,11 +206,11 @@ pub trait RustGenerator<'a> {
         }
     }
 
-    fn type_path(&self, id: TypeId, param: bool) -> String {
-        let name = if param {
-            self.param_name(id)
-        } else {
+    fn type_path(&self, id: TypeId, owned: bool) -> String {
+        let name = if owned {
             self.result_name(id)
+        } else {
+            self.param_name(id)
         };
         if let TypeOwner::Interface(id) = self.resolve().types[id].owner {
             if let Some(path) = self.path_to_interface(id) {
@@ -226,13 +225,13 @@ pub trait RustGenerator<'a> {
         let lt = self.lifetime_for(&info, mode);
         let ty = &self.resolve().types[id];
         if ty.name.is_some() {
-            let name = self.type_path(id, lt.is_some());
+            let name = self.type_path(id, lt.is_none());
             self.push_str(&name);
 
             // If the type recursively owns data and it's a
             // variant/record/list, then we need to place the
             // lifetime parameter on the type as well.
-            if info.owns_data() && needs_generics(self.resolve(), &ty.kind) {
+            if info.has_list && needs_generics(self.resolve(), &ty.kind) {
                 self.print_generics(lt);
             }
 
@@ -383,11 +382,9 @@ pub trait RustGenerator<'a> {
     fn modes_of(&self, ty: TypeId) -> Vec<(String, TypeMode)> {
         let info = self.info(ty);
         let mut result = Vec::new();
-        if info.param {
-            result.push((self.param_name(ty), self.default_param_mode()));
-        }
-        if info.result && (!info.param || self.uses_two_names(&info)) {
-            result.push((self.result_name(ty), TypeMode::Owned));
+        result.push((self.result_name(ty), TypeMode::Owned));
+        if self.uses_two_names(&info) {
+            result.push((self.param_name(ty), TypeMode::AllBorrowed("'a")));
         }
         return result;
     }
@@ -524,7 +521,7 @@ pub trait RustGenerator<'a> {
                 self.push_str("#[component(record)]\n");
             }
 
-            if !info.owns_data() {
+            if !info.has_list {
                 self.push_str("#[repr(C)]\n");
                 self.push_str("#[derive(Copy, Clone)]\n");
             } else {
@@ -680,7 +677,7 @@ pub trait RustGenerator<'a> {
                 self.push_str("#[derive(wasmtime::component::Lower)]\n");
                 self.push_str(&format!("#[component({})]\n", derive_component));
             }
-            if !info.owns_data() {
+            if !info.has_list {
                 self.push_str("#[derive(Clone, Copy)]\n");
             } else {
                 self.push_str("#[derive(Clone)]\n");
@@ -977,13 +974,7 @@ pub trait RustGenerator<'a> {
     }
 
     fn uses_two_names(&self, info: &TypeInfo) -> bool {
-        info.owns_data()
-            && info.param
-            && info.result
-            && match self.default_param_mode() {
-                TypeMode::AllBorrowed(_) | TypeMode::LeafBorrowed(_) => true,
-                TypeMode::Owned => false,
-            }
+        info.has_list && info.borrowed && info.owned
     }
 
     fn lifetime_for(&self, info: &TypeInfo, mode: TypeMode) -> Option<&'static str> {
@@ -1104,19 +1095,15 @@ pub trait RustFunctionGenerator {
     }
 
     fn typename_lower(&self, id: TypeId) -> String {
-        let param = match self.lift_lower() {
-            LiftLower::LowerArgsLiftResults => true,
-            LiftLower::LiftArgsLowerResults => false,
+        let owned = match self.lift_lower() {
+            LiftLower::LowerArgsLiftResults => false,
+            LiftLower::LiftArgsLowerResults => true,
         };
-        self.rust_gen().type_path(id, param)
+        self.rust_gen().type_path(id, owned)
     }
 
     fn typename_lift(&self, id: TypeId) -> String {
-        let param = match self.lift_lower() {
-            LiftLower::LiftArgsLowerResults => true,
-            LiftLower::LowerArgsLiftResults => false,
-        };
-        self.rust_gen().type_path(id, param)
+        self.rust_gen().type_path(id, true)
     }
 }
 
@@ -1193,16 +1180,6 @@ pub fn int_repr(repr: Int) -> &'static str {
         Int::U16 => "u16",
         Int::U32 => "u32",
         Int::U64 => "u64",
-    }
-}
-
-trait TypeInfoExt {
-    fn owns_data(&self) -> bool;
-}
-
-impl TypeInfoExt for TypeInfo {
-    fn owns_data(&self) -> bool {
-        self.has_list
     }
 }
 

--- a/tests/codegen/lift-lower-foreign.wit
+++ b/tests/codegen/lift-lower-foreign.wit
@@ -8,11 +8,14 @@ interface a {
   type t7 = option<t2>
   type t8 = result<t2, t3>
   union t9 { t1, t2, t3, t4, u32 }
+  type t10 = list<t5>
+  type t11 = t10
 }
 
 interface the-interface {
   use self.a.{t1 as u1, t2 as u2, t3 as u3, t4 as u4, t5 as u5}
   use self.a.{t6 as u6, t7 as u7, t8 as %u8, t9 as u9}
+  use self.a.{t10 as u10, t11 as u11}
 
   f1: func(a: u1) -> u1
   f2: func(a: u2) -> u2
@@ -23,11 +26,14 @@ interface the-interface {
   f7: func(a: u7) -> u7
   f8: func(a: %u8) -> %u8
   f9: func(a: u9) -> u9
+  f10: func(a: u10) -> u10
+  f11: func(a: u11) -> u11
 }
 
 default world foo {
   use self.a.{t1 as u1, t2 as u2, t3 as u3, t4 as u4, t5 as u5}
   use self.a.{t6 as u6, t7 as u7, t8 as %u8, t9 as u9}
+  use self.a.{t10 as u10, t11 as u11}
 
   export f1: func(a: u1) -> u1
   export f2: func(a: u2) -> u2
@@ -38,6 +44,8 @@ default world foo {
   export f7: func(a: u7) -> u7
   export f8: func(a: %u8) -> %u8
   export f9: func(a: u9) -> u9
+  export f10: func(a: u10) -> u10
+  export f11: func(a: u11) -> u11
 
   import the-import: self.the-interface
   export the-export: self.the-interface

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -12,7 +12,7 @@ impl Flavorful for Component {
 
         let _guard = test_rust_wasm::guard();
 
-        f_list_in_record1(ListInRecord1 {
+        f_list_in_record1(ListInRecord1Param {
             a: "list_in_record1",
         });
         assert_eq!(f_list_in_record2().a, "list_in_record2");
@@ -30,7 +30,11 @@ impl Flavorful for Component {
             "result4"
         );
 
-        f_list_in_variant1(Some("foo"), Err("bar"), ListInVariant1V3::String("baz"));
+        f_list_in_variant1(
+            Some("foo"),
+            Err("bar"),
+            ListInVariant1V3Param::String("baz"),
+        );
         assert_eq!(f_list_in_variant2(), Some("list_in_variant2".to_string()));
         assert_eq!(
             f_list_in_variant3(Some("input3")),
@@ -62,7 +66,7 @@ impl Flavorful for Component {
 }
 
 impl exports::Exports for Component {
-    fn f_list_in_record1(ty: ListInRecord1) {
+    fn f_list_in_record1(ty: ListInRecord1Result) {
         assert_eq!(ty.a, "list_in_record1");
     }
 
@@ -72,26 +76,30 @@ impl exports::Exports for Component {
         }
     }
 
-    fn f_list_in_record3(a: ListInRecord3) -> ListInRecord3 {
+    fn f_list_in_record3(a: ListInRecord3Result) -> ListInRecord3Result {
         assert_eq!(a.a, "list_in_record3 input");
-        ListInRecord3 {
+        ListInRecord3Result {
             a: "list_in_record3 output".to_string(),
         }
     }
 
-    fn f_list_in_record4(a: ListInAlias) -> ListInAlias {
+    fn f_list_in_record4(a: ListInAliasResult) -> ListInAliasResult {
         assert_eq!(a.a, "input4");
-        ListInRecord4 {
+        ListInRecord4Result {
             a: "result4".to_string(),
         }
     }
 
-    fn f_list_in_variant1(a: ListInVariant1V1, b: ListInVariant1V2, c: ListInVariant1V3) {
+    fn f_list_in_variant1(
+        a: ListInVariant1V1Result,
+        b: ListInVariant1V2Result,
+        c: ListInVariant1V3Result,
+    ) {
         assert_eq!(a.unwrap(), "foo");
         assert_eq!(b.unwrap_err(), "bar");
         match c {
-            ListInVariant1V3::String(s) => assert_eq!(s, "baz"),
-            ListInVariant1V3::F32(_) => panic!(),
+            ListInVariant1V3Result::String(s) => assert_eq!(s, "baz"),
+            ListInVariant1V3Result::F32(_) => panic!(),
         }
     }
 
@@ -99,7 +107,7 @@ impl exports::Exports for Component {
         Some("list_in_variant2".to_string())
     }
 
-    fn f_list_in_variant3(a: ListInVariant3) -> Option<String> {
+    fn f_list_in_variant3(a: ListInVariant3Result) -> Option<String> {
         assert_eq!(a.unwrap(), "input3");
         Some("output3".to_string())
     }
@@ -112,7 +120,10 @@ impl exports::Exports for Component {
         Err(MyErrno::B)
     }
 
-    fn list_typedefs(a: ListTypedef, b: ListTypedef3) -> (ListTypedef2, ListTypedef3) {
+    fn list_typedefs(
+        a: ListTypedefResult,
+        b: ListTypedef3Result,
+    ) -> (ListTypedef2, ListTypedef3Result) {
         assert_eq!(a, "typedef1");
         assert_eq!(b.len(), 1);
         assert_eq!(b[0], "typedef2");

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -188,10 +188,10 @@ impl exports::Exports for Component {
         }
     }
 
-    fn replace_first_char(text: AllText, letter: char) -> AllText {
+    fn replace_first_char(text: AllTextResult, letter: char) -> AllTextResult {
         match text {
-            AllText::Char(_c) => AllText::Char(letter),
-            AllText::String(s) => AllText::String(format!("{}{}", letter, &s[1..])),
+            AllTextResult::Char(_c) => AllTextResult::Char(letter),
+            AllTextResult::String(s) => AllTextResult::String(format!("{}{}", letter, &s[1..])),
         }
     }
 
@@ -219,10 +219,10 @@ impl exports::Exports for Component {
         }
     }
 
-    fn identify_text(text: AllText) -> u8 {
+    fn identify_text(text: AllTextResult) -> u8 {
         match text {
-            AllText::Char(_c) => 0,
-            AllText::String(_s) => 1,
+            AllTextResult::Char(_c) => 0,
+            AllTextResult::String(_s) => 1,
         }
     }
 


### PR DESCRIPTION
This pulls in type analysis code from Wasmtime which has a more modern notion of param/result as owned/borrowed and additionally removes the need for a `default_param_mode` which caused #513 in the first place.

Closes #513