### PR TITLE
Fix Rust compilation with only borrowed structs

### DIFF
--- a/crates/gen-rust-lib/src/lib.rs
+++ b/crates/gen-rust-lib/src/lib.rs
@@ -382,7 +382,13 @@ pub trait RustGenerator<'a> {
     fn modes_of(&self, ty: TypeId) -> Vec<(String, TypeMode)> {
         let info = self.info(ty);
         let mut result = Vec::new();
-        result.push((self.result_name(ty), TypeMode::Owned));
+        let first_mode = if info.owned || !info.borrowed {
+            TypeMode::Owned
+        } else {
+            assert!(!self.uses_two_names(&info));
+            TypeMode::AllBorrowed("'a")
+        };
+        result.push((self.result_name(ty), first_mode));
         if self.uses_two_names(&info) {
             result.push((self.param_name(ty), TypeMode::AllBorrowed("'a")));
         }

--- a/tests/codegen/simple-http.wit
+++ b/tests/codegen/simple-http.wit
@@ -1,0 +1,18 @@
+interface http-fetch-imports {
+    record request{
+        method: string,
+        uri: string,
+        body: string
+    }
+
+    record response{
+        status: u16,
+        body: string
+    }
+
+    fetch: func(req: request) -> result<response>
+}
+
+default world http-fetch-simple {
+    import http-fetch-simple: self.http-fetch-imports
+}


### PR DESCRIPTION
Fixes a mistake from #514

Closes #518