### PR TITLE
Use `snake_case` when generating Rust filenames.

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -307,7 +307,8 @@ impl WorldGenerator for RustWasm {
             assert!(status.success());
         }
 
-        files.push(&format!("{name}.rs"), src.as_bytes());
+        let module_name = name.to_snake_case();
+        files.push(&format!("{module_name}.rs"), src.as_bytes());
     }
 }
 


### PR DESCRIPTION
When generating a Rust file for a world named `cli-reactor`, name the file `cli_reactor.rs` so that Rust can refer to it with `mod cli_reactor`.