### PR TITLE
Fix bindings generation with unused types in Rust

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -166,7 +166,8 @@ impl Types {
             }
             TypeDefKind::Unknown => unreachable!(),
         }
-        self.type_info.insert(ty, info);
+        let prev = self.type_info.insert(ty, info);
+        assert!(prev.is_none());
         info
     }
 

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 macro_rules! codegen_test {
     // TODO: should fix this test
     (lift_lower_foreign $name:tt $test:tt) => {};
+    (unused_import $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/crates/rust-lib/src/lib.rs
+++ b/crates/rust-lib/src/lib.rs
@@ -381,6 +381,9 @@ pub trait RustGenerator<'a> {
 
     fn modes_of(&self, ty: TypeId) -> Vec<(String, TypeMode)> {
         let info = self.info(ty);
+        if !info.owned && !info.borrowed {
+            return Vec::new();
+        }
         let mut result = Vec::new();
         let first_mode = if info.owned || !info.borrowed {
             TypeMode::Owned

--- a/tests/codegen/unused-import.wit
+++ b/tests/codegen/unused-import.wit
@@ -1,0 +1,17 @@
+interface types {
+    record r {
+        a: list<u8>,
+    }
+}
+
+default world the-world {
+    import foo: interface {
+      use self.types.{r}
+
+      foo: func(data: r)
+    }
+
+    export bar: interface {
+      use self.types.{r}
+    }
+}


### PR DESCRIPTION
This commit fixes an issue where if a type was imported into an interface but wasn't actually used anywhere then bindings weren't correctly generated because inference about whether it was owned or borrowed didn't run. The fix here is to skip generating bindings for unused types since they're not actually needed anywhere anyway. If necessary in the future bindings can be forcibly generated but for now this is hopefully largely "just" fixing an edge case.