### PR TITLE
Bump all crates to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "wit-bindgen-rust-macro",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-c"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-go"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "heck",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-markdown"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "heck",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "heck",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-lib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-teavm-java"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-cli"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition = { workspace = true }
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -35,14 +35,14 @@ wat = "1.0.59"
 wit-parser = "0.6.2"
 wit-component = "0.7.1"
 
-wit-bindgen-core = { path = 'crates/core', version = '0.3.0' }
-wit-bindgen-c = { path = 'crates/c', version = '0.3.0' }
-wit-bindgen-rust = { path = "crates/rust", version = "0.3.0" }
-wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.3.0' }
-wit-bindgen-go = { path = 'crates/go', version = '0.1.0' }
-wit-bindgen-markdown = { path = 'crates/markdown', version = '0.3.0' }
-wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.3.0' }
-wit-bindgen = { path = 'crates/guest-rust', version = '0.3.0', default-features = false }
+wit-bindgen-core = { path = 'crates/core', version = '0.4.0' }
+wit-bindgen-c = { path = 'crates/c', version = '0.4.0' }
+wit-bindgen-rust = { path = "crates/rust", version = "0.4.0" }
+wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.4.0' }
+wit-bindgen-go = { path = 'crates/go', version = '0.2.0' }
+wit-bindgen-markdown = { path = 'crates/markdown', version = '0.4.0' }
+wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.4.0' }
+wit-bindgen = { path = 'crates/guest-rust', version = '0.4.0', default-features = false }
 wit-bindgen-rust-macro-shared = { path = 'crates/rust-macro-shared', version = '0.3.0' }
 
 [[bin]]

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -30,6 +30,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wit-bindgen-rust-lib",
     "wit-bindgen-c",
     "wit-bindgen-rust",
+    "wit-bindgen-go",
     "wit-bindgen-teavm-java",
     "wit-bindgen-markdown",
     "wit-bindgen-rust-macro",

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-c"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-core"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/go/Cargo.toml
+++ b/crates/go/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-go"
 authors = ["Mossaka <duibao55328@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ Used when compiling Rust programs to the component model.
 """
 
 [dependencies]
-wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.3.0" }
+wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.4.0" }
 bitflags = { workspace = true }
 
 [features]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-markdown"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-lib/Cargo.toml
+++ b/crates/rust-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-lib"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/teavm-java/Cargo.toml
+++ b/crates/teavm-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-teavm-java"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Enough has happened it seems reasonable to release everything now. There have been a number of fixes to Rust and other generators and additionally there's a new Go generator!