### PR TITLE
rust: export funcs explicitly invoke static constructors at most once

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -21,6 +21,7 @@ pub mod rt {
     /// permitted by the Component Model when inside realloc.
     ///
     /// We intend to remove this once rust 1.69.0 stabilizes.
+    #[cfg(target_arch = "wasm32")]
     pub fn run_ctors_once() {
         static mut RUN: bool = false;
         unsafe {

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -509,6 +509,20 @@ impl InterfaceGenerator<'_> {
             "
                 #[allow(unused_imports)]
                 use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
+
+                // Before executing any other code, use this function
+                // (provided by wasm-ld) to run all static constructors. When
+                // wasm-ld sees this explicit invocation of ctors, it will not
+                // generate a wrapper around each exported func which executes
+                // ctors first, and therefore we make sure that cabi_realloc
+                // doesnt invoke ctors when called as an export func.
+                // See
+                // https://github.com/bytecodealliance/preview2-prototyping/issues/99
+                // for more details.
+
+                extern \"C\" {{ fn __wasm_call_ctors(); }}
+                unsafe {{ __wasm_call_ctors() }}
+
             "
         );
 

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -520,8 +520,11 @@ impl InterfaceGenerator<'_> {
                 // https://github.com/bytecodealliance/preview2-prototyping/issues/99
                 // for more details.
 
-                extern \"C\" {{ fn __wasm_call_ctors(); }}
-                unsafe {{ __wasm_call_ctors() }}
+                #[cfg(target_arch=\"wasm32\")]
+                {{
+                    extern \"C\" {{ fn __wasm_call_ctors(); }}
+                    unsafe {{ __wasm_call_ctors() }}
+                }}
 
             "
         );

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -521,7 +521,7 @@ impl InterfaceGenerator<'_> {
                 // See
                 // https://github.com/bytecodealliance/preview2-prototyping/issues/99
                 // for more details.
-
+                #[cfg(target_arch=\"wasm32\")]
                 wit_bindgen::rt::run_ctors_once();
 
             "

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -510,21 +510,19 @@ impl InterfaceGenerator<'_> {
                 #[allow(unused_imports)]
                 use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
 
-                // Before executing any other code, use this function
-                // (provided by wasm-ld) to run all static constructors. When
-                // wasm-ld sees this explicit invocation of ctors, it will not
-                // generate a wrapper around each exported func which executes
-                // ctors first, and therefore we make sure that cabi_realloc
-                // doesnt invoke ctors when called as an export func.
+                // Before executing any other code, use this function to run all static
+                // constructors, if they have not yet been run. This is a hack required
+                // to work around wasi-libc ctors calling import functions to initialize
+                // the environment.
+                //
+                // This functionality will be removed once rust 1.69.0 is stable, at which
+                // point wasi-libc will no longer have this behavior.
+                //
                 // See
                 // https://github.com/bytecodealliance/preview2-prototyping/issues/99
                 // for more details.
 
-                #[cfg(target_arch=\"wasm32\")]
-                {{
-                    extern \"C\" {{ fn __wasm_call_ctors(); }}
-                    unsafe {{ __wasm_call_ctors() }}
-                }}
+                wit_bindgen::rt::run_ctors_once();
 
             "
         );


### PR DESCRIPTION
Before executing any other code, use this function (provided by wasm-ld)
to run all static constructors. When wasm-ld sees this explicit invocation
of ctors, it will not generate a wrapper aorund each exported func which
executes ctors first, and therefore we make sure that cabi_realloc doesnt
invoke ctors when called as an export func.
See https://github.com/bytecodealliance/preview2-prototyping/issues/99
for more details.
