### PR TITLE
wit-bindgen-rust: link component type for imports.

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -375,7 +375,7 @@ impl InterfaceGenerator<'_> {
                     #[used]
                     #[doc(hidden)]
                     #[cfg(target_arch = \"wasm32\")]
-                    static __FORCE_SECTION_REF: fn() = crate::__link_section;
+                    static __FORCE_SECTION_REF: fn() = super::__link_section;
 
                     {module}
                 }}

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -230,12 +230,7 @@ impl WorldGenerator for RustWasm {
                         #[used]
                         #[doc(hidden)]
                         #[cfg(target_arch = \"wasm32\")]
-                        static __FORCE_SECTION_REF: fn() = __force_section_ref;
-                        #[doc(hidden)]
-                        #[cfg(target_arch = \"wasm32\")]
-                        fn __force_section_ref() {{
-                            {prefix}__link_section()
-                        }}
+                        static __FORCE_SECTION_REF: fn() = {prefix}__link_section;
                     }});
                 ",
                 prefix = self.opts.macro_call_prefix.as_deref().unwrap_or("")
@@ -377,9 +372,14 @@ impl InterfaceGenerator<'_> {
             "
                 #[allow(clippy::all)]
                 pub mod {snake} {{
+                    #[used]
+                    #[doc(hidden)]
+                    #[cfg(target_arch = \"wasm32\")]
+                    static __FORCE_SECTION_REF: fn() = crate::__link_section;
+
                     {module}
                 }}
-            "
+            ",
         );
     }
 


### PR DESCRIPTION
This PR forces a reference to the component type in import sub-modules.

It fixes an issue when building bindings to a different crate and only referencing an import binding.

As there was no reference to `__link_section`, the generated core module from the LLVM toolchain was missing the component type custom section.

The fix simply performs what we're already doing for exports in the `export!` macro, but adds the reference to each generated import submodule.