### PR TITLE
Don't generate `*Param` and `*Result` types in Rust by default

### DIFF
--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -60,6 +60,7 @@ impl Parse for Config {
                     Opt::UseStdFeature => opts.std_feature = true,
                     Opt::RawStrings => opts.raw_strings = true,
                     Opt::MacroExport => opts.macro_export = true,
+                    Opt::DuplicateIfNecessary => opts.duplicate_if_necessary = true,
                     Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
                     Opt::ExportMacroName(name) => opts.export_macro_name = Some(name.value()),
                     Opt::Skip(list) => opts.skip.extend(list.iter().map(|i| i.value())),
@@ -146,6 +147,7 @@ mod kw {
     syn::custom_keyword!(world);
     syn::custom_keyword!(path);
     syn::custom_keyword!(inline);
+    syn::custom_keyword!(duplicate_if_necessary);
 }
 
 enum Opt {
@@ -158,6 +160,7 @@ enum Opt {
     MacroCallPrefix(syn::LitStr),
     ExportMacroName(syn::LitStr),
     Skip(Vec<syn::LitStr>),
+    DuplicateIfNecessary,
 }
 
 impl Parse for Opt {
@@ -184,6 +187,9 @@ impl Parse for Opt {
         } else if l.peek(kw::macro_export) {
             input.parse::<kw::macro_export>()?;
             Ok(Opt::MacroExport)
+        } else if l.peek(kw::duplicate_if_necessary) {
+            input.parse::<kw::duplicate_if_necessary>()?;
+            Ok(Opt::DuplicateIfNecessary)
         } else if l.peek(kw::macro_call_prefix) {
             input.parse::<kw::macro_call_prefix>()?;
             input.parse::<Token![:]>()?;

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -66,6 +66,12 @@ pub struct Opts {
     /// Names of functions to skip generating bindings for.
     #[cfg_attr(feature = "clap", arg(long))]
     pub skip: Vec<String>,
+
+    /// Whether or not to generate "duplicate" type definitions for a single
+    /// WIT type if necessary, for example if it's used as both an import and an
+    /// export.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub duplicate_if_necessary: bool,
 }
 
 impl Opts {
@@ -399,7 +405,7 @@ impl InterfaceGenerator<'_> {
         self.src.push_str(
             "
                 #[allow(unused_imports)]
-                use wit_bindgen::rt::{{alloc, vec::Vec, string::String}};
+                use wit_bindgen::rt::{alloc, vec::Vec, string::String};
             ",
         );
         self.src.push_str("unsafe {\n");
@@ -615,6 +621,10 @@ impl InterfaceGenerator<'_> {
 impl<'a> RustGenerator<'a> for InterfaceGenerator<'a> {
     fn resolve(&self) -> &'a Resolve {
         self.resolve
+    }
+
+    fn duplicate_if_necessary(&self) -> bool {
+        self.gen.opts.duplicate_if_necessary
     }
 
     fn path_to_interface(&self, interface: InterfaceId) -> Option<String> {

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -8,6 +8,17 @@ mod codegen_tests {
 
                 #[test]
                 fn works() {}
+
+                mod duplicate {
+                    wit_bindgen::generate!({
+                        world: $name,
+                        path: $test,
+                        duplicate_if_necessary,
+                    });
+
+                    #[test]
+                    fn works() {}
+                }
             }
 
         };

--- a/tests/runtime/flavorful/wasm.rs
+++ b/tests/runtime/flavorful/wasm.rs
@@ -12,32 +12,35 @@ impl Flavorful for Component {
 
         let _guard = test_rust_wasm::guard();
 
-        f_list_in_record1(ListInRecord1Param {
-            a: "list_in_record1",
+        f_list_in_record1(&ListInRecord1 {
+            a: "list_in_record1".to_string(),
         });
         assert_eq!(f_list_in_record2().a, "list_in_record2");
 
         assert_eq!(
-            f_list_in_record3(ListInRecord3Param {
-                a: "list_in_record3 input"
+            f_list_in_record3(&ListInRecord3 {
+                a: "list_in_record3 input".to_string()
             })
             .a,
             "list_in_record3 output"
         );
 
         assert_eq!(
-            f_list_in_record4(ListInAliasParam { a: "input4" }).a,
+            f_list_in_record4(&ListInAlias {
+                a: "input4".to_string()
+            })
+            .a,
             "result4"
         );
 
         f_list_in_variant1(
-            Some("foo"),
-            Err("bar"),
-            ListInVariant1V3Param::String("baz"),
+            &Some("foo".to_string()),
+            &Err("bar".to_string()),
+            &ListInVariant1V3::String("baz".to_string()),
         );
         assert_eq!(f_list_in_variant2(), Some("list_in_variant2".to_string()));
         assert_eq!(
-            f_list_in_variant3(Some("input3")),
+            f_list_in_variant3(&Some("input3".to_string())),
             Some("output3".to_string())
         );
 
@@ -49,7 +52,7 @@ impl Flavorful for Component {
 
         assert!(errno_result().is_ok());
 
-        let (a, b) = list_typedefs("typedef1", &["typedef2"]);
+        let (a, b) = list_typedefs(&"typedef1".to_string(), &vec!["typedef2".to_string()]);
         assert_eq!(a, b"typedef3");
         assert_eq!(b.len(), 1);
         assert_eq!(b[0], "typedef4");
@@ -66,7 +69,7 @@ impl Flavorful for Component {
 }
 
 impl exports::Exports for Component {
-    fn f_list_in_record1(ty: ListInRecord1Result) {
+    fn f_list_in_record1(ty: ListInRecord1) {
         assert_eq!(ty.a, "list_in_record1");
     }
 
@@ -76,30 +79,26 @@ impl exports::Exports for Component {
         }
     }
 
-    fn f_list_in_record3(a: ListInRecord3Result) -> ListInRecord3Result {
+    fn f_list_in_record3(a: ListInRecord3) -> ListInRecord3 {
         assert_eq!(a.a, "list_in_record3 input");
-        ListInRecord3Result {
+        ListInRecord3 {
             a: "list_in_record3 output".to_string(),
         }
     }
 
-    fn f_list_in_record4(a: ListInAliasResult) -> ListInAliasResult {
+    fn f_list_in_record4(a: ListInAlias) -> ListInAlias {
         assert_eq!(a.a, "input4");
-        ListInRecord4Result {
+        ListInRecord4 {
             a: "result4".to_string(),
         }
     }
 
-    fn f_list_in_variant1(
-        a: ListInVariant1V1Result,
-        b: ListInVariant1V2Result,
-        c: ListInVariant1V3Result,
-    ) {
+    fn f_list_in_variant1(a: ListInVariant1V1, b: ListInVariant1V2, c: ListInVariant1V3) {
         assert_eq!(a.unwrap(), "foo");
         assert_eq!(b.unwrap_err(), "bar");
         match c {
-            ListInVariant1V3Result::String(s) => assert_eq!(s, "baz"),
-            ListInVariant1V3Result::F32(_) => panic!(),
+            ListInVariant1V3::String(s) => assert_eq!(s, "baz"),
+            ListInVariant1V3::F32(_) => panic!(),
         }
     }
 
@@ -107,7 +106,7 @@ impl exports::Exports for Component {
         Some("list_in_variant2".to_string())
     }
 
-    fn f_list_in_variant3(a: ListInVariant3Result) -> Option<String> {
+    fn f_list_in_variant3(a: ListInVariant3) -> Option<String> {
         assert_eq!(a.unwrap(), "input3");
         Some("output3".to_string())
     }
@@ -120,10 +119,7 @@ impl exports::Exports for Component {
         Err(MyErrno::B)
     }
 
-    fn list_typedefs(
-        a: ListTypedefResult,
-        b: ListTypedef3Result,
-    ) -> (ListTypedef2, ListTypedef3Result) {
+    fn list_typedefs(a: ListTypedef, b: ListTypedef3) -> (ListTypedef2, ListTypedef3) {
         assert_eq!(a, "typedef1");
         assert_eq!(b.len(), 1);
         assert_eq!(b[0], "typedef2");

--- a/tests/runtime/unions/wasm.rs
+++ b/tests/runtime/unions/wasm.rs
@@ -97,11 +97,11 @@ impl Unions for Component {
 
         // All-Text
         assert!(matches!(
-            replace_first_char(AllTextParam::Char('a'), 'z'),
-            AllTextResult::Char('z')
+            replace_first_char(&AllText::Char('a'), 'z'),
+            AllText::Char('z')
         ));
         assert!(
-            matches!(replace_first_char(AllTextParam::String("abc"), 'z'), AllTextResult::String(r) if r == "zbc")
+            matches!(replace_first_char(&AllText::String("abc".to_string()), 'z'), AllText::String(r) if r == "zbc")
         );
 
         // All-Integers
@@ -120,8 +120,11 @@ impl Unions for Component {
         assert!(matches!(identify_float(AllFloats::F64(0.0)), 1));
 
         // All-Text
-        assert!(matches!(identify_text(AllTextParam::Char('a')), 0));
-        assert!(matches!(identify_text(AllTextParam::String("abc")), 1));
+        assert!(matches!(identify_text(&AllText::Char('a')), 0));
+        assert!(matches!(
+            identify_text(&AllText::String("abc".to_string())),
+            1
+        ));
 
         // Duplicated
         assert!(matches!(
@@ -188,10 +191,10 @@ impl exports::Exports for Component {
         }
     }
 
-    fn replace_first_char(text: AllTextResult, letter: char) -> AllTextResult {
+    fn replace_first_char(text: AllText, letter: char) -> AllText {
         match text {
-            AllTextResult::Char(_c) => AllTextResult::Char(letter),
-            AllTextResult::String(s) => AllTextResult::String(format!("{}{}", letter, &s[1..])),
+            AllText::Char(_c) => AllText::Char(letter),
+            AllText::String(s) => AllText::String(format!("{}{}", letter, &s[1..])),
         }
     }
 
@@ -219,10 +222,10 @@ impl exports::Exports for Component {
         }
     }
 
-    fn identify_text(text: AllTextResult) -> u8 {
+    fn identify_text(text: AllText) -> u8 {
         match text {
-            AllTextResult::Char(_c) => 0,
-            AllTextResult::String(_s) => 1,
+            AllText::Char(_c) => 0,
+            AllText::String(_s) => 1,
         }
     }
 


### PR DESCRIPTION
Previously when a single WIT type was used in a "borrowed" position, or a parameter to an import, and an "owned" position then the type would have two copies of its definition generated if it internally contained a list. This was intended to signify that for import parameters ownership wasn't necessary so borrowed values could be passed in.

In practice though I don't think this was the right default to have. This surprisingly generates two types when one might expect one and otherwise if a type if received from an export and expected to be passed to an import then it's not easy to do so since it must be converted to the borrowed type.

This commit moves the preexisting behavior of generating duplicate types behind a new `duplicate_if_necessary` option. The default behavior is to no longer generate two types, but instead just one. Imports now generate their types with a `&` in front if it's otherwise owned internally to signify that ownership isn't required.

Closes #535