### PR TITLE
Bump crate versions for a release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.1.0",
  "wit-bindgen-rust-macro",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-c"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-go"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "heck",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-markdown"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "heck",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "heck",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-lib"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-teavm-java"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-cli"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition = { workspace = true }
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -35,14 +35,14 @@ wat = "1.0.62"
 wit-parser = "0.7.0"
 wit-component = "0.8.1"
 
-wit-bindgen-core = { path = 'crates/core', version = '0.4.0' }
-wit-bindgen-c = { path = 'crates/c', version = '0.4.0' }
-wit-bindgen-rust = { path = "crates/rust", version = "0.4.0" }
-wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.4.0' }
-wit-bindgen-go = { path = 'crates/go', version = '0.2.0' }
-wit-bindgen-markdown = { path = 'crates/markdown', version = '0.4.0' }
-wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.4.0' }
-wit-bindgen = { path = 'crates/guest-rust', version = '0.4.0', default-features = false }
+wit-bindgen-core = { path = 'crates/core', version = '0.5.0' }
+wit-bindgen-c = { path = 'crates/c', version = '0.5.0' }
+wit-bindgen-rust = { path = "crates/rust", version = "0.5.0" }
+wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.5.0' }
+wit-bindgen-go = { path = 'crates/go', version = '0.3.0' }
+wit-bindgen-markdown = { path = 'crates/markdown', version = '0.5.0' }
+wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.5.0' }
+wit-bindgen = { path = 'crates/guest-rust', version = '0.5.0', default-features = false }
 wit-bindgen-rust-macro-shared = { path = 'crates/rust-macro-shared', version = '0.3.0' }
 
 [[bin]]

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-c"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-core"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/go/Cargo.toml
+++ b/crates/go/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-go"
 authors = ["Mossaka <duibao55328@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ Used when compiling Rust programs to the component model.
 """
 
 [dependencies]
-wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.4.0" }
+wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.5.0" }
 bitflags = { workspace = true }
 
 [features]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-markdown"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-lib/Cargo.toml
+++ b/crates/rust-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-lib"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/teavm-java/Cargo.toml
+++ b/crates/teavm-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-teavm-java"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Given we've bumped the dependencies on the wasm-tools crates, I thought it might be a good time to release the wit-bindgen crates too.
