### PR TITLE
docs: link to non-command wasi_snapshot_preview1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ which has a `_start` entrypoint (e.g. a `src/main.rs` in Rust).
 
 [preview2-prototyping]: https://github.com/bytecodealliance/preview2-prototyping
 [preview1-build]: https://github.com/bytecodealliance/preview2-prototyping/releases/tag/latest
-[non-command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.wasm
+[non-command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.reactor.wasm
 [command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.command.wasm
 
 ## Supported Guest Languages


### PR DESCRIPTION
This commit updates the `non-command` link to
`wasi_snapshot_preview1.reactor.wasm`.

The motivation for this is that the current link results in a 404 Not Found.