### PR TITLE
Fix types used when interfaces are imported and exported

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -397,15 +397,25 @@ pub trait WorldGenerator {
         }
         funcs.clear();
 
+        // First generate bindings for any freestanding functions, if any. If
+        // these refer to types defined in the world they need to refer to the
+        // imported types generated above.
+        //
+        // Interfaces are then generated afterwards so if the same interface is
+        // both imported and exported the right types are all used everywhere.
+        let mut interfaces = Vec::new();
         for (name, export) in world.exports.iter() {
             match export {
                 WorldItem::Function(f) => funcs.push((name.as_str(), f)),
-                WorldItem::Interface(id) => self.export_interface(resolve, name, *id, files),
+                WorldItem::Interface(id) => interfaces.push((name, id)),
                 WorldItem::Type(_) => unreachable!(),
             }
         }
         if !funcs.is_empty() {
             self.export_funcs(resolve, id, &funcs, files);
+        }
+        for (name, id) in interfaces {
+            self.export_interface(resolve, name, *id, files);
         }
         self.finish(resolve, id, files);
     }

--- a/tests/codegen/issue573.wit
+++ b/tests/codegen/issue573.wit
@@ -1,0 +1,117 @@
+default interface types-interface {
+  /// "package of named fields"
+  record r {
+    a: u32,
+    b: string,
+    c: list<tuple<string, option<t4>>>
+  }
+
+  /// values of this type will be one of the specified cases
+  variant human {
+    baby,
+    /// type payload
+    child(u32), // optional type payload
+    adult,
+  }
+
+  /// similar to `variant`, but no type payloads
+  enum errno {
+    too-big,
+    too-small,
+    too-fast,
+    too-slow,
+  }
+
+  /// similar to `variant`, but doesn't require naming cases and all variants
+  /// have a type payload -- note that this is not a C union, it still has a
+  /// discriminant
+  union input {
+    u64,
+    string,
+  }
+
+  /// a bitflags type
+  flags permissions {
+    read,
+    write,
+    exec,
+  }
+
+  // type aliases are allowed to primitive types and additionally here are some
+  // examples of other types
+  type t1 = u32
+  type t2 = tuple<u32, u64>
+  type t3 = string
+  type t4 = option<u32>
+  /// no "ok" type
+  type t5 = result<_, errno>            // no "ok" type
+  type t6 = result<string>              // no "err" type
+  type t7 = result<char, errno>         // both types specified
+  type t8 = result                      // no "ok" or "err" type
+  type t9 = list<string>
+  type t10 = t9
+}
+
+/// Comment for import interface
+interface api-imports {
+  use self.types-interface.{t7}
+
+  /// Same name as the type in `types-interface`, but this is a different type
+  variant human {
+    baby,
+    child(u64),
+    adult(tuple<string, option<option<string>>, tuple<s64>>),
+  }
+
+  api-a1-b2: func(arg: list<human>) -> (h1: t7, val2: human)
+}
+
+interface api {
+  /// Comment for export function
+  f1: func() -> (val-one: tuple<s32>, val2: string)
+
+  /// Comment for t5 in api
+  type t5 = result<_, option<errno>>
+
+  record errno {
+    a-u1: u64,
+    /// A list of signed 64-bit integers
+    list-s1: list<s64>,
+    str: option<string>,
+    c: option<char>,
+  }
+
+  class: func(break: option<option<t5>>) -> tuple<>
+  continue: func(abstract: option<result<_, errno>>, extends: tuple<>) -> (%implements: option<tuple<>>)
+}
+
+default world types-example {
+    use self.types-interface.{t2 as t2-renamed, t10, permissions}
+
+    import imports: self.api-imports
+    import print: func(message: string, level: log-level)
+    /// Comment for import inline
+    import inline: interface {
+      /// Comment for import inline function
+      inline-imp: func(args: list<option<char>>) -> result<_, char>
+    }
+
+    export types-export: self.types-interface
+    export api: self.api
+
+    enum log-level {
+      /// lowest level
+      debug,
+      info,
+      warn,
+      error,
+    }
+
+    record empty {}
+
+    export f-f1: func(typedef: t10) -> t10
+    export f1: func(f: float32, f-list: list<tuple<char, float64>>) -> (val-p1: s64, val2: string)
+    /// t2 has been renamed with `use self.types-interface.{t2 as t2-renamed}`
+    export re-named: func(perm: option<permissions>, e: option<empty>) -> t2-renamed
+    export re-named2: func(tup: tuple<list<u16>>, e: empty) -> tuple<option<u8>, s8>
+}


### PR DESCRIPTION
This fixes an issue where exported freestanding functions are intended to refer to imported types, not exported types. The order of bindings generation is altered here to ensure that code generators get access to types only as they're available, ensuring that functions refer to imported types rather than exported ones.

Closes #573