### PR TITLE
Update preview2-prototyping download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ which has a `_start` entrypoint (e.g. a `src/main.rs` in Rust).
 
 [preview2-prototyping]: https://github.com/bytecodealliance/preview2-prototyping
 [preview1-build]: https://github.com/bytecodealliance/preview2-prototyping/releases/tag/latest
-[non-command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.reactor.wasm
-[command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.command.wasm
+[non-command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_preview1_component_adapter.reactor.wasm
+[command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_preview1_component_adapter.command.wasm
 
 ## Supported Guest Languages
 [guests]: #supported-guest-languages

--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ which has a `_start` entrypoint (e.g. a `src/main.rs` in Rust).
 
 [preview2-prototyping]: https://github.com/bytecodealliance/preview2-prototyping
 [preview1-build]: https://github.com/bytecodealliance/preview2-prototyping/releases/tag/latest
-[non-command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_preview1_component_adapter.reactor.wasm
-[command]: https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_preview1_component_adapter.command.wasm
+[non-command]: https://github.com/bytecodealliance/wasmtime/releases/latest/download/wasi_snapshot_preview1.reactor.wasm
+[command]: https://github.com/bytecodealliance/wasmtime/releases/latest/download/wasi_snapshot_preview1.command.wasm
+
+
 
 ## Supported Guest Languages
 [guests]: #supported-guest-languages


### PR DESCRIPTION
This commit updates the preview2-prototyping command and reactor .wasm download links as they have been updated.