### PR TITLE
Give the C component-type object a valid encoding.

### DIFF
--- a/crates/c/src/component_type_object.rs
+++ b/crates/c/src/component_type_object.rs
@@ -23,7 +23,9 @@ pub fn object(resolve: &Resolve, world: WorldId, encoding: StringEncoding) -> Re
     funcs.function(0);
     module.section(&funcs);
     let mut code = CodeSection::new();
-    code.function(&Function::new([]));
+    let mut func = Function::new([]);
+    func.instruction(&wasm_encoder::Instruction::End);
+    code.function(&func);
     module.section(&code);
 
     let mut producers = wasm_metadata::Producers::empty();


### PR DESCRIPTION
Add an `end` opcode to the dummy function in the component-type object produced for the C bindings, which is needed in order for the resulting binary encoding to validate.