### PR TITLE
update go generator to re-enable codegen-tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ default = [
   'rust',
   'markdown',
   'teavm-java',
-  # 'go',
+  'go',
 ]
 c = ['dep:wit-bindgen-c']
 rust = ['dep:wit-bindgen-rust']

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -11,9 +11,6 @@ macro_rules! codegen_test {
     (issue544 $name:tt $test:tt) => {};
     (issue551 $name:tt $test:tt) => {};
 
-    // TODO: should fix handling of new `WorldKey` in go generator
-    ($id:ident $name:tt $test:tt) => {};
-
     ($id:ident $name:tt $test:tt) => {
         #[test]
         fn $id() {


### PR DESCRIPTION
This fixes the breaking change introduced in https://github.com/bytecodealliance/wit-bindgen/pull/580 and re-enable all the codegen-tests

I realized that I still need to re-enable all the runtime tests that were disabled in #545 . Will work on that. In the meantime this PR can merge without being blocked. 