### PR TITLE
provide more control over type ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,7 @@ dependencies = [
  "syn 2.0.15",
  "wit-bindgen-core",
  "wit-bindgen-rust",
+ "wit-bindgen-rust-lib",
  "wit-component",
 ]
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -80,11 +80,13 @@ impl Types {
             live.add_type(resolve, ty);
         }
         for id in live.iter() {
-            let info = self.type_info.get_mut(&id).unwrap();
-            if import {
-                info.borrowed = true;
-            } else {
-                info.owned = true;
+            if resolve.types[id].name.is_some() {
+                let info = self.type_info.get_mut(&id).unwrap();
+                if import {
+                    info.borrowed = true;
+                } else {
+                    info.owned = true;
+                }
             }
         }
         let mut live = LiveTypes::default();
@@ -93,7 +95,9 @@ impl Types {
             live.add_type(resolve, ty);
         }
         for id in live.iter() {
-            self.type_info.get_mut(&id).unwrap().owned = true;
+            if resolve.types[id].name.is_some() {
+                self.type_info.get_mut(&id).unwrap().owned = true;
+            }
         }
 
         for ty in func.results.iter_types() {

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -20,5 +20,6 @@ proc-macro2 = "1.0"
 syn = "2.0"
 wit-bindgen-core = { workspace = true }
 wit-bindgen-rust = { workspace = true }
+wit-bindgen-rust-lib = { workspace = true }
 wit-component = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -2,9 +2,10 @@ use proc_macro2::{Span, TokenStream};
 use std::path::{Path, PathBuf};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
-use syn::{token, Token};
+use syn::{braced, token, Token};
 use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackage, WorldId};
 use wit_bindgen_rust::Opts;
+use wit_bindgen_rust_lib::Ownership;
 
 #[proc_macro]
 pub fn generate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -60,7 +61,7 @@ impl Parse for Config {
                     Opt::UseStdFeature => opts.std_feature = true,
                     Opt::RawStrings => opts.raw_strings = true,
                     Opt::MacroExport => opts.macro_export = true,
-                    Opt::DuplicateIfNecessary => opts.duplicate_if_necessary = true,
+                    Opt::Ownership(ownership) => opts.ownership = ownership,
                     Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
                     Opt::ExportMacroName(name) => opts.export_macro_name = Some(name.value()),
                     Opt::Skip(list) => opts.skip.extend(list.iter().map(|i| i.value())),
@@ -146,7 +147,7 @@ mod kw {
     syn::custom_keyword!(world);
     syn::custom_keyword!(path);
     syn::custom_keyword!(inline);
-    syn::custom_keyword!(duplicate_if_necessary);
+    syn::custom_keyword!(ownership);
 }
 
 enum Opt {
@@ -159,7 +160,7 @@ enum Opt {
     MacroCallPrefix(syn::LitStr),
     ExportMacroName(syn::LitStr),
     Skip(Vec<syn::LitStr>),
-    DuplicateIfNecessary,
+    Ownership(Ownership),
 }
 
 impl Parse for Opt {
@@ -186,9 +187,44 @@ impl Parse for Opt {
         } else if l.peek(kw::macro_export) {
             input.parse::<kw::macro_export>()?;
             Ok(Opt::MacroExport)
-        } else if l.peek(kw::duplicate_if_necessary) {
-            input.parse::<kw::duplicate_if_necessary>()?;
-            Ok(Opt::DuplicateIfNecessary)
+        } else if l.peek(kw::ownership) {
+            input.parse::<kw::ownership>()?;
+            input.parse::<Token![:]>()?;
+            let ownership = input.parse::<syn::Ident>()?;
+            Ok(Opt::Ownership(match ownership.to_string().as_str() {
+                "Owning" => Ownership::Owning,
+                "Borrowing" => Ownership::Borrowing {
+                    duplicate_if_necessary: {
+                        let contents;
+                        braced!(contents in input);
+                        let field = contents.parse::<syn::Ident>()?;
+                        match field.to_string().as_str() {
+                            "duplicate_if_necessary" => {
+                                contents.parse::<Token![:]>()?;
+                                contents.parse::<syn::LitBool>()?.value
+                            }
+                            name => {
+                                return Err(Error::new(
+                                    field.span(),
+                                    format!(
+                                        "unrecognized `Ownership::Borrowing` field: `{name}`; \
+                                         expected `duplicate_if_necessary`"
+                                    ),
+                                ));
+                            }
+                        }
+                    },
+                },
+                name => {
+                    return Err(Error::new(
+                        ownership.span(),
+                        format!(
+                            "unrecognized ownership: `{name}`; \
+                             expected `Owning` or `Borrowing`"
+                        ),
+                    ));
+                }
+            }))
         } else if l.peek(kw::macro_call_prefix) {
             input.parse::<kw::macro_call_prefix>()?;
             input.parse::<Token![:]>()?;

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -18,7 +18,9 @@ mod codegen_tests {
                 mod duplicate {
                     wit_bindgen::generate!({
                         path: $test,
-                        duplicate_if_necessary,
+                        ownership: Borrowing {
+                            duplicate_if_necessary: true
+                        }
                     });
 
                     #[test]

--- a/crates/test-rust-wasm/src/bin/borrowing-duplicate-if-necessary.rs
+++ b/crates/test-rust-wasm/src/bin/borrowing-duplicate-if-necessary.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/ownership/borrowing-duplicate-if-necessary.rs");
+
+fn main() {}

--- a/crates/test-rust-wasm/src/bin/borrowing.rs
+++ b/crates/test-rust-wasm/src/bin/borrowing.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/ownership/borrowing.rs");
+
+fn main() {}

--- a/crates/test-rust-wasm/src/bin/owning.rs
+++ b/crates/test-rust-wasm/src/bin/owning.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/ownership/owning.rs");
+
+fn main() {}

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -1,4 +1,9 @@
-wit_bindgen::generate!(in "../../tests/runtime/lists");
+wit_bindgen::generate!({
+    path: "../../tests/runtime/lists",
+    ownership: Borrowing {
+        duplicate_if_necessary: false
+    }
+});
 
 struct Component;
 

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 use wasm_encoder::{Encode, Section};
 use wasmtime::component::{Component, Instance, Linker};
@@ -14,6 +14,7 @@ mod flavorful;
 mod lists;
 mod many_arguments;
 mod numbers;
+mod ownership;
 mod records;
 mod smoke;
 mod strings;
@@ -289,8 +290,6 @@ fn tests(name: &str) -> Result<Vec<PathBuf>> {
 
     #[cfg(feature = "teavm-java")]
     if !java.is_empty() {
-        use heck::*;
-
         const DEPTH_FROM_TARGET_DIR: u32 = 2;
 
         let base_dir = {
@@ -327,7 +326,6 @@ fn tests(name: &str) -> Result<Vec<PathBuf>> {
             dst_files.push(dst);
         }
 
-        let upper = world_name.to_upper_camel_case();
         for java_impl in java {
             let dst = java_dir.join(
                 java_impl

--- a/tests/runtime/ownership.rs
+++ b/tests/runtime/ownership.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use wasmtime::Store;
+
+wasmtime::component::bindgen!(in "tests/runtime/ownership");
+
+#[derive(Default)]
+pub struct MyImports {
+    called_foo: bool,
+    called_bar: bool,
+    called_baz: bool,
+}
+
+impl lists::Host for MyImports {
+    fn foo(&mut self, list: Vec<Vec<String>>) -> Result<Vec<Vec<String>>> {
+        self.called_foo = true;
+        Ok(list)
+    }
+}
+
+impl thing_in::Host for MyImports {
+    fn bar(&mut self, _value: thing_in::Thing) -> Result<()> {
+        self.called_bar = true;
+        Ok(())
+    }
+}
+
+impl thing_in_and_out::Host for MyImports {
+    fn baz(&mut self, value: thing_in_and_out::Thing) -> Result<thing_in_and_out::Thing> {
+        self.called_baz = true;
+        Ok(value)
+    }
+}
+
+#[test]
+fn run() -> Result<()> {
+    crate::run_test(
+        "ownership",
+        |linker| Ownership::add_to_linker(linker, |x| &mut x.0),
+        |store, component, linker| Ownership::instantiate(store, component, linker),
+        run_test,
+    )
+}
+
+fn run_test(exports: Ownership, store: &mut Store<crate::Wasi<MyImports>>) -> Result<()> {
+    exports.call_foo(&mut *store)?;
+
+    assert!(store.data().0.called_foo);
+    assert!(store.data().0.called_bar);
+    assert!(store.data().0.called_baz);
+
+    Ok(())
+}

--- a/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
+++ b/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
@@ -1,0 +1,43 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/ownership",
+    ownership: Borrowing {
+        duplicate_if_necessary: true
+    }
+});
+
+impl PartialEq for thing_in_and_out::ThingResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.value == other.value
+    }
+}
+
+struct Exports;
+
+export_ownership!(Exports);
+
+impl Ownership for Exports {
+    fn foo() {
+        let value = &[&["foo", "bar"] as &[_]] as &[_];
+        assert_eq!(
+            vec![vec!["foo".to_owned(), "bar".to_owned()]],
+            lists::foo(value)
+        );
+
+        thing_in::bar(thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        });
+
+        let value = thing_in_and_out::ThingParam {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        };
+        assert_eq!(
+            thing_in_and_out::ThingResult {
+                name: "thing 1".to_owned(),
+                value: vec!["some value".to_owned(), "another value".to_owned()],
+            },
+            thing_in_and_out::baz(value)
+        );
+    }
+}

--- a/tests/runtime/ownership/borrowing.rs
+++ b/tests/runtime/ownership/borrowing.rs
@@ -1,0 +1,37 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/ownership",
+    ownership: Borrowing {
+        duplicate_if_necessary: false
+    }
+});
+
+impl PartialEq for thing_in_and_out::Thing {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.value == other.value
+    }
+}
+
+struct Exports;
+
+export_ownership!(Exports);
+
+impl Ownership for Exports {
+    fn foo() {
+        let value = &[&["foo", "bar"] as &[_]] as &[_];
+        assert_eq!(
+            vec![vec!["foo".to_owned(), "bar".to_owned()]],
+            lists::foo(value)
+        );
+
+        thing_in::bar(thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        });
+
+        let value = thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, thing_in_and_out::baz(&value));
+    }
+}

--- a/tests/runtime/ownership/owning.rs
+++ b/tests/runtime/ownership/owning.rs
@@ -1,0 +1,32 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/ownership",
+    ownership: Owning
+});
+
+impl PartialEq for thing_in_and_out::Thing {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.value == other.value
+    }
+}
+
+struct Exports;
+
+export_ownership!(Exports);
+
+impl Ownership for Exports {
+    fn foo() {
+        let value = vec![vec!["foo".to_owned(), "bar".to_owned()]];
+        assert_eq!(value, lists::foo(&value));
+
+        thing_in::bar(&thing_in::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        });
+
+        let value = thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, thing_in_and_out::baz(&value));
+    }
+}

--- a/tests/runtime/ownership/world.wit
+++ b/tests/runtime/ownership/world.wit
@@ -1,0 +1,27 @@
+package test:ownership
+
+world ownership {
+    import lists: interface {
+        foo: func(a: list<list<string>>) -> list<list<string>>
+    }
+
+    import thing-in: interface {
+        record thing {
+            name: string,
+            value: list<string>
+        }
+
+        bar: func(a: thing)
+    }
+
+    import thing-in-and-out: interface {
+        record thing {
+            name: string,
+            value: list<string>
+        }
+
+        baz: func(a: thing) -> thing
+    }
+
+    export foo: func()
+}


### PR DESCRIPTION
This is the guest version of https://github.com/bytecodealliance/wasmtime/pull/6648.

This replaces the duplicate_if_necessary parameter to the Rust binding generator with a new ownership parameter which provides finer-grained control over whether and how generated types own their fields.

The default is `Ownership::Owning`, which means types own their fields regardless of how they are used in functions. These types are passed by reference when used as parameters to guest-exported functions. Note that this also affects how unnamed types (e.g. `list<list<string>>`) are passed: using a reference only at the top level (e.g. `&[Vec<String>]` instead of `&[&[&str]]`, which is more difficult to construct when using non-'static data).

The other option is `Ownership::Borrowing`, which includes a `duplicate_if_necessary` field, providing the same code generation strategy as was used prior to this change.