### PR TITLE
Alias anon types in tiny-go

### DIFF
--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -34,7 +34,8 @@ macro_rules! codegen_test {
 test_helpers::codegen_tests!();
 
 fn verify(dir: &Path, name: &str) {
-    let path = PathBuf::from(env::var_os("WASI_SDK_PATH").unwrap());
+    let path =
+        PathBuf::from(env::var_os("WASI_SDK_PATH").expect("WASI_SDK_PATH env variable not set"));
     let mut cmd = Command::new(path.join("bin/clang"));
     cmd.arg("--sysroot").arg(path.join("share/wasi-sysroot"));
     cmd.arg(dir.join(format!("{}.c", name.to_snake_case())));

--- a/tests/codegen/use-across-interfaces.wit
+++ b/tests/codegen/use-across-interfaces.wit
@@ -1,7 +1,10 @@
 package foo:foo
 
 interface foo {
-  record a {}
+  type headers = list<tuple<string, string>>
+  record a {
+    headers: headers
+  }
   x: func() -> a
 }
 


### PR DESCRIPTION
This fixes a bug where previously when an anonymous type had already been defined, we simply replaced the definition. However, this did not work as other parts of the codegen could already be referring to the anon type by that previous name. 

This change keeps track of all the names used for a type. Then in the codegen for an anonymous type, it first looks to see if the type was already defined, and if so, it generates aliases for the previously used name. 

I imagine we'll want to add a test that would have caught this. Do we want to add a new test or to change an existing test to exercise this? I think it should be as simple some `use`s in the wit file. 