### PR TITLE
C: Namespace types inside of annoymous types

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -864,7 +864,7 @@ fn push_optional_ty_name(
     }
 }
 
-fn owner_namespace(
+pub fn owner_namespace(
     resolve: &Resolve,
     id: TypeId,
     interface_names: &HashMap<InterfaceId, WorldKey>,

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -34,7 +34,6 @@ pub fn test_directory(suite_name: &str, gen_name: &str, wit_name: &str) -> PathB
 /// Helper function to execute a process during tests and print informative
 /// information if it fails.
 pub fn run_command(cmd: &mut Command) {
-    println!("running {cmd:?}");
     let output = cmd
         .output()
         .expect("failed to run executable; is it installed");
@@ -44,6 +43,7 @@ pub fn run_command(cmd: &mut Command) {
     }
     panic!(
         "
+command: {cmd:?}
 status: {status}
 
 stdout ---

--- a/tests/codegen/issue607.wit
+++ b/tests/codegen/issue607.wit
@@ -5,9 +5,10 @@ interface interface1 {
         some-error
     } 
     record my-record {
-        wow: u32
+        field: u32
     }
     my-func: func() -> result<my-record, error>
+    optional: func() -> option<my-record>
 }
 
 interface interface2 {
@@ -15,9 +16,10 @@ interface interface2 {
         other-error
     } 
     record my-record {
-        wow: u32
+        other-field: u32
     }
     my-other-func: func() -> result<my-record, error>
+    other-optional: func() -> option<my-record>
 }
 
 world my-world {

--- a/tests/codegen/issue607.wit
+++ b/tests/codegen/issue607.wit
@@ -1,0 +1,26 @@
+package local:demo
+
+interface interface1 {
+    variant error {
+        some-error
+    } 
+    record my-record {
+        wow: u32
+    }
+    my-func: func() -> result<my-record, error>
+}
+
+interface interface2 {
+    variant error {
+        other-error
+    } 
+    record my-record {
+        wow: u32
+    }
+    my-other-func: func() -> result<my-record, error>
+}
+
+world my-world {
+    import interface1
+    import interface2
+}

--- a/tests/codegen/issue607.wit
+++ b/tests/codegen/issue607.wit
@@ -5,10 +5,12 @@ interface interface1 {
         some-error
     } 
     record my-record {
-        field: u32
+        some-field: u32
     }
     my-func: func() -> result<my-record, error>
-    optional: func() -> option<my-record>
+    my-optional: func() -> option<my-record>
+    my-tuple: func() -> tuple<my-record, error>
+    my-list: func() -> list<my-record>
 }
 
 interface interface2 {
@@ -18,8 +20,10 @@ interface interface2 {
     record my-record {
         other-field: u32
     }
-    my-other-func: func() -> result<my-record, error>
-    other-optional: func() -> option<my-record>
+    my-func: func() -> result<my-record, error>
+    my-optional: func() -> option<my-record>
+    my-tuple: func() -> tuple<my-record, error>
+    my-list: func() -> list<my-record>
 }
 
 world my-world {

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -105,7 +105,7 @@ void flavorful_test_imports() {
     b.ptr = b_val;
     b.len = 2;
 
-    flavorful_list_my_errno_t c;
+    flavorful_list_test_flavorful_test_my_errno_t c;
     test_flavorful_test_my_errno_t c_val[2];
     c_val[0] = TEST_FLAVORFUL_TEST_MY_ERRNO_SUCCESS;
     c_val[1] = TEST_FLAVORFUL_TEST_MY_ERRNO_A;
@@ -114,7 +114,7 @@ void flavorful_test_imports() {
 
     flavorful_list_bool_t d;
     flavorful_list_result_void_void_t e;
-    flavorful_list_my_errno_t f;
+    flavorful_list_test_flavorful_test_my_errno_t f;
     test_flavorful_test_list_of_variants(&a, &b, &c, &d, &e, &f);
 
     assert(d.len == 2);
@@ -131,7 +131,7 @@ void flavorful_test_imports() {
 
     flavorful_list_bool_free(&d);
     flavorful_list_result_void_void_free(&e);
-    flavorful_list_my_errno_free(&f);
+    flavorful_list_test_flavorful_test_my_errno_free(&f);
   }
 }
 
@@ -208,9 +208,9 @@ void exports_test_flavorful_test_list_typedefs(test_flavorful_test_list_typedef_
 void exports_test_flavorful_test_list_of_variants(
     flavorful_list_bool_t *a,
     flavorful_list_result_void_void_t *b,
-    flavorful_list_my_errno_t *c,
+    flavorful_list_test_flavorful_test_my_errno_t *c,
     flavorful_list_bool_t *ret0,
     flavorful_list_result_void_void_t *ret1,
-    flavorful_list_my_errno_t *ret2) {
+    flavorful_list_test_flavorful_test_my_errno_t *ret2) {
   assert(0); // unimplemented
 }

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -123,7 +123,7 @@ void variants_test_imports() {
   }
 
   {
-    variants_tuple3_bool_result_void_void_my_errno_t ret;
+    variants_tuple3_bool_result_void_void_test_variants_test_my_errno_t ret;
     variants_result_void_void_t b;
     b.is_err = false;
     test_variants_test_variant_enums(true, &b, TEST_VARIANTS_TEST_MY_ERRNO_SUCCESS, &ret);
@@ -173,7 +173,7 @@ void exports_test_variants_test_variant_enums(
       bool a,
       variants_result_void_void_t *b,
       test_variants_test_my_errno_t c,
-      variants_tuple3_bool_result_void_void_my_errno_t *ret) {
+      variants_tuple3_bool_result_void_void_test_variants_test_my_errno_t *ret) {
   assert(0);
 }
 


### PR DESCRIPTION
This fixes the issue in C for #607, but unfortunately does not yet fix the issue in the Go generator as the Go generator uses bespoke logic for rebuilding C type names. I wanted to get this up first to initial feedback, but my plan is to fix the issue in the Go generator tomorrow. 