### PR TITLE
Correct the accounting for results containing empty types.

### DIFF
--- a/tests/codegen/result-empty.wit
+++ b/tests/codegen/result-empty.wit
@@ -1,0 +1,18 @@
+package local:demo
+
+interface my-interface {
+    variant stuff {
+        thing
+    } 
+    record empty {
+    }
+    stuff-or-stuff: func() -> result<stuff, stuff>
+    stuff-or-empty: func() -> result<stuff, empty>
+    empty-or-stuff: func() -> result<empty, stuff>
+    empty-or-empty: func() -> result<empty, empty>
+}
+
+
+world my-world {
+    import my-interface
+}

--- a/tests/codegen/result-empty.wit
+++ b/tests/codegen/result-empty.wit
@@ -2,14 +2,25 @@ package local:demo
 
 interface my-interface {
     variant stuff {
-        thing
+        this,
+        that
     } 
+
     record empty {
     }
+
     stuff-or-stuff: func() -> result<stuff, stuff>
     stuff-or-empty: func() -> result<stuff, empty>
     empty-or-stuff: func() -> result<empty, stuff>
     empty-or-empty: func() -> result<empty, empty>
+
+    stuff-or-absent: func() -> result<stuff>
+    absent-or-stuff: func() -> result<_, stuff>
+
+    empty-or-absent: func() -> result<empty>
+    absent-or-empty: func() -> result<_, empty>
+
+    absent-or-absent: func() -> result
 }
 
 


### PR DESCRIPTION
Empty types are special-cased in the C backend because C doesn't allow zero-sized types. In the case of a result containing an empty type, when processing the ok side, increment the return value counter even if the store is omitted due to the value being empty.

Fixes #609.