### PR TITLE
Fix warnings when compiling with Rust 1.71

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1091,8 +1091,8 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.finish_ty(id, prev);
     }
 
-    fn type_builtin(&mut self, _id: TypeId, name: &str, ty: &Type, docs: &Docs) {
-        drop((_id, name, ty, docs));
+    fn type_builtin(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        let _ = (id, name, ty, docs);
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -447,8 +447,7 @@ pub trait WorldGenerator {
     }
 
     fn preprocess(&mut self, resolve: &Resolve, world: WorldId) {
-        drop(resolve);
-        drop(world);
+        let _ = (resolve, world);
     }
 
     fn import_interface(

--- a/crates/rust-lib/src/lib.rs
+++ b/crates/rust-lib/src/lib.rs
@@ -101,7 +101,7 @@ pub trait RustGenerator<'a> {
     }
 
     fn rustdoc_params(&mut self, docs: &[(String, Type)], header: &str) {
-        drop((docs, header));
+        let _ = (docs, header);
         // let docs = docs
         //     .iter()
         //     .filter(|param| param.docs.trim().len() > 0)


### PR DESCRIPTION
New Rust version, new warnings:

```
warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
```