### PR TITLE
Rust: add option for path to wit-bindgen runtime.

### DIFF
--- a/crates/rust-lib/src/lib.rs
+++ b/crates/rust-lib/src/lib.rs
@@ -65,11 +65,11 @@ pub trait RustGenerator<'a> {
         true
     }
 
-    /// Return the fully-qualified name for the `Vec` type to use.
-    fn vec_name(&self) -> &'static str;
+    /// Pushes the name of the `Vec` type to use.
+    fn push_vec_name(&mut self);
 
-    /// Return the fully-qualified name for the `String` type to use.
-    fn string_name(&self) -> &'static str;
+    /// Pushes the name of the `String` type to use.
+    fn push_string_name(&mut self);
 
     /// Return true iff the generator should use `&[u8]` instead of `&str` in bindings.
     fn use_raw_strings(&self) -> bool {
@@ -238,10 +238,10 @@ pub trait RustGenerator<'a> {
                 }
                 TypeMode::Owned => {
                     if self.use_raw_strings() {
-                        self.push_str(self.vec_name());
+                        self.push_vec_name();
                         self.push_str("::<u8>");
                     } else {
-                        self.push_str(self.string_name());
+                        self.push_string_name();
                     }
                 }
             },
@@ -405,14 +405,14 @@ pub trait RustGenerator<'a> {
                 if self.resolve().all_bits_valid(ty) {
                     self.print_borrowed_slice(false, ty, lt, next_mode);
                 } else {
-                    self.push_str(self.vec_name());
+                    self.push_vec_name();
                     self.push_str("::<");
                     self.print_ty(ty, next_mode);
                     self.push_str(">");
                 }
             }
             TypeMode::Owned => {
-                self.push_str(self.vec_name());
+                self.push_vec_name();
                 self.push_str("::<");
                 self.print_ty(ty, next_mode);
                 self.push_str(">");

--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -65,6 +65,7 @@ impl Parse for Config {
                     Opt::MacroCallPrefix(prefix) => opts.macro_call_prefix = Some(prefix.value()),
                     Opt::ExportMacroName(name) => opts.export_macro_name = Some(name.value()),
                     Opt::Skip(list) => opts.skip.extend(list.iter().map(|i| i.value())),
+                    Opt::RuntimePath(path) => opts.runtime_path = Some(path.value()),
                 }
             }
         } else {
@@ -148,6 +149,7 @@ mod kw {
     syn::custom_keyword!(path);
     syn::custom_keyword!(inline);
     syn::custom_keyword!(ownership);
+    syn::custom_keyword!(runtime_path);
 }
 
 enum Opt {
@@ -161,6 +163,7 @@ enum Opt {
     ExportMacroName(syn::LitStr),
     Skip(Vec<syn::LitStr>),
     Ownership(Ownership),
+    RuntimePath(syn::LitStr),
 }
 
 impl Parse for Opt {
@@ -240,6 +243,10 @@ impl Parse for Opt {
             syn::bracketed!(contents in input);
             let list = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
             Ok(Opt::Skip(list.iter().cloned().collect()))
+        } else if l.peek(kw::runtime_path) {
+            input.parse::<kw::runtime_path>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::RuntimePath(input.parse()?))
         } else {
             Err(l.error())
         }

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -226,3 +226,25 @@ mod symbol_does_not_conflict {
 
     export_foo!(Component);
 }
+
+mod alternative_runtime_path {
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline
+            world foo {
+                export foo: func()
+            }
+        ",
+        runtime_path: "my_rt",
+    });
+
+    pub(crate) use wit_bindgen::rt as my_rt;
+
+    struct Component;
+
+    impl Foo for Component {
+        fn foo() {}
+    }
+
+    export_foo!(Component);
+}

--- a/tests/runtime/records.rs
+++ b/tests/runtime/records.rs
@@ -19,7 +19,7 @@ impl test_imports::Host for MyImports {
 
     fn roundtrip_flags1(&mut self, a: test_imports::F1) -> Result<test_imports::F1> {
         drop(format!("{:?}", a));
-        drop(a & test_imports::F1::all());
+        let _ = a & test_imports::F1::all();
         Ok(a)
     }
 


### PR DESCRIPTION
This PR adds an optional path to the `wit-bindgen` runtime to use for Rust code generation.

This will allow a different crate from `wit-bindgen` to generate bindings while also re-exporting `wit-bindgen::rt` at a known path for the generated code to use.