### PR TITLE
Adjustments to Rust guest code generation

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -11,6 +11,8 @@ pub use bitflags;
 
 #[doc(hidden)]
 pub mod rt {
+    use crate::alloc::string::String;
+    use crate::alloc::vec::Vec;
 
     /// Provide a hook for generated export functions to run static
     /// constructors at most once. wit-bindgen-rust generates a call to this
@@ -123,5 +125,41 @@ pub mod rt {
         (AsI32 as_i32 i32 <=> i32 u32 i16 u16 i8 u8 char usize)
         (AsF32 as_f32 f32 <=> f32)
         (AsF64 as_f64 f64 <=> f64)
+    }
+
+    pub unsafe fn string_lift(bytes: Vec<u8>) -> String {
+        if cfg!(debug_assertions) {
+            String::from_utf8(bytes).unwrap()
+        } else {
+            String::from_utf8_unchecked(bytes)
+        }
+    }
+
+    pub unsafe fn invalid_enum_discriminant<T>() -> T {
+        if cfg!(debug_assertions) {
+            panic!("invalid enum discriminant")
+        } else {
+            core::hint::unreachable_unchecked()
+        }
+    }
+
+    pub unsafe fn char_lift(val: u32) -> char {
+        if cfg!(debug_assertions) {
+            core::char::from_u32(val).unwrap()
+        } else {
+            core::char::from_u32_unchecked(val)
+        }
+    }
+
+    pub unsafe fn bool_lift(val: u8) -> bool {
+        if cfg!(debug_assertions) {
+            match val {
+                0 => false,
+                1 => true,
+                _ => panic!("invalid bool discriminant"),
+            }
+        } else {
+            core::mem::transmute::<u8, bool>(val)
+        }
     }
 }

--- a/crates/rust-lib/src/lib.rs
+++ b/crates/rust-lib/src/lib.rs
@@ -893,7 +893,7 @@ pub trait RustGenerator<'a> {
                 self.push_str(
                     "fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {\n",
                 );
-                self.push_str("write!(f, \"{:?}\", self)");
+                self.push_str("write!(f, \"{:?}\", self)\n");
                 self.push_str("}\n");
                 self.push_str("}\n");
                 self.push_str("\n");
@@ -1069,7 +1069,7 @@ pub trait RustGenerator<'a> {
             self.push_str(
                 "{\nfn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {\n",
             );
-            self.push_str("write!(f, \"{} (error {})\", self.name(), *self as i32)");
+            self.push_str("write!(f, \"{} (error {})\", self.name(), *self as i32)\n");
             self.push_str("}\n");
             self.push_str("}\n");
             self.push_str("\n");
@@ -1294,12 +1294,12 @@ pub trait RustFunctionGenerator {
         results: &mut Vec<String>,
     ) {
         let mut result = self.typename_lift(id);
-        result.push_str("{");
+        result.push_str("{\n");
         for (field, val) in ty.fields.iter().zip(operands) {
             result.push_str(&to_rust_ident(&field.name));
-            result.push_str(":");
+            result.push_str(": ");
             result.push_str(&val);
-            result.push_str(", ");
+            result.push_str(",\n");
         }
         result.push_str("}");
         results.push(result);


### PR DESCRIPTION
This commit refactors the exact shape of the Rust guest code generated by `wit-bindgen`. The original problem here was that `rustfmt` would fail on the generated output due to extreme nesting and extreme line lengths presumably causing `rustfmt`'s heuristics to give up. While the issue has been fixed for the input WIT world this is a bit of a game of whack-a-mole so there's not a great regression test suite to have here.

In general the changes here are:

* Where possible move library functionality into the guest crate which generated code calls into. For example removing branches with `cfg(debug_assertions)`.
* Trying to de-indent code by less using nested Rust expressions and moreso using `let foo = ...` and propagate `foo` as the result of an operation.
* Enum lifting operations are now helper functions to avoid generating a lift-per-callsite which can be quite a lot for errors.
* Various other minor adjustments as aliasing variant names as a local `V{N}` instead of `super::super::super::your::here::Type` or restructuring variant lifts/lowers to have less nesting and/or be easier for `rustfmt` to format.

I think there's still a good bit to improve here. For example the generated code has a lot of blocks such as:

    for ... {
        let base = ...;
        {
            // use `base`
        }
    }

where the body of the `for` loop has an unnecessary block. I've left fixing this for a future refactoring though.