### PR TITLE
chore: bump tinygo version to 0.29.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         go-version: '1.20'
     - uses: acifani/setup-tinygo@v1
       with:
-        tinygo-version: 0.28.1
+        tinygo-version: 0.29.0
     - run: cargo test --workspace
     - run: cargo build
     - run: cargo build --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         go-version: '1.20'
     - uses: acifani/setup-tinygo@v1
       with:
-        tinygo-version: 0.27.0
+        tinygo-version: 0.28.1
     - run: cargo test --workspace
     - run: cargo build
     - run: cargo build --no-default-features


### PR DESCRIPTION
TinyGo `v0.29` was release a few days and added many new features. You can see a list of features [here](https://github.com/tinygo-org/tinygo/releases/tag/v0.29.0). This PR bumps the CI tinygo version to `v0.29.0`, and in theory, this has better performance and less bugs. 