### PR TITLE
add `resource-borrow-in-record-export` codegen test

### DIFF
--- a/tests/codegen/resource-borrow-in-record-export.wit
+++ b/tests/codegen/resource-borrow-in-record-export.wit
@@ -1,0 +1,15 @@
+package foo:bar
+
+interface foo4 {
+  resource y
+
+  record r {
+    y: borrow<y>
+  }
+
+  f: func(a: list<r>)
+}
+
+world x {
+  export foo4
+}


### PR DESCRIPTION
I had meant to include this in #604 but forgot to `git add` it.