### PR TITLE
changed to correct name for drop functions

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -556,7 +556,7 @@ impl C {
 
                 uwriteln!(
                     c_str,
-                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-drop-own]{name}")))
+                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-drop]{name}")))
                        void __wasm_import_{namespace}_{snake}_drop_own(int32_t);
 
                        void {namespace}_{snake}_drop_own({own_name}{space}arg) {{
@@ -576,7 +576,7 @@ impl C {
 
                 uwriteln!(
                     c_str,
-                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-drop-borrow]{name}")))
+                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-drop]{name}")))
                        void __wasm_import_{borrow_namespace}_{snake}_drop_borrow(int32_t);
 
                        void {borrow_namespace}_{snake}_drop_borrow({borrow_name}{space}arg) {{

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -668,7 +668,7 @@ impl InterfaceGenerator<'_> {
                                          #[cfg(target_arch = "wasm32")]
                                          #[link(wasm_import_module = "{wasm_import_module}")]
                                          extern "C" {{
-                                             #[link_name = "[resource-drop-own]{name}"]
+                                             #[link_name = "[resource-drop]{name}"]
                                              fn wit_import(_: i32);
                                          }}
 
@@ -677,7 +677,7 @@ impl InterfaceGenerator<'_> {
                                          #[cfg(target_arch = "wasm32")]
                                          #[link(wasm_import_module = "{wasm_import_module}")]
                                          extern "C" {{
-                                             #[link_name = "[resource-drop-borrow]{name}"]
+                                             #[link_name = "[resource-drop]{name}"]
                                              fn wit_import(_: i32);
                                          }}
 
@@ -838,7 +838,7 @@ impl InterfaceGenerator<'_> {
                                 #[cfg(target_arch = "wasm32")]
                                 #[link(wasm_import_module = "[export]{module}")]
                                 extern "C" {{
-                                    #[link_name = "[resource-drop-own]{name}"]
+                                    #[link_name = "[resource-drop]{name}"]
                                     fn wit_import(_: i32);
                                 }}
 


### PR DESCRIPTION
Changes resource drop function names from `resource-drop-{own|borrow}` to `resource-drop`
Solves #636 