### PR TITLE
Rust: make the path to the `bitflags` re-export configurable.

### DIFF
--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -63,6 +63,7 @@ impl Parse for Config {
                     Opt::Ownership(ownership) => opts.ownership = ownership,
                     Opt::Skip(list) => opts.skip.extend(list.iter().map(|i| i.value())),
                     Opt::RuntimePath(path) => opts.runtime_path = Some(path.value()),
+                    Opt::BitflagsPath(path) => opts.bitflags_path = Some(path.value()),
                     Opt::Exports(exports) => opts.exports.extend(
                         exports
                             .into_iter()
@@ -154,6 +155,7 @@ mod kw {
     syn::custom_keyword!(inline);
     syn::custom_keyword!(ownership);
     syn::custom_keyword!(runtime_path);
+    syn::custom_keyword!(bitflags_path);
     syn::custom_keyword!(exports);
     syn::custom_keyword!(stubs);
     syn::custom_keyword!(export_prefix);
@@ -210,6 +212,7 @@ enum Opt {
     Skip(Vec<syn::LitStr>),
     Ownership(Ownership),
     RuntimePath(syn::LitStr),
+    BitflagsPath(syn::LitStr),
     Exports(Vec<Export>),
     Stubs,
     ExportPrefix(syn::LitStr),
@@ -292,6 +295,10 @@ impl Parse for Opt {
             input.parse::<kw::runtime_path>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::RuntimePath(input.parse()?))
+        } else if l.peek(kw::bitflags_path) {
+            input.parse::<kw::bitflags_path>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::BitflagsPath(input.parse()?))
         } else if l.peek(kw::stubs) {
             input.parse::<kw::stubs>()?;
             Ok(Opt::Stubs)

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -137,6 +137,12 @@ pub struct Opts {
     /// This defaults to `wit_bindgen::rt`.
     #[cfg_attr(feature = "clap", arg(long))]
     pub runtime_path: Option<String>,
+
+    /// The optional path to the bitflags crate to use.
+    ///
+    /// This defaults to `wit_bindgen::bitflags`.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub bitflags_path: Option<String>,
 }
 
 impl Opts {
@@ -212,6 +218,13 @@ impl RustWasm {
             .runtime_path
             .as_deref()
             .unwrap_or("wit_bindgen::rt")
+    }
+
+    fn bitflags_path(&self) -> &str {
+        self.opts
+            .bitflags_path
+            .as_deref()
+            .unwrap_or("wit_bindgen::bitflags")
     }
 }
 
@@ -1281,7 +1294,10 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn type_flags(&mut self, _id: TypeId, name: &str, flags: &Flags, docs: &Docs) {
-        self.src.push_str("wit_bindgen::bitflags::bitflags! {\n");
+        self.src.push_str(&format!(
+            "{bitflags}::bitflags! {{\n",
+            bitflags = self.gen.bitflags_path()
+        ));
         self.rustdoc(docs);
         let repr = RustFlagsRepr::new(flags);
         self.src.push_str(&format!(

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -195,3 +195,33 @@ mod alternative_runtime_path {
         fn foobar() {}
     }
 }
+
+mod alternative_bitflags_path {
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline
+            world foo {
+                flags bar {
+                    foo,
+                    bar,
+                    baz
+                }
+                export get-flag: func() -> bar
+            }
+        ",
+        bitflags_path: "my_bitflags",
+        exports: {
+            world: Component
+        }
+    });
+
+    pub(crate) use wit_bindgen::bitflags as my_bitflags;
+
+    struct Component;
+
+    impl Foo for Component {
+        fn get_flag() -> Bar {
+            Bar::BAZ
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `bitflags_path` option to the macro allowing an alternative path to the `bitflags` crate, similar to the `runtime_path` option.

It is primarily intended for crates that wrap wit-bindgen and therefore wit-bindgen might not be a direct dependency from user crates.