### PR TITLE
Implement DerefMut for Own<Resource> in Rust component export

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -833,6 +833,26 @@ impl InterfaceGenerator<'_> {
                         }}
                     }}
 
+                    impl core::ops::DerefMut for Own{camel} {{
+                        fn deref_mut(&mut self) -> &mut Rep{camel} {{
+                            unsafe {{
+                                #[cfg(target_arch = "wasm32")]
+                                #[link(wasm_import_module = "[export]{module}")]
+                                extern "C" {{
+                                    #[link_name = "[resource-rep]{name}"]
+                                    fn wit_import(_: i32) -> i32;
+                                }}
+
+                                #[cfg(not(target_arch = "wasm32"))]
+                                unsafe fn wit_import(_n: i32) -> i32 {{ unreachable!() }}
+
+                                ::core::mem::transmute::<isize, &mut Rep{camel}>(
+                                    wit_import(self.handle).try_into().unwrap()
+                                )
+                            }}
+                        }}
+                    }}
+
                     impl Drop for Own{camel} {{
                         fn drop(&mut self) {{
                             unsafe {{


### PR DESCRIPTION
Work towards #641 (but does not fix it, since consumption of an owned resource into the owned Rust type is still not possible)