### PR TITLE
Bump crate versions to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.0",
  "wit-bindgen-rust-macro",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-c"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-go"
-version = "0.8.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-markdown"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-lib"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-teavm-java"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-cli"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -34,14 +34,14 @@ wasm-metadata = "0.10.3"
 wit-parser = "0.11.0"
 wit-component = "0.14.0"
 
-wit-bindgen-core = { path = 'crates/core', version = '0.10.0' }
-wit-bindgen-c = { path = 'crates/c', version = '0.10.0' }
-wit-bindgen-rust = { path = "crates/rust", version = "0.10.0" }
-wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.10.0' }
-wit-bindgen-go = { path = 'crates/go', version = '0.8.0' }
-wit-bindgen-markdown = { path = 'crates/markdown', version = '0.10.0' }
-wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.10.0' }
-wit-bindgen = { path = 'crates/guest-rust', version = '0.10.0', default-features = false }
+wit-bindgen-core = { path = 'crates/core', version = '0.11.0' }
+wit-bindgen-c = { path = 'crates/c', version = '0.11.0' }
+wit-bindgen-rust = { path = "crates/rust", version = "0.11.0" }
+wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.11.0' }
+wit-bindgen-go = { path = 'crates/go', version = '0.11.0' }
+wit-bindgen-markdown = { path = 'crates/markdown', version = '0.11.0' }
+wit-bindgen-rust-lib = { path = 'crates/rust-lib', version = '0.11.0' }
+wit-bindgen = { path = 'crates/guest-rust', version = '0.11.0', default-features = false }
 wit-bindgen-rust-macro-shared = { path = 'crates/rust-macro-shared', version = '0.3.0' }
 
 [[bin]]

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-c"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-core"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/go/Cargo.toml
+++ b/crates/go/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-go"
 authors = ["Mossaka <duibao55328@gmail.com>"]
-version = "0.8.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ Used when compiling Rust programs to the component model.
 """
 
 [dependencies]
-wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.10.0" }
+wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.11.0" }
 bitflags = { workspace = true }
 
 [features]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-markdown"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-lib/Cargo.toml
+++ b/crates/rust-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-lib"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/teavm-java/Cargo.toml
+++ b/crates/teavm-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-teavm-java"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Also update the Go bindings generator 0.11.0 as a version number to keep it in line with the other code generators for now (as for now everything is bumping in lockstep).