### PR TITLE
Update link of wasi_snapshot_preview1.wasm release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ don't have a `_start` entrypoint in the generated core wasm module (e.g. the
 which has a `_start` entrypoint (e.g. a `src/main.rs` in Rust).
 
 [preview2-prototyping]: https://github.com/bytecodealliance/preview2-prototyping
-[preview1-build]: https://github.com/bytecodealliance/preview2-prototyping/releases/tag/latest
+[preview1-build]: https://github.com/bytecodealliance/wasmtime/releases/latest
 [non-command]: https://github.com/bytecodealliance/wasmtime/releases/latest/download/wasi_snapshot_preview1.reactor.wasm
 [command]: https://github.com/bytecodealliance/wasmtime/releases/latest/download/wasi_snapshot_preview1.command.wasm
 


### PR DESCRIPTION
I've got same error with https://github.com/bytecodealliance/wit-bindgen/issues/660 .
Part of the README is misleading as to the download destination due to outdated links.