### PR TITLE
Fix taking owned resource handles in Rust imports

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,6 +42,9 @@ pub struct TypeInfo {
 
     /// Whether or not this type (transitively) has a borrow handle.
     pub has_borrow_handle: bool,
+
+    /// Whether or not this type (transitively) has an own handle.
+    pub has_own_handle: bool,
 }
 
 impl std::ops::BitOrAssign for TypeInfo {
@@ -52,6 +55,7 @@ impl std::ops::BitOrAssign for TypeInfo {
         self.has_list |= rhs.has_list;
         self.has_resource |= rhs.has_resource;
         self.has_borrow_handle |= rhs.has_borrow_handle;
+        self.has_own_handle |= rhs.has_own_handle;
     }
 }
 
@@ -164,7 +168,10 @@ impl Types {
                 info.has_resource = true;
             }
             TypeDefKind::Handle(handle) => {
-                info.has_borrow_handle = matches!(handle, Handle::Borrow(_));
+                match handle {
+                    Handle::Borrow(_) => info.has_borrow_handle = true,
+                    Handle::Own(_) => info.has_own_handle = true,
+                }
                 info.has_resource = true;
             }
             TypeDefKind::Tuple(t) => {

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -18,6 +18,7 @@ macro_rules! codegen_test {
     (resource_borrow_in_record $name:tt $test:tt) => {};
     (resource_borrow_in_record_export $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
+    (issue668 $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/crates/teavm-java/tests/codegen.rs
+++ b/crates/teavm-java/tests/codegen.rs
@@ -17,6 +17,7 @@ macro_rules! codegen_test {
     (resource_borrow_in_record_export $name:tt $test:tt) => {};
     (same_names5 $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
+    (issue668 $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/tests/codegen/issue668.wit
+++ b/tests/codegen/issue668.wit
@@ -1,0 +1,20 @@
+package test:test
+
+interface test-import {
+  resource resource-a {
+    constructor(id: u32)
+  }
+
+  record record-a {
+    resource-a: resource-a,
+    resources: list<resource-a>,
+  }
+
+  resource resource-b {
+    make: static func(record-a: record-a)
+  }
+}
+
+world test-world {
+  import test-import
+}

--- a/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
+++ b/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
@@ -24,7 +24,7 @@ impl Guest for Exports {
             lists::foo(value)
         );
 
-        thing_in::bar(thing_in::Thing {
+        thing_in::bar(&thing_in::Thing {
             name: "thing 1",
             value: &["some value", "another value"],
         });
@@ -38,7 +38,7 @@ impl Guest for Exports {
                 name: "thing 1".to_owned(),
                 value: vec!["some value".to_owned(), "another value".to_owned()],
             },
-            thing_in_and_out::baz(value)
+            thing_in_and_out::baz(&value)
         );
     }
 }

--- a/tests/runtime/ownership/borrowing.rs
+++ b/tests/runtime/ownership/borrowing.rs
@@ -24,7 +24,7 @@ impl Guest for Exports {
             lists::foo(value)
         );
 
-        thing_in::bar(thing_in::Thing {
+        thing_in::bar(&thing_in::Thing {
             name: "thing 1",
             value: &["some value", "another value"],
         });


### PR DESCRIPTION
I went ahead and did a bit more refactoring at the logic here since I think the old conditions aren't as applicable any more (they haven't aged well)

Closes #668