### PR TITLE
Fix generated bindings for list-of-borrows

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -1462,7 +1462,13 @@ impl Bindgen for FunctionBindgen<'_, '_> {
     }
 
     fn is_list_canonical(&self, resolve: &Resolve, ty: &Type) -> bool {
-        resolve.all_bits_valid(ty)
+        if !resolve.all_bits_valid(ty) {
+            return false;
+        }
+        match ty {
+            Type::Id(id) => !self.gen.gen.types.get(*id).has_resource,
+            _ => true,
+        }
     }
 
     fn emit(


### PR DESCRIPTION
This commit fixes an issue for imported functions taking `list<borrow<T>>` arguments. Previously they were erroneously passed through as lists-of-pointers and now they're correctly mapped to list-of-handle-indexes in the ABI. This required rejiggering a bit how types are generated and what's considered owned when, namely requiring that all own handles use `Vec<T>` at the boundary since they need to take ownership.