### PR TITLE
Look through aliases when creating import params

### DIFF
--- a/tests/runtime/ownership.rs
+++ b/tests/runtime/ownership.rs
@@ -8,6 +8,14 @@ pub struct MyImports {
     called_foo: bool,
     called_bar: bool,
     called_baz: bool,
+    called_aliased: bool,
+}
+
+impl aliased::Host for MyImports {
+    fn call(&mut self, _string1: String, _string2: String) -> Result<()> {
+        self.called_aliased = true;
+        Ok(())
+    }
 }
 
 impl lists::Host for MyImports {
@@ -52,6 +60,7 @@ fn run_test(exports: Ownership, store: &mut Store<crate::Wasi<MyImports>>) -> Re
     assert!(store.data().0.called_foo);
     assert!(store.data().0.called_bar);
     assert!(store.data().0.called_baz);
+    assert!(store.data().0.called_aliased);
 
     Ok(())
 }

--- a/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
+++ b/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
@@ -40,5 +40,6 @@ impl Guest for Exports {
             },
             thing_in_and_out::baz(&value)
         );
+        aliased::call("string1", "string2")
     }
 }

--- a/tests/runtime/ownership/borrowing.rs
+++ b/tests/runtime/ownership/borrowing.rs
@@ -34,5 +34,6 @@ impl Guest for Exports {
             value: vec!["some value".to_owned(), "another value".to_owned()],
         };
         assert_eq!(value, thing_in_and_out::baz(&value));
+        aliased::call("string1", "string2")
     }
 }

--- a/tests/runtime/ownership/owning.rs
+++ b/tests/runtime/ownership/owning.rs
@@ -29,5 +29,7 @@ impl Guest for Exports {
             value: vec!["some value".to_owned(), "another value".to_owned()],
         };
         assert_eq!(value, thing_in_and_out::baz(&value));
+
+        aliased::call("string1", "string2")
     }
 }

--- a/tests/runtime/ownership/world.wit
+++ b/tests/runtime/ownership/world.wit
@@ -22,6 +22,11 @@ world ownership {
 
         baz: func(a: thing) -> thing
     }
+    import aliased: interface {
+        type other-alias = string
+        type aliased = other-alias
+        call: func(str: string, aliased: aliased)
+    }
 
     export foo: func()
 }


### PR DESCRIPTION
When creating params for imported functions, look through aliases so that they are treated exactly like their aliased type. 

This prevents aliased primitive types from being borrowed more than they need to be.