### PR TITLE
Rust: Don't borrow borrowed types

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -670,10 +670,13 @@ impl InterfaceGenerator<'_> {
             // it is actually required that we take ownership since Rust is
             // losing access to those handles.
             //
+            // We also skip borrowing if the type has a lifetime associated with
+            // in which case we treated it as already borrowed.
+            //
             // Check here if the type has the right shape and if we're in the
             // right mode, and if those conditions are met a lifetime is
             // printed.
-            if info.has_list && !info.has_own_handle {
+            if info.has_list && !info.has_own_handle && lt.is_none() {
                 if let TypeMode::AllBorrowed(lt) | TypeMode::HandlesBorrowed(lt) = mode {
                     self.push_str("&");
                     if lt != "'_" {

--- a/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
+++ b/tests/runtime/ownership/borrowing-duplicate-if-necessary.rs
@@ -24,7 +24,7 @@ impl Guest for Exports {
             lists::foo(value)
         );
 
-        thing_in::bar(&thing_in::Thing {
+        thing_in::bar(thing_in::Thing {
             name: "thing 1",
             value: &["some value", "another value"],
         });
@@ -38,7 +38,7 @@ impl Guest for Exports {
                 name: "thing 1".to_owned(),
                 value: vec!["some value".to_owned(), "another value".to_owned()],
             },
-            thing_in_and_out::baz(&value)
+            thing_in_and_out::baz(value)
         );
     }
 }

--- a/tests/runtime/ownership/borrowing.rs
+++ b/tests/runtime/ownership/borrowing.rs
@@ -24,7 +24,7 @@ impl Guest for Exports {
             lists::foo(value)
         );
 
-        thing_in::bar(&thing_in::Thing {
+        thing_in::bar(thing_in::Thing {
             name: "thing 1",
             value: &["some value", "another value"],
         });


### PR DESCRIPTION
Fixes #673

This partially reverts a change now live in v0.12 that was introduced in #669. If a type has a lifetime associated with it, treat it as already borrowed and don't borrow again. 