### PR TITLE
Fix the `exports` key for packages-with-versions

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -296,24 +296,14 @@ impl WorldGenerator for RustWasm {
         id: InterfaceId,
         _files: &mut Files,
     ) -> Result<()> {
-        let (pkg, inner_name) = match name {
-            WorldKey::Name(name) => (None, name),
+        let inner_name = match name {
+            WorldKey::Name(name) => name,
             WorldKey::Interface(id) => {
                 let interface = &resolve.interfaces[*id];
-                (
-                    Some(&resolve.packages[interface.package.unwrap()].name),
-                    interface.name.as_ref().unwrap(),
-                )
+                interface.name.as_ref().unwrap()
             }
         };
-        let path = format!(
-            "{}{inner_name}",
-            if let Some(pkg) = pkg {
-                format!("{}:{}/", pkg.namespace, pkg.name)
-            } else {
-                String::new()
-            }
-        );
+        let path = resolve.id_of(id).unwrap_or(inner_name.to_string());
         let mut gen = self.interface(Identifier::Interface(id, name), None, resolve, false);
         let (snake, pkg) = gen.start_append_submodule(name);
         gen.types(id);

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -134,7 +134,6 @@ mod symbol_does_not_conflict {
                 bar: func() -> string
             }
 
-
             world foo {
                 export foo1
                 export foo2
@@ -269,6 +268,35 @@ mod owned_resource_deref_mut {
             let mutable_data: &mut u32 = &mut this.data;
             *mutable_data = new_data;
             this.data
+        }
+    }
+}
+
+mod package_with_versions {
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline@0.0.0
+
+            interface foo {
+                resource bar {
+                    constructor()
+                }
+            }
+
+            world baz {
+                export foo
+            }
+        ",
+        exports: {
+            "my:inline/foo@0.0.0/bar": Resource
+        }
+    });
+
+    pub struct Resource;
+
+    impl exports::my::inline::foo::GuestBar for Resource {
+        fn new() -> Self {
+            loop {}
         }
     }
 }


### PR DESCRIPTION
Previously one location looking up `exports` would account for the version and another wouldn't which caused the `ERROR` case to leak through by accident. These are now kept in sync to ensure that the right errors get surfaced.