### PR TITLE
Ignore flaky TinyGo test

### DIFF
--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -19,6 +19,7 @@ macro_rules! codegen_test {
     (resource_borrow_in_record_export $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
     (issue668 $name:tt $test:tt) => {};
+    (flavorful $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]


### PR DESCRIPTION
This has failed on CI a number of times recently so ignore it for now until there's a chance to investigate.