### PR TITLE
Make resources in Rust #[repr(transparent)]

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -184,6 +184,7 @@ pub mod rt {
 ///
 /// This type is primarily used in generated code for exported and imported
 /// resources.
+#[repr(transparent)]
 pub struct Resource<T: WasmResource> {
     handle: u32,
     _marker: marker::PhantomData<Box<T>>,

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1586,6 +1586,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 self.src,
                 r#"
                     #[derive(Debug)]
+                    #[repr(transparent)]
                     pub struct {camel} {{
                         handle: {rt}::Resource<{camel}>,
                     }}


### PR DESCRIPTION
Enables them to be usable in FFI contexts