### PR TITLE
fix(rust): Re-exports to_rust_ident

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -576,7 +576,7 @@ struct FnSig {
     self_is_first_param: bool,
 }
 
-fn to_rust_ident(name: &str) -> String {
+pub fn to_rust_ident(name: &str) -> String {
     match name {
         // Escape Rust keywords.
         // Source: https://doc.rust-lang.org/reference/keywords.html


### PR DESCRIPTION
This function was public before the crates were merged and `cargo component` depends on this function. This re-marks the function as public