### PR TITLE
Add resource-own-in-other-interface test and fix C

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1039,8 +1039,7 @@ impl C {
                                 }
                                 _ => {}
                             }
-                            self.public_anonymous_types.insert(*id);
-                            self.private_anonymous_types.remove(id);
+                            self.visit_anonymous_types(resolve, &Type::Id(*id));
                             dst.push_str(&ns);
                             dst.push_str("_");
                             push_ty_name(
@@ -1055,6 +1054,87 @@ impl C {
                     },
                 }
             }
+        }
+    }
+
+    fn visit_anonymous_types(&mut self, resolve: &Resolve, ty: &Type) {
+        match ty {
+            Type::String => {
+                self.needs_string = true;
+            }
+            Type::Id(id) => {
+                let ty = &resolve.types[*id];
+                if ty.name.is_none() {
+                    match &ty.kind {
+                        TypeDefKind::Type(_) => {}
+                        TypeDefKind::Handle(Handle::Borrow(resource))
+                            if matches!(
+                                self.resources
+                                    .get(&dealias(resolve, *resource))
+                                    .map(|info| &info.direction),
+                                Some(Direction::Export)
+                            ) => {}
+                        _ => {
+                            self.public_anonymous_types.insert(*id);
+                            self.private_anonymous_types.remove(id);
+                        }
+                    }
+                }
+
+                match &ty.kind {
+                    TypeDefKind::Type(t) => self.visit_anonymous_types(resolve, t),
+                    TypeDefKind::Record(r) => {
+                        for field in &r.fields {
+                            self.visit_anonymous_types(resolve, &field.ty);
+                        }
+                    }
+                    TypeDefKind::Resource
+                    | TypeDefKind::Handle(_)
+                    | TypeDefKind::Flags(_)
+                    | TypeDefKind::Enum(_) => {}
+                    TypeDefKind::Variant(v) => {
+                        for case in &v.cases {
+                            if let Some(ty) = &case.ty {
+                                self.visit_anonymous_types(resolve, ty);
+                            }
+                        }
+                    }
+                    TypeDefKind::Tuple(t) => {
+                        for ty in &t.types {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                    }
+                    TypeDefKind::Option(ty) => {
+                        self.visit_anonymous_types(resolve, ty);
+                    }
+                    TypeDefKind::Result(r) => {
+                        if let Some(ty) = &r.ok {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                        if let Some(ty) = &r.err {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                    }
+                    TypeDefKind::List(ty) => {
+                        self.visit_anonymous_types(resolve, ty);
+                    }
+                    TypeDefKind::Future(ty) => {
+                        if let Some(ty) = ty {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                    }
+                    TypeDefKind::Stream(s) => {
+                        if let Some(ty) = &s.element {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                        if let Some(ty) = &s.end {
+                            self.visit_anonymous_types(resolve, ty);
+                        }
+                    }
+                    TypeDefKind::Unknown => unreachable!(),
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -17,6 +17,7 @@ macro_rules! codegen_test {
     (resource_local_alias_borrow_import $name:tt $test:tt) => {};
     (resource_borrow_in_record $name:tt $test:tt) => {};
     (resource_borrow_in_record_export $name:tt $test:tt) => {};
+    (resource_own_in_other_interface $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
     (issue668 $name:tt $test:tt) => {};
 

--- a/crates/teavm-java/tests/codegen.rs
+++ b/crates/teavm-java/tests/codegen.rs
@@ -15,6 +15,7 @@ macro_rules! codegen_test {
     (resource_local_alias_borrow_import $name:tt $test:tt) => {};
     (resource_borrow_in_record $name:tt $test:tt) => {};
     (resource_borrow_in_record_export $name:tt $test:tt) => {};
+    (resource_own_in_other_interface $name:tt $test:tt) => {};
     (same_names5 $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
     (issue668 $name:tt $test:tt) => {};

--- a/tests/codegen/resource-own-in-other-interface.wit
+++ b/tests/codegen/resource-own-in-other-interface.wit
@@ -1,0 +1,13 @@
+package my:resources
+interface e1 {
+	resource x {
+		fun: func() -> tuple<x>
+	}
+}
+
+world resources {
+  import e2: interface {
+    use e1.{x}
+    use-res: func() -> x
+}
+}


### PR DESCRIPTION
This tests a case of aliasing a resource across interfaces which we hadn't covered before, and fixes the C generator to handle it.