### PR TITLE
test(C): test all generated C header files for C++ compatibility, too

### DIFF
--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -44,19 +44,37 @@ macro_rules! codegen_test {
 test_helpers::codegen_tests!();
 
 fn verify(dir: &Path, name: &str) {
-    let path = PathBuf::from(
+    let name = name.to_snake_case();
+    let sdk_path = PathBuf::from(
         env::var_os("WASI_SDK_PATH").expect("environment variable WASI_SDK_PATH should be set"),
     );
-    let mut cmd = Command::new(path.join("bin/clang"));
-    cmd.arg("--sysroot").arg(path.join("share/wasi-sysroot"));
-    cmd.arg(dir.join(format!("{}.c", name.to_snake_case())));
-    cmd.arg("-I").arg(dir);
-    cmd.arg("-Wall")
-        .arg("-Wextra")
-        .arg("-Werror")
-        .arg("-Wno-unused-parameter");
-    cmd.arg("-c");
-    cmd.arg("-o").arg(dir.join("obj.o"));
+    let sysroot = sdk_path.join("share/wasi-sysroot");
+    let c_src = dir.join(format!("{name}.c"));
 
+    let shared_args = vec![
+        "--sysroot",
+        sysroot.to_str().unwrap(),
+        "-I",
+        dir.to_str().unwrap(),
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wno-unused-parameter",
+        "-c",
+        "-o",
+    ];
+
+    let mut cmd = Command::new(sdk_path.join("bin/clang"));
+    cmd.args(&shared_args);
+    cmd.arg(dir.join("obj.o"));
+    cmd.arg(&c_src);
+    test_helpers::run_command(&mut cmd);
+
+    let cpp_src = c_src.with_extension("cpp");
+    std::fs::write(&cpp_src, format!("#include \"{name}.h\"\n")).unwrap();
+    let mut cmd = Command::new(sdk_path.join("bin/clang++"));
+    cmd.args(&shared_args);
+    cmd.arg(dir.join("obj.o"));
+    cmd.arg(&cpp_src);
     test_helpers::run_command(&mut cmd);
 }


### PR DESCRIPTION
This can't land yet, because it causes a bunch of tests to fail. One will be addressed by #690, but the others all involve empty types, and will probably require changes to the tests themselves.