### PR TITLE
Multi version support 

### DIFF
--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -12,6 +12,7 @@ macro_rules! codegen_test {
     (resource_local_alias $name:tt $test:tt) => {};
     (resources_with_lists $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
+    (multiversion $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -20,6 +20,7 @@ macro_rules! codegen_test {
     (resource_own_in_other_interface $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
     (issue668 $name:tt $test:tt) => {};
+    (multiversion $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -191,7 +191,7 @@ impl InterfaceGenerator<'_> {
         (snake, pkg)
     }
 
-    pub fn finish_append_submodule(mut self, snake: &str, pkg: Option<PackageName>) {
+    pub fn finish_append_submodule(mut self, snake: &str, module_path: Vec<String>) {
         let module = self.finish();
         let path_to_root = self.path_to_root();
         let module = format!(
@@ -211,7 +211,7 @@ impl InterfaceGenerator<'_> {
         } else {
             &mut self.gen.export_modules
         };
-        map.entry(pkg).or_insert(Vec::new()).push(module);
+        map.push((module, module_path))
     }
 
     fn generate_guest_import(&mut self, func: &Function) {

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -404,16 +404,16 @@ impl InterfaceGenerator<'_> {
     pub fn generate_stub(
         &mut self,
         resource: Option<TypeId>,
-        pkg: Option<&PackageName>,
+        pkg: Option<(String, String)>,
         name: &str,
         in_interface: bool,
         funcs: &[&Function],
     ) {
-        let path = if let Some(pkg) = pkg {
+        let path = if let Some((namespace, pkg_name)) = pkg {
             format!(
                 "{}::{}::{}",
-                to_rust_ident(&pkg.namespace),
-                to_rust_ident(&pkg.name),
+                to_rust_ident(&namespace),
+                to_rust_ident(&pkg_name),
                 to_rust_ident(name),
             )
         } else {

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -466,7 +466,7 @@ impl WorldGenerator for RustWasm {
                     WorldKey::Interface(id) => {
                         let interface = &resolve.interfaces[*id];
                         (
-                            Some(&resolve.packages[interface.package.unwrap()].name),
+                            Some(interface.package.unwrap()),
                             interface.name.as_ref().unwrap(),
                         )
                     }
@@ -481,6 +481,11 @@ impl WorldGenerator for RustWasm {
                         {
                             let mut gen =
                                 self.interface(Identifier::World(world_id), None, resolve, false);
+                            let pkg = pkg.map(|pid| {
+                                let namespace = resolve.packages[pid].name.namespace.clone();
+                                let package_module = name_package_module(resolve, pid);
+                                (namespace, package_module)
+                            });
                             gen.generate_stub(resource, pkg, name, true, &funcs);
                             let stub = gen.finish();
                             self.src.push_str(&stub);

--- a/crates/teavm-java/tests/codegen.rs
+++ b/crates/teavm-java/tests/codegen.rs
@@ -19,6 +19,7 @@ macro_rules! codegen_test {
     (same_names5 $name:tt $test:tt) => {};
     (resources_in_aggregates $name:tt $test:tt) => {};
     (issue668 $name:tt $test:tt) => {};
+    (multiversion $name:tt $test:tt) => {};
 
     ($id:ident $name:tt $test:tt) => {
         #[test]

--- a/tests/codegen/multiversion/deps/v1/root.wit
+++ b/tests/codegen/multiversion/deps/v1/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.1.0;
+
+interface a {
+  x: func();
+}

--- a/tests/codegen/multiversion/deps/v1/root.wit
+++ b/tests/codegen/multiversion/deps/v1/root.wit
@@ -1,5 +1,6 @@
 package my:dep@0.1.0;
 
 interface a {
+  type foo = u8;
   x: func();
 }

--- a/tests/codegen/multiversion/deps/v2/root.wit
+++ b/tests/codegen/multiversion/deps/v2/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.2.0;
+
+interface a {
+  x: func();
+}

--- a/tests/codegen/multiversion/deps/v2/root.wit
+++ b/tests/codegen/multiversion/deps/v2/root.wit
@@ -1,5 +1,6 @@
 package my:dep@0.2.0;
 
 interface a {
-  x: func();
+  use my:dep/a@0.1.0.{foo};
+  x: func() -> foo;
 }

--- a/tests/codegen/multiversion/root.wit
+++ b/tests/codegen/multiversion/root.wit
@@ -3,4 +3,5 @@ package foo:bar;
 world foo {
   import my:dep/a@0.1.0;
   import my:dep/a@0.2.0;
+  export my:dep/a@0.2.0;
 }

--- a/tests/codegen/multiversion/root.wit
+++ b/tests/codegen/multiversion/root.wit
@@ -1,0 +1,6 @@
+package foo:bar;
+
+world foo {
+  import my:dep/a@0.1.0;
+  import my:dep/a@0.2.0;
+}


### PR DESCRIPTION
A continuation of https://github.com/bytecodealliance/wasmtime/pull/7172 and https://github.com/bytecodealliance/wasmtime/pull/7196 and borrows liberally from those PRs. This allows the use of different versions of the same logical interface. 

This only fixes Rust so I'm marking it as a draft until tomorrow when I can fix the other languages. 