### PR TITLE
chore: bump workspace dependencies to make wit-bindgen compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
  "wasm-encoder 0.33.2",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.0",
 ]
 
 [[package]]
@@ -1188,18 +1188,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.10.7"
+name = "wasm-encoder"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c051ef041d348324b01ff0419f6f6593f094b4897d93c9cf52d5d1ac879ba"
+checksum = "f14a94e06a3e2ed1af4e80cac712fed883142019ebe33c3899fd1b5e8550df9d"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346c0975b2fea462dbe9bf692dd054272f9872f8c3958be21c83b3ebf44a9b85"
 dependencies = [
  "anyhow",
  "indexmap",
  "serde",
+ "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.33.2",
- "wasmparser 0.113.3",
+ "wasm-encoder 0.34.1",
+ "wasmparser 0.114.0",
 ]
 
 [[package]]
@@ -1217,6 +1227,16 @@ name = "wasmparser"
 version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
+dependencies = [
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef211410dcb08b037eb6d197b2398f8ef9d635c5dc5598d0dfda32094315ea3"
 dependencies = [
  "indexmap",
  "semver",
@@ -1313,7 +1333,7 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.11.3",
 ]
 
 [[package]]
@@ -1530,7 +1550,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap",
- "wit-parser",
+ "wit-parser 0.11.3",
 ]
 
 [[package]]
@@ -1541,21 +1561,21 @@ checksum = "5412bb464066d64c3398c96e6974348f90fa2a55110ad7da3f9295438cd4de84"
 
 [[package]]
 name = "wast"
-version = "66.0.0"
+version = "66.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da7529bb848d58ab8bf32230fc065b363baee2bd338d5e58c589a1e7d83ad07"
+checksum = "49d1457e95d4b8e1f72bd50f5ed804931f94cf1b5449697255aef466e46fa4b0"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.33.2",
+ "wasm-encoder 0.34.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4780374047c65b6b6e86019093fe80c18b66825eb684df778a4e068282a780e7"
+checksum = "964639e3c731f12b7bf6be78f0b2c3e646321acab18e7cb9f18e44c6720bb4fa"
 dependencies = [
  "wast",
 ]
@@ -1703,7 +1723,7 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-bindgen-teavm-java",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.0",
 ]
 
 [[package]]
@@ -1712,7 +1732,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.0",
 ]
 
 [[package]]
@@ -1784,21 +1804,22 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2bf941487fc5afa9e3fc94761f6b80ecef5a2bed6239b959d23d9de69e3448"
+checksum = "0e99c85960e9e0a6211b4bb127347151224183fae69c2fe89ccc36c6c6551c0d"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
  "indexmap",
  "log",
  "serde",
+ "serde_derive",
  "serde_json",
- "wasm-encoder 0.33.2",
+ "wasm-encoder 0.34.1",
  "wasm-metadata",
- "wasmparser 0.113.3",
+ "wasmparser 0.114.0",
  "wat",
- "wit-parser",
+ "wit-parser 0.12.0",
 ]
 
 [[package]]
@@ -1817,6 +1838,23 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "url",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08c9557c65c428ac18a3cce80bf2527dbec24ab06639642c7db73f2c7613f93"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ indexmap = "2.0.0"
 
 wasm-encoder = "0.33.2"
 wasm-metadata = "0.10.6"
-wit-parser = "0.11.3"
-wit-component = "0.14.4"
+wit-parser = "0.12"
+wit-component = "0.14.6"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.12.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.12.0' }


### PR DESCRIPTION
Fixes #697