### PR TITLE
Bump tinygo and re-enable flavorful runtime test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         go-version: '1.20'
     - uses: acifani/setup-tinygo@v1
       with:
-        tinygo-version: 0.29.0
+        tinygo-version: 0.30.0
     - run: cargo test --workspace
     - run: cargo build
     - run: cargo build --no-default-features

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -225,7 +225,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
 
     // FIXME: need to fix flaky Go test
     #[cfg(feature = "go")]
-    if !go.is_empty() && name != "flavorful" {
+    if !go.is_empty() {
         let world_name = &resolve.worlds[world].name;
         let out_dir = out_dir.join(format!("go-{}", world_name));
         drop(fs::remove_dir_all(&out_dir));


### PR DESCRIPTION
This bumps the tinygo version to 0.30.0 and re-enable the flavorful runtime test. Closes #707 