### PR TITLE
fix(rust/with): use correct remapped path

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -298,7 +298,7 @@ impl RustWasm {
             uwriteln!(self.src, "use {remapped_path} as {name};");
             InterfaceName {
                 remapped: true,
-                path: name,
+                path: format!("super::super::super::{name}"),
             }
         } else {
             let path = compute_module_path(name, resolve, is_export).join("::");


### PR DESCRIPTION
Fix a bug introduced in https://github.com/bytecodealliance/wit-bindgen/pull/699/commits/6ed4e010109079b79044e7d31ae3ce17b86dfc2e from https://github.com/bytecodealliance/wit-bindgen/pull/699 where the `__with*` remapping added to the root is referred to as `__with*` from the submodule.

Here's an example of a generated code that this PR fixes:

For an invocation like:
```rust
wit_bindgen::generate!({
    exports: {
        world: Actor,
        "wasi:http/incoming-handler": Actor,
    },
    with: {
        "wasi:io/streams": wasmcloud_actor::wasi::io::streams,
    }
});
```

Before:
```rust
use wasmcloud_actor::wasi::io::streams as __with_name0;
pub mod wasi {
    pub mod http {
        #[allow(clippy::all)]
        pub mod types {
            pub type InputStream = __with_name0::InputStream;
            pub type OutputStream = __with_name0::OutputStream;
```

After:
```rust
use wasmcloud_actor::wasi::io::streams as __with_name0;
pub mod wasi {
    pub mod http {
        #[allow(clippy::all)]
        pub mod types {
            pub type InputStream = super::super::super::__with_name0::InputStream;
            pub type OutputStream = super::super::super::__with_name0::OutputStream;
```