### PR TITLE
wit-bindgen-rust: ignore unused unsafe warnings in generated source.

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -259,7 +259,7 @@ impl InterfaceGenerator<'_> {
                 }
             }
         }
-        self.src.push_str("#[allow(clippy::all)]\n");
+        self.src.push_str("#[allow(unused_unsafe, clippy::all)]\n");
         let params = self.print_signature(func, param_mode, &sig);
         self.src.push_str("{\n");
         self.src.push_str(&format!(


### PR DESCRIPTION
This PR automatically ignores unused unsafe on generated functions.

If, for example, the function has no parameters or results, there won't be any marshalling of data requiring the use of `unsafe`.