### PR TITLE
add "[export]" to imported resource functions in C

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -606,7 +606,7 @@ impl C {
 
                 uwriteln!(
                     c_str,
-                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-new]{name}")))
+                    r#"__attribute__((__import_module__("[export]{module}"), __import_name__("[resource-new]{name}")))
                        int32_t __wasm_import_{namespace}_{snake}_new(int32_t);
 
                        {own_name} {namespace}_{snake}_new({namespace}_{snake}_t* arg) {{
@@ -621,7 +621,7 @@ impl C {
 
                 uwriteln!(
                     c_str,
-                    r#"__attribute__((__import_module__("{module}"), __import_name__("[resource-rep]{snake}")))
+                    r#"__attribute__((__import_module__("[export]{module}"), __import_name__("[resource-rep]{snake}")))
                        int32_t __wasm_import_{namespace}_{snake}_rep(int32_t);
 
                        {namespace}_{snake}_t* {namespace}_{snake}_rep({own_name}{space}arg) {{


### PR DESCRIPTION
Following the host bindgen test cases described at here: https://github.com/bytecodealliance/wasmtime/blob/519808fc5c2565f11f9b6a7f5fe3d2385f9f95e8/tests/all/component_model/bindgen.rs#L527-L528, I found that the `Resource.new`, `Resource.rep` for exported resources in the guest module needs to be imported by the module name in the form of `[exports]{module-name}`. 

Hence I added the missing `"[export]"` to each imported methods of exported resources. 

This closes #721 

@dicej could you please take a look? 🙏