### PR TITLE
c bindgen: Avoid emitting empty unions for variants with no data

### DIFF
--- a/tests/codegen/variants.wit
+++ b/tests/codegen/variants.wit
@@ -128,6 +128,14 @@ interface variants {
 
   return-named-option: func() -> (a: option<u8>);
   return-named-result: func() -> (a: result<u8, my-errno>);
+
+  variant no-data {
+    a,
+    b,
+  }
+
+  consumes-no-data: func(x: no-data);
+  produces-no-data: func() -> no-data;
 }
 
 world my-world {


### PR DESCRIPTION
Avoid emitting the `union {...} val;` part of a variant type declaration when the variant cases contain no data. This fixes one instance of representation differences between c and c++, as pointed out in #725.

I tested this by modifying the c codegen tests to include `-Wgnu-empty-struct`, and verifying that after the fix is applied, the number of errors goes down to two with the modified variants.wit test.

Fixes #725
