### PR TITLE
feat(go): add resources support

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -224,7 +224,7 @@ impl WorldGenerator for C {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut gen = self.interface(resolve, false);
+        let mut gen = self.interface(resolve, true);
         for (name, id) in types {
             gen.define_type(name, *id);
         }

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -95,3 +95,7 @@ test = false
 [[bin]]
 name = "resource_aggregates"
 test = false
+
+[[bin]]
+name = "resource_borrow_simple"
+test = false

--- a/crates/test-rust-wasm/src/bin/resource_borrow_simple.rs
+++ b/crates/test-rust-wasm/src/bin/resource_borrow_simple.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/resource_borrow_simple/wasm.rs");
+
+fn main() {}

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -262,9 +262,9 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
     if !go.is_empty() {
         let world_name = &resolve.worlds[world].name;
         let out_dir = out_dir.join(format!("go-{}", world_name));
+        let snake = world_name.replace("-", "_");
         drop(fs::remove_dir_all(&out_dir));
 
-        let snake = world_name.replace("-", "_");
         let mut files = Default::default();
         wit_bindgen_go::Opts::default()
             .build()

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -25,6 +25,7 @@ mod resource_alias_redux;
 mod resource_borrow_export;
 mod resource_borrow_import;
 mod resource_borrow_in_record;
+mod resource_borrow_simple;
 mod resource_floats;
 mod resource_import_and_export;
 mod resource_into_inner;

--- a/tests/runtime/resource_borrow_simple.rs
+++ b/tests/runtime/resource_borrow_simple.rs
@@ -1,0 +1,43 @@
+use wasmtime::Store;
+
+wasmtime::component::bindgen!(in "tests/runtime/resource_borrow_simple");
+
+#[derive(Default)]
+
+pub struct MyHostRImpl {}
+
+impl HostR for MyHostRImpl {
+    fn drop(
+        &mut self,
+        _: wasmtime::component::Resource<R>,
+    ) -> std::result::Result<(), anyhow::Error> {
+        Ok(())
+    }
+}
+
+impl ResourceBorrowSimpleImports for MyHostRImpl {
+    fn test(&mut self, _: wasmtime::component::Resource<R>) -> wasmtime::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn run() -> anyhow::Result<()> {
+    crate::run_test(
+        "resource_borrow_import",
+        |linker| ResourceBorrowSimple::add_to_linker(linker, |x| &mut x.0),
+        |store, component: &wasmtime::component::Component, linker| {
+            let (u, e) = ResourceBorrowSimple::instantiate(store, component, linker)?;
+            Ok((u, e))
+        },
+        run_test,
+    )
+}
+
+fn run_test(
+    instance: ResourceBorrowSimple,
+    store: &mut Store<crate::Wasi<MyHostRImpl>>,
+) -> anyhow::Result<()> {
+    instance.call_test_imports(&mut *store)?;
+    Ok(())
+}

--- a/tests/runtime/resource_borrow_simple/wasm.c
+++ b/tests/runtime/resource_borrow_simple/wasm.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <resource_borrow_simple.h>
+
+bool resource_borrow_simple_test_imports(void) {
+    resource_borrow_simple_borrow_r_t r = resource_borrow_simple_borrow_r_t {
+        .__handle = 0,
+    }
+    resource_borrow_simple_test(r);
+    resource_borrow_simple_r_drop_borrow(r);
+}

--- a/tests/runtime/resource_borrow_simple/wasm.rs
+++ b/tests/runtime/resource_borrow_simple/wasm.rs
@@ -1,0 +1,17 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/resource_borrow_simple",
+    exports: {
+        world: Test,
+    }
+});
+
+pub struct Test {}
+
+impl Guest for Test {
+    fn test_imports() {
+        unsafe {
+            let r = R { handle: wit_bindgen::rt::Resource::from_handle(0) };
+            test(&r);
+        }
+    }
+}

--- a/tests/runtime/resource_borrow_simple/world.wit
+++ b/tests/runtime/resource_borrow_simple/world.wit
@@ -1,0 +1,7 @@
+package test:resource-borrow-simple;
+
+world resource-borrow-simple {
+  resource r;
+  import test: func(r: borrow<r>);
+  export test-imports: func();
+}

--- a/tests/runtime/resources.rs
+++ b/tests/runtime/resources.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use wasmtime::component::ResourceAny;
 use std::collections::HashMap;
 
 wasmtime::component::bindgen!(in "tests/runtime/resources");
@@ -76,11 +77,25 @@ fn run_test(exports: Exports, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
     let x = exports.x();
     let x_instance = x.call_constructor(&mut *store, 5)?;
     assert_eq!(x.call_get_a(&mut *store, x_instance)?, 5);
-    let _ = x.call_set_a(&mut *store, x_instance, 10);
+    x.call_set_a(&mut *store, x_instance, 10)?;
     assert_eq!(x.call_get_a(&mut *store, x_instance)?, 10);
-    let y = exports.z();
-    let y_instance = y.call_constructor(&mut *store, 10)?;
-    assert_eq!(y.call_get_a(&mut *store, y_instance)?, 10);
+    let z = exports.z();
+    let z_instance_1 = z.call_constructor(&mut *store, 10)?;
+    assert_eq!(z.call_get_a(&mut *store, z_instance_1)?, 10);
+
+    let z_instance_2 = z.call_constructor(&mut *store, 20)?;
+    assert_eq!(z.call_get_a(&mut *store, z_instance_2)?, 20);
+
+    let x_add = x.call_add(&mut *store, x_instance, 5)?;
+    assert_eq!(x.call_get_a(&mut *store, x_add)?, 15);
+
+    let z_add = exports.call_add(&mut *store, z_instance_1, z_instance_2)?;
+    assert_eq!(z.call_get_a(&mut *store, z_add)?, 30);
+
+
+    ResourceAny::resource_drop(x_instance, &mut *store)?;
+    ResourceAny::resource_drop(z_instance_1, &mut *store)?;
+    ResourceAny::resource_drop(z_instance_2, &mut *store)?;
 
     Ok(())
 }

--- a/tests/runtime/resources.rs
+++ b/tests/runtime/resources.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use wasmtime::component::ResourceAny;
 use std::collections::HashMap;
+use wasmtime::component::ResourceAny;
 
 wasmtime::component::bindgen!(in "tests/runtime/resources");
 
@@ -91,7 +91,6 @@ fn run_test(exports: Exports, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
 
     let z_add = exports.call_add(&mut *store, z_instance_1, z_instance_2)?;
     assert_eq!(z.call_get_a(&mut *store, z_add)?, 30);
-
 
     ResourceAny::resource_drop(x_instance, &mut *store)?;
     ResourceAny::resource_drop(z_instance_1, &mut *store)?;

--- a/tests/runtime/resources/wasm.go
+++ b/tests/runtime/resources/wasm.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	. "wit_resources_go/gen"
+)
+
+func init() {
+	n := &ExportsImpl{}
+	SetExports(n)
+}
+
+type ExportsImpl struct {
+
+}
+
+type MyX struct {
+	a int32
+}
+
+type MyZ struct {
+	a int32
+}
+
+func (e ExportsImpl) NewX(a int32) ExportsX {
+	return &MyX{a: a}
+}
+
+func (e ExportsImpl) NewZ(a int32) ExportsZ {
+	return &MyZ{a: a}
+}
+
+func (x *MyX) GetA() int32 {
+	return x.a
+}
+
+func (x *MyX) SetA(a int32) {
+	x.a = a
+}
+
+func (e ExportsImpl) XAdd(x ExportsX, a int32) ExportsX {
+	return &MyX{a: x.GetA() + a}
+}
+
+func (z *MyZ) GetA() int32 {
+	return z.a
+}
+
+func (e ExportsImpl) ZAdd(z ExportsZ, b ExportsZ) ExportsZ {
+	return &MyZ{a: z.GetA() + b.GetA()}
+}
+
+func (e ExportsImpl) X() ExportsX {
+	return &MyX{a: 0}
+}
+
+func (e ExportsImpl) Z() ExportsZ {
+	return &MyZ{a: 0}
+}
+
+func (e ExportsImpl) TestImports() Result[struct{}, string]  {
+	y := NewY(1)
+	if y.GetA() != 1 {
+		panic("y.GetA() != 1")
+	}
+	y.SetA(2)
+	if y.GetA() != 2 {
+		panic("y.GetA() != 2")
+	}
+
+	y2 := YAdd(y, 3)
+	if y2.GetA() != 5 {
+		panic("y2.GetA() != 5")
+	}
+
+	y.SetA(5)
+
+	if y.GetA() != 5 {
+		panic("y.GetA() != 5")
+	}
+
+	y.Drop()
+	y2.Drop()
+
+	return Result[struct{}, string]{
+		Kind: Ok,
+		Val: struct{}{},
+	}
+}
+
+func main() {}

--- a/tests/runtime/resources/wasm.go
+++ b/tests/runtime/resources/wasm.go
@@ -21,65 +21,54 @@ type MyZ struct {
 	a int32
 }
 
-func (e ExportsImpl) NewX(a int32) ExportsX {
+func (e ExportsImpl) ConstructorX(a int32) ExportsX {
 	return &MyX{a: a}
 }
 
-func (e ExportsImpl) NewZ(a int32) ExportsZ {
+func (e ExportsImpl) ConstructorZ(a int32) ExportsZ {
 	return &MyZ{a: a}
 }
 
-func (x *MyX) GetA() int32 {
+func (x *MyX) MethodXGetA() int32 {
 	return x.a
 }
 
-func (x *MyX) SetA(a int32) {
+func (x *MyX) MethodXSetA(a int32) {
 	x.a = a
 }
 
-func (e ExportsImpl) XAdd(x ExportsX, a int32) ExportsX {
-	return &MyX{a: x.GetA() + a}
+func (e ExportsImpl) StaticXAdd(x ExportsX, a int32) ExportsX {
+	return &MyX{a: x.MethodXGetA() + a}
 }
 
-func (z *MyZ) GetA() int32 {
+func (z *MyZ) MethodZGetA() int32 {
 	return z.a
 }
 
-func (e ExportsImpl) ZAdd(z ExportsZ, b ExportsZ) ExportsZ {
-	return &MyZ{a: z.GetA() + b.GetA()}
-}
-
-func (e ExportsImpl) X() ExportsX {
-	return &MyX{a: 0}
-}
-
-func (e ExportsImpl) Z() ExportsZ {
-	return &MyZ{a: 0}
+func (e ExportsImpl) Add(z ExportsZ, b ExportsZ) ExportsZ {
+	return &MyZ{a: z.MethodZGetA() + b.MethodZGetA()}
 }
 
 func (e ExportsImpl) TestImports() Result[struct{}, string]  {
-	y := NewY(1)
-	if y.GetA() != 1 {
+	y := ImportsConstructorY(1)
+	if y.ImportsMethodYGetA() != 1 {
 		panic("y.GetA() != 1")
 	}
-	y.SetA(2)
-	if y.GetA() != 2 {
+	y.ImportsMethodYSetA(2)
+	if y.ImportsMethodYGetA() != 2 {
 		panic("y.GetA() != 2")
 	}
 
-	y2 := YAdd(y, 3)
-	if y2.GetA() != 5 {
+	y2 := ImportsStaticYAdd(y, 3)
+	if y2.ImportsMethodYGetA() != 5 {
 		panic("y2.GetA() != 5")
 	}
 
-	y.SetA(5)
+	y.ImportsMethodYSetA(5)
 
-	if y.GetA() != 5 {
+	if y.ImportsMethodYGetA() != 5 {
 		panic("y.GetA() != 5")
 	}
-
-	y.Drop()
-	y2.Drop()
 
 	return Result[struct{}, string]{
 		Kind: Ok,


### PR DESCRIPTION
This is a WIP PR to add `resources` support to `wit-bindgen-go`. 

Should close #696 and #615

TODO list
- [ ] Fix C's resource built-in functions imported module name for exported resources. https://github.com/bytecodealliance/wit-bindgen/pull/748 
- [x] enable `resources` runtime test
- [ ] enable `resources` codegen test
- [ ] enable `return_resource_from_export` codegen test
- [ ] enable `resource_local_alias_borrow` codegen test
- [ ] enable `resource_borrow_in_record` codegen test
- [ ] Fix C's import and export of the same resource issue. #723 
- [ ] test on `wasi-http/proxy` world. #735 