### PR TITLE
Bump to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-c"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-cli"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-csharp"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-go"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-markdown"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-teavm-java"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-cli"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition = { workspace = true }
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -34,14 +34,14 @@ wasmtime-wasi = "14.0.0"
 wit-parser = "0.13.0"
 wit-component = "0.18.0"
 
-wit-bindgen-core = { path = 'crates/core', version = '0.13.2' }
-wit-bindgen-c = { path = 'crates/c', version = '0.13.2' }
-wit-bindgen-rust = { path = "crates/rust", version = "0.13.3" }
-wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.13.2' }
-wit-bindgen-go = { path = 'crates/go', version = '0.13.2' }
-wit-bindgen-csharp = { path = 'crates/csharp', version = '0.13.2' }
-wit-bindgen-markdown = { path = 'crates/markdown', version = '0.13.2' }
-wit-bindgen = { path = 'crates/guest-rust', version = '0.13.2', default-features = false }
+wit-bindgen-core = { path = 'crates/core', version = '0.14.0' }
+wit-bindgen-c = { path = 'crates/c', version = '0.14.0' }
+wit-bindgen-rust = { path = "crates/rust", version = "0.14.0" }
+wit-bindgen-teavm-java = { path = 'crates/teavm-java', version = '0.14.0' }
+wit-bindgen-go = { path = 'crates/go', version = '0.14.0' }
+wit-bindgen-csharp = { path = 'crates/csharp', version = '0.14.0' }
+wit-bindgen-markdown = { path = 'crates/markdown', version = '0.14.0' }
+wit-bindgen = { path = 'crates/guest-rust', version = '0.14.0', default-features = false }
 
 [[bin]]
 name = "wit-bindgen"

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-c"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-core"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/csharp/Cargo.toml
+++ b/crates/csharp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-csharp"
 authors = ["Timmy Silesmo <silesmo@nor2.io>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/go/Cargo.toml
+++ b/crates/go/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-go"
 authors = ["Mossaka <duibao55328@gmail.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ Used when compiling Rust programs to the component model.
 """
 
 [dependencies]
-wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.13.2" }
+wit-bindgen-rust-macro = { path = "../rust-macro", optional = true, version = "0.14.0" }
 bitflags = { workspace = true }
 
 [features]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-markdown"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.3"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/teavm-java/Cargo.toml
+++ b/crates/teavm-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-teavm-java"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
I yanked the most recent 0.13.x track release because it started requiring semicolons and that's a breaking change for existing projects not using semicolons still on 0.13.x.