### PR TITLE
Require semicolons in WIT files on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,6 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Install wasm32-wasi target
       run: rustup target add wasm32-wasi
-    - name: Require semicolons
-      run: echo WIT_REQUIRE_SEMICOLONS=0 >> $GITHUB_ENV
 
     - run: |
         curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz -L | tar xzvf -

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -359,7 +359,7 @@ mod with {
             }
 
             interface bar {
-                use foo.{msg}
+                use foo.{msg};
 
                 bar: func(m: msg);
             }

--- a/tests/runtime/resource_aggregates/world.wit
+++ b/tests/runtime/resource_aggregates/world.wit
@@ -1,8 +1,8 @@
-package test:resource-aggregates
+package test:resource-aggregates;
 
 interface test {
   resource thing {
-    constructor(v: u32)
+    constructor(v: u32);
   }
 
   record r1 {
@@ -18,9 +18,9 @@ interface test {
     thing2: thing,
   }
 
-  type t1 = tuple<thing, r1>
+  type t1 = tuple<thing, r1>;
 
-  type t2 = tuple<borrow<thing>>
+  type t2 = tuple<borrow<thing>>;
 
   variant v1 {
     thing(thing),
@@ -30,9 +30,9 @@ interface test {
     thing(borrow<thing>),
   }
 
-  type l1 = list<thing>
+  type l1 = list<thing>;
 
-  type l2 = list<borrow<thing>>
+  type l2 = list<borrow<thing>>;
 
   foo: func(
     r1: r1,
@@ -48,10 +48,10 @@ interface test {
     o2: option<borrow<thing>>,
     result1: result<thing>,
     result2: result<borrow<thing>>,
-  ) -> u32
+  ) -> u32;
 }
 
 world resource-aggregates {
-  import test
-  export test
+  import test;
+  export test;
 }

--- a/tests/runtime/resource_alias/world.wit
+++ b/tests/runtime/resource_alias/world.wit
@@ -1,24 +1,24 @@
-package test:resource-alias
+package test:resource-alias;
 
 interface e1 {
   resource x {
-    constructor(v: u32)
+    constructor(v: u32);
   }
 
   record foo { x: x }
 
-  a: func(f: foo) -> list<x>
+  a: func(f: foo) -> list<x>;
 }
 
 interface e2 {
-  use e1.{x, foo as bar}
+  use e1.{x, foo as bar};
 
   record foo { x: x }
 
-  a: func(f: foo, g: bar) -> list<x>
+  a: func(f: foo, g: bar) -> list<x>;
 }
 
 world resource-alias {
-  export e1
-  export e2
+  export e1;
+  export e2;
 }

--- a/tests/runtime/resource_alias_redux/world.wit
+++ b/tests/runtime/resource_alias_redux/world.wit
@@ -1,31 +1,31 @@
-package test:resource-alias-redux
+package test:resource-alias-redux;
 
 interface resource-alias1 {
   resource thing {
-    constructor(s: string)
-    get: func() -> string
+    constructor(s: string);
+    get: func() -> string;
   }
 
   record foo { thing: thing }
 
-  a: func(f: foo) -> list<thing>
+  a: func(f: foo) -> list<thing>;
 }
 
 interface resource-alias2 {
-  use resource-alias1.{thing, foo as bar}
+  use resource-alias1.{thing, foo as bar};
 
   record foo { thing: thing }
 
-  b: func(f: foo, g: bar) -> list<thing>
+  b: func(f: foo, g: bar) -> list<thing>;
 }
 
 world resource-alias-redux {
-  use resource-alias1.{thing}
+  use resource-alias1.{thing};
 
-  import resource-alias1
-  import resource-alias2
-  export resource-alias1
-  export resource-alias2
-  
-  export test: func(things: list<thing>) -> list<thing>
+  import resource-alias1;
+  import resource-alias2;
+  export resource-alias1;
+  export resource-alias2;
+
+  export test: func(things: list<thing>) -> list<thing>;
 }

--- a/tests/runtime/resource_borrow_export/world.wit
+++ b/tests/runtime/resource_borrow_export/world.wit
@@ -1,13 +1,13 @@
-package test:resource-borrow-export
+package test:resource-borrow-export;
 
 interface test {
   resource thing {
-    constructor(v: u32)
+    constructor(v: u32);
   }
 
-  foo: func(v: borrow<thing>) -> u32
+  foo: func(v: borrow<thing>) -> u32;
 }
 
 world resource-borrow-export {
-  export test
+  export test;
 }

--- a/tests/runtime/resource_borrow_import/world.wit
+++ b/tests/runtime/resource_borrow_import/world.wit
@@ -1,15 +1,15 @@
-package test:resource-borrow-import
+package test:resource-borrow-import;
 
 interface test {
   resource thing {
-    constructor(v: u32)
+    constructor(v: u32);
   }
 
-  foo: func(v: borrow<thing>) -> u32
+  foo: func(v: borrow<thing>) -> u32;
 }
 
 world resource-borrow-import {
-  import test
+  import test;
 
-  export test: func(v: u32) -> u32
+  export test: func(v: u32) -> u32;
 }

--- a/tests/runtime/resource_borrow_in_record/world.wit
+++ b/tests/runtime/resource_borrow_in_record/world.wit
@@ -1,19 +1,19 @@
-package test:resource-borrow-in-record
+package test:resource-borrow-in-record;
 
 interface test {
   resource thing {
-    constructor(s: string)
-    get: func() -> string
+    constructor(s: string);
+    get: func() -> string;
   }
 
   record foo {
     thing: borrow<thing>
   }
 
-  test: func(a: list<foo>) -> list<thing>
+  test: func(a: list<foo>) -> list<thing>;
 }
 
 world resource-borrow-in-record {
-  import test
-  export test
+  import test;
+  export test;
 }

--- a/tests/runtime/resource_floats/world.wit
+++ b/tests/runtime/resource_floats/world.wit
@@ -1,30 +1,30 @@
-package test:resource-floats
+package test:resource-floats;
 
 interface test {
   resource float {
-    constructor(v: float64)
-    get: func() -> float64
+    constructor(v: float64);
+    get: func() -> float64;
   }
 }
 
 world resource-floats {
-  use test.{float}
+  use test.{float};
 
   export exports: interface {
     resource float {
-      constructor(v: float64)
-      get: func() -> float64
-      add: static func(a: float, b: float64) -> float
+      constructor(v: float64);
+      get: func() -> float64;
+      add: static func(a: float, b: float64) -> float;
     }
   }
 
   import imports: interface {
     resource float {
-      constructor(v: float64)
-      get: func() -> float64
-      add: static func(a: float, b: float64) -> float
+      constructor(v: float64);
+      get: func() -> float64;
+      add: static func(a: float, b: float64) -> float;
     }
   }
 
-  export add: func(a: borrow<float>, b: borrow<float>) -> own<float>
+  export add: func(a: borrow<float>, b: borrow<float>) -> own<float>;
 }

--- a/tests/runtime/resource_import_and_export/world.wit
+++ b/tests/runtime/resource_import_and_export/world.wit
@@ -1,17 +1,17 @@
-package test:resource-import-and-export
+package test:resource-import-and-export;
 
 interface test {
   resource thing {
-    constructor(v: u32)
+    constructor(v: u32);
 
-    foo: func() -> u32
-    bar: func(v: u32)
+    foo: func() -> u32;
+    bar: func(v: u32);
 
-    baz: static func(a: thing, b: thing) -> thing
+    baz: static func(a: thing, b: thing) -> thing;
   }
 }
 
 world resource-import-and-export {
-  import test
-  export test
+  import test;
+  export test;
 }

--- a/tests/runtime/resource_with_lists/world.wit
+++ b/tests/runtime/resource_with_lists/world.wit
@@ -1,15 +1,15 @@
-package test:resource-with-lists
+package test:resource-with-lists;
 
 interface test {
   resource thing {
-    constructor(l: list<u8>)
-    foo: func() -> list<u8>
-    bar: func(l: list<u8>)
-    baz: static func(l: list<u8>) -> list<u8>
+    constructor(l: list<u8>);
+    foo: func() -> list<u8>;
+    bar: func(l: list<u8>);
+    baz: static func(l: list<u8>) -> list<u8>;
  }
 }
 
 world resource-with-lists {
-  import test
-  export test
+  import test;
+  export test;
 }

--- a/tests/runtime/resources/world.wit
+++ b/tests/runtime/resources/world.wit
@@ -1,30 +1,30 @@
-package test:resources
+package test:resources;
 
 world resources {
   import imports: interface {
     resource y {
-      constructor(a: s32)
-      get-a: func() -> s32
-      set-a: func(a: s32)
-      add: static func(y: y, a: s32) -> y
+      constructor(a: s32);
+      get-a: func() -> s32;
+      set-a: func(a: s32);
+      add: static func(y: y, a: s32) -> y;
     }
   }
 
   export exports: interface {
     resource x {
-      constructor(a: s32)
-      get-a: func() -> s32
-      set-a: func(a: s32)
-      add: static func(x: x, a: s32) -> x
+      constructor(a: s32);
+      get-a: func() -> s32;
+      set-a: func(a: s32);
+      add: static func(x: x, a: s32) -> x;
     }
 
     resource z {
-      constructor(a: s32)
-      get-a: func() -> s32
+      constructor(a: s32);
+      get-a: func() -> s32;
     }
 
-    add: func(a: borrow<z>, b: borrow<z>) -> own<z>
+    add: func(a: borrow<z>, b: borrow<z>) -> own<z>;
 
-    test-imports: func() -> result<_, string>
+    test-imports: func() -> result<_, string>;
   }
 }


### PR DESCRIPTION
I believe that the `=0` here in CI configuration was a mistake and it was intended to be `=1`.