### PR TITLE
Remove handling of empty types from C

### DIFF
--- a/tests/codegen/issue573.wit
+++ b/tests/codegen/issue573.wit
@@ -75,8 +75,8 @@ interface api {
     c: option<char>,
   }
 
-  class: func(break: option<option<t5>>) -> tuple<>;
-  continue: func(abstract: option<result<_, errno>>, extends: tuple<>) -> (%implements: option<tuple<u32>>);
+  class: func(break: option<option<t5>>) -> tuple<u32>;
+  continue: func(abstract: option<result<_, errno>>, extends: tuple<u32>) -> (%implements: option<tuple<u32>>);
 }
 
 world types-example {
@@ -101,7 +101,11 @@ world types-example {
       error,
     }
 
-    record empty {}
+    // NB: this record used to be empty, but that's no longer valid, so now it's
+    // non-empty. Don't want to delete the whole test however.
+    record empty {
+        not-empty-anymore: bool,
+    }
 
     export f-f1: func(typedef: t10) -> t10;
     export f1: func(f: float32, f-list: list<tuple<char, float64>>) -> (val-p1: s64, val2: string);

--- a/tests/codegen/issue573.wit
+++ b/tests/codegen/issue573.wit
@@ -76,7 +76,7 @@ interface api {
   }
 
   class: func(break: option<option<t5>>) -> tuple<>;
-  continue: func(abstract: option<result<_, errno>>, extends: tuple<>) -> (%implements: option<tuple<>>);
+  continue: func(abstract: option<result<_, errno>>, extends: tuple<>) -> (%implements: option<tuple<u32>>);
 }
 
 world types-example {

--- a/tests/codegen/option-result.wit
+++ b/tests/codegen/option-result.wit
@@ -1,78 +1,82 @@
 package foo:foo;
 
 interface option-result {
-	record empty {}
-	record o-one {
-		a: option<bool>,
-	}
+  // NB: this record used to be empty, but that's no longer valid, so now it's
+  // non-empty. Don't want to delete the whole test however.
+  record empty {
+    not-empty-anymore: bool,
+  }
+  record o-one {
+    a: option<bool>,
+  }
 
-	record o-nested {
-		a: option<option<o-one>>,
-	}
+  record o-nested {
+    a: option<option<o-one>>,
+  }
 
-	type o1 = option<o-one>;
-	type o2 = option<empty>;
-	type o3 = option<o-nested>;
-	type o4 = option<option<o-nested>>;
+  type o1 = option<o-one>;
+  type o2 = option<empty>;
+  type o3 = option<o-nested>;
+  type o4 = option<option<o-nested>>;
 
-	type r1 = result;
-	type r2 = result<_, empty>;
-	type r3 = result<empty>;
-	type r4 = result<empty, empty>;
-	type r5 = result<option<o-one>, o1>;
-	type r6 = result<option<option<o-one>>, o2>;
-	type r7 = result<option<option<o-one>>, o4>;
-
-
-	type o5 = option<result>;
-	type o6 = option<result<option<result>>>;
+  type r1 = result;
+  type r2 = result<_, empty>;
+  type r3 = result<empty>;
+  type r4 = result<empty, empty>;
+  type r5 = result<option<o-one>, o1>;
+  type r6 = result<option<option<o-one>>, o2>;
+  type r7 = result<option<option<o-one>>, o4>;
 
 
-	 o1-arg: func(x: o1);
-	 o1-result: func() -> o1;
+  type o5 = option<result>;
+  type o6 = option<result<option<result>>>;
 
-	 o2-arg: func(x: o2);
-	 o2-result: func() -> o2;
 
-	 o3-arg: func(x: o3);
-	 o3-result: func() -> o3;
+   o1-arg: func(x: o1);
+   o1-result: func() -> o1;
 
-	 o4-arg: func(x: o4);
-	 o4-result: func() -> o4;
+   o2-arg: func(x: o2);
+   o2-result: func() -> o2;
 
-	 o5-arg: func(x: o5);
-	 o5-result: func() -> o5;
+   o3-arg: func(x: o3);
+   o3-result: func() -> o3;
 
-	 o6-arg: func(x: o6);
-	 o6-result: func() -> o6;
+   o4-arg: func(x: o4);
+   o4-result: func() -> o4;
 
-	 r1-arg: func(x: r1);
-	 r1-result: func() -> r1;
+   o5-arg: func(x: o5);
+   o5-result: func() -> o5;
 
-	 r2-arg: func(x: r2);
-	 r2-result: func() -> r2;
+   o6-arg: func(x: o6);
+   o6-result: func() -> o6;
 
-	 r3-arg: func(x: r3);
-	 r3-result: func() -> r3;
+   r1-arg: func(x: r1);
+   r1-result: func() -> r1;
 
-	 r4-arg: func(x: r4);
-	 r4-result: func() -> r4;
+   r2-arg: func(x: r2);
+   r2-result: func() -> r2;
 
-	 r5-arg: func(x: r5);
-	 r5-result: func() -> r5;
+   r3-arg: func(x: r3);
+   r3-result: func() -> r3;
 
-	 r6-arg: func(x: r6);
-	 r6-result: func() -> r6;
+   r4-arg: func(x: r4);
+   r4-result: func() -> r4;
 
-	 r7-arg: func(x: r7);
-	 r7-result: func() -> r7;
+   r5-arg: func(x: r5);
+   r5-result: func() -> r5;
 
-	 multi: func(x: r7, y: r7) -> (a: r7, b:r7, c: r7);
-	 multi-option: func(x: r7, y: r7) -> option<tuple<r7, r7>>;
+   r6-arg: func(x: r6);
+   r6-result: func() -> r6;
+
+   r7-arg: func(x: r7);
+   r7-result: func() -> r7;
+
+   multi: func(x: r7, y: r7) -> (a: r7, b:r7, c: r7);
+   multi-option: func(x: r7, y: r7) -> option<tuple<r7, r7>>;
 }
 
 world my-world {
-	import option-result;
-	export option-result;
+  import option-result;
+  export option-result;
 }
 

--- a/tests/codegen/records.wit
+++ b/tests/codegen/records.wit
@@ -4,7 +4,11 @@ interface records {
   tuple-arg: func(x: tuple<char, u32>);
   tuple-result: func() -> tuple<char, u32>;
 
-  record empty {}
+  // NB: this record used to be empty, but that's no longer valid, so now it's
+  // non-empty. Don't want to delete the whole test however.
+  record empty {
+    not-empty-anymore: bool,
+  }
 
   empty-arg: func(x: empty);
   empty-result: func() -> empty;

--- a/tests/codegen/result-empty.wit
+++ b/tests/codegen/result-empty.wit
@@ -6,7 +6,10 @@ interface my-interface {
         that
     }
 
+    // NB: this record used to be empty, but that's no longer valid, so now it's
+    // non-empty. Don't want to delete the whole test however.
     record empty {
+        not-empty-anymore: bool,
     }
 
     stuff-or-stuff: func() -> result<stuff, stuff>;

--- a/tests/codegen/same-names5.wit
+++ b/tests/codegen/same-names5.wit
@@ -2,6 +2,7 @@ package name5:name5;
 
 world name5 {
   record name5 {
+    r: bool,
   }
 
   export x: func() -> name5;

--- a/tests/codegen/variants.wit
+++ b/tests/codegen/variants.wit
@@ -8,7 +8,11 @@ interface variants {
   e1-arg: func(x: e1);
   e1-result: func() -> e1;
 
-  record empty {}
+  // NB: this record used to be empty, but that's no longer valid, so now it's
+  // non-empty. Don't want to delete the whole test however.
+  record empty {
+    not-empty-anymore: bool,
+  }
 
   variant v1 {
       a,
@@ -27,7 +31,7 @@ interface variants {
 
   option-arg: func(
     a: option<bool>,
-    b: option<tuple<>>,
+    b: option<tuple<u32>>,
     c: option<u32>,
     d: option<e1>,
     e: option<float32>,
@@ -35,7 +39,7 @@ interface variants {
   );
   option-result: func() -> tuple<
     option<bool>,
-    option<tuple<>>,
+    option<tuple<u32>>,
     option<u32>,
     option<e1>,
     option<float32>,
@@ -92,7 +96,7 @@ interface variants {
     a: result,
     b: result<_, e1>,
     c: result<e1>,
-    d: result<tuple<>, tuple<>>,
+    d: result<tuple<u32>, tuple<u32>>,
     e: result<u32, v1>,
     f: result<string, list<u8>>,
   );
@@ -100,7 +104,7 @@ interface variants {
     result,
     result<_, e1>,
     result<e1>,
-    result<tuple<>, tuple<>>,
+    result<tuple<u32>, tuple<u32>>,
     result<u32, v1>,
     result<string, list<u8>>,
   >;


### PR DESCRIPTION
This is no longer necessary because the component model now disallows empty types. Additionally update some tests to no longer exercise the usage of empty types.