### PR TITLE
fix(c, go): pass the right direction to interface generator in `import_types`

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -231,7 +231,7 @@ impl WorldGenerator for C {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut gen = self.interface(resolve, false);
+        let mut gen = self.interface(resolve, true);
         for (name, id) in types {
             gen.define_type(name, *id);
         }

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -228,7 +228,7 @@ impl WorldGenerator for TinyGo {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut gen = self.interface(resolve, &None, false);
+        let mut gen = self.interface(resolve, &None, true);
         for (name, id) in types {
             gen.define_type(name, *id);
         }

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -95,3 +95,7 @@ test = false
 [[bin]]
 name = "resource_aggregates"
 test = false
+
+[[bin]]
+name = "resource_borrow_simple"
+test = false

--- a/crates/test-rust-wasm/src/bin/resource_borrow_simple.rs
+++ b/crates/test-rust-wasm/src/bin/resource_borrow_simple.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/resource_borrow_simple/wasm.rs");
+
+fn main() {}

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -25,6 +25,7 @@ mod resource_alias_redux;
 mod resource_borrow_export;
 mod resource_borrow_import;
 mod resource_borrow_in_record;
+mod resource_borrow_simple;
 mod resource_floats;
 mod resource_import_and_export;
 mod resource_with_lists;

--- a/tests/runtime/resource_borrow_simple.rs
+++ b/tests/runtime/resource_borrow_simple.rs
@@ -1,0 +1,43 @@
+use wasmtime::Store;
+
+wasmtime::component::bindgen!(in "tests/runtime/resource_borrow_simple");
+
+#[derive(Default)]
+
+pub struct MyHostRImpl {}
+
+impl HostR for MyHostRImpl {
+    fn drop(
+        &mut self,
+        _: wasmtime::component::Resource<R>,
+    ) -> std::result::Result<(), anyhow::Error> {
+        Ok(())
+    }
+}
+
+impl ResourceBorrowSimpleImports for MyHostRImpl {
+    fn test(&mut self, _: wasmtime::component::Resource<R>) -> wasmtime::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn run() -> anyhow::Result<()> {
+    crate::run_test(
+        "resource_borrow_import",
+        |linker| ResourceBorrowSimple::add_to_linker(linker, |x| &mut x.0),
+        |store, component: &wasmtime::component::Component, linker| {
+            let (u, e) = ResourceBorrowSimple::instantiate(store, component, linker)?;
+            Ok((u, e))
+        },
+        run_test,
+    )
+}
+
+fn run_test(
+    instance: ResourceBorrowSimple,
+    store: &mut Store<crate::Wasi<MyHostRImpl>>,
+) -> anyhow::Result<()> {
+    instance.call_test_imports(&mut *store)?;
+    Ok(())
+}

--- a/tests/runtime/resource_borrow_simple.rs
+++ b/tests/runtime/resource_borrow_simple.rs
@@ -24,7 +24,7 @@ impl ResourceBorrowSimpleImports for MyHostRImpl {
 #[test]
 fn run() -> anyhow::Result<()> {
     crate::run_test(
-        "resource_borrow_import",
+        "resource_borrow_simple",
         |linker| ResourceBorrowSimple::add_to_linker(linker, |x| &mut x.0),
         |store, component: &wasmtime::component::Component, linker| {
             let (u, e) = ResourceBorrowSimple::instantiate(store, component, linker)?;

--- a/tests/runtime/resource_borrow_simple/wasm.c
+++ b/tests/runtime/resource_borrow_simple/wasm.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <resource_borrow_simple.h>
+
+bool resource_borrow_simple_test_imports(void) {
+    resource_borrow_simple_borrow_r_t r = resource_borrow_simple_borrow_r_t {
+        .__handle = 0,
+    }
+    resource_borrow_simple_test(r);
+    resource_borrow_simple_r_drop_borrow(r);
+}

--- a/tests/runtime/resource_borrow_simple/wasm.c
+++ b/tests/runtime/resource_borrow_simple/wasm.c
@@ -1,10 +1,10 @@
 #include <assert.h>
 #include <resource_borrow_simple.h>
 
-bool resource_borrow_simple_test_imports(void) {
-    resource_borrow_simple_borrow_r_t r = resource_borrow_simple_borrow_r_t {
+void resource_borrow_simple_test_imports(void) {
+    resource_borrow_simple_borrow_r_t r = {
         .__handle = 0,
-    }
+    };
     resource_borrow_simple_test(r);
     resource_borrow_simple_r_drop_borrow(r);
 }

--- a/tests/runtime/resource_borrow_simple/wasm.rs
+++ b/tests/runtime/resource_borrow_simple/wasm.rs
@@ -1,0 +1,17 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/resource_borrow_simple",
+    exports: {
+        world: Test,
+    }
+});
+
+pub struct Test {}
+
+impl Guest for Test {
+    fn test_imports() {
+        unsafe {
+            let r = R { handle: wit_bindgen::rt::Resource::from_handle(0) };
+            test(&r);
+        }
+    }
+}

--- a/tests/runtime/resource_borrow_simple/world.wit
+++ b/tests/runtime/resource_borrow_simple/world.wit
@@ -1,0 +1,7 @@
+package test:resource-borrow-simple;
+
+world resource-borrow-simple {
+  resource r;
+  import test: func(r: borrow<r>);
+  export test-imports: func();
+}


### PR DESCRIPTION

Closes #749 