### PR TITLE
Refactor generation of types in C

### DIFF
--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -4,14 +4,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 macro_rules! codegen_test {
-    // TODO: support importing and exporting the same interface containing one
-    // or more resources, then remove the following lines:
-    (import_and_export_resource $name:tt $test:tt) => {};
-    (import_and_export_resource_alias $name:tt $test:tt) => {};
-    (resource_alias $name:tt $test:tt) => {};
-    (resource_local_alias $name:tt $test:tt) => {};
-    (resources_with_lists $name:tt $test:tt) => {};
-    (resources_in_aggregates $name:tt $test:tt) => {};
     ($id:ident $name:tt $test:tt) => {
         #[test]
         fn $id() {

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, mem};
 use anyhow::Result;
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
 
-use wit_bindgen_c::{flags_repr, int_repr, is_arg_by_pointer, owns_anything};
+use wit_bindgen_c::{flags_repr, int_repr, is_arg_by_pointer};
 use wit_bindgen_core::wit_parser::{InterfaceId, Resolve, TypeOwner, WorldId};
 use wit_bindgen_core::{
     uwriteln,
@@ -760,7 +760,7 @@ impl InterfaceGenerator<'_> {
 
     fn get_c_ty_name(&self, ty: &Type) -> String {
         let mut name = String::new();
-        wit_bindgen_c::push_ty_name(self.resolve, ty, &self.gen.interface_names, &mut name);
+        wit_bindgen_c::push_ty_name(self.resolve, ty, &mut name);
         name
     }
 
@@ -1253,7 +1253,8 @@ impl InterfaceGenerator<'_> {
 
             // free all the parameters
             for (name, ty) in func.params.iter() {
-                if owns_anything(resolve, ty, &|_, _| todo!("support resources")) {
+                // TODO: should test if owns anything
+                if false {
                     let free = self.get_free_c_arg(ty, &avoid_keyword(&name.to_snake_case()));
                     src.push_str(&free);
                 }
@@ -1595,11 +1596,9 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
         // If this variable is in inner node of the recursive call, no need to be freed.
         //    This is because the root node's call to free will recursively free the whole tree.
         // Otherwise, free this variable.
-        if !in_export
-            && owns_anything(self.interface.resolve, ty, &|_, _| {
-                todo!("support resources")
-            })
-        {
+        //
+        // TODO: should test if free is necessary
+        if !in_export && false {
             self.lower_src
                 .push_str(&self.interface.get_free_c_arg(ty, &format!("&{lower_name}")));
         }

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -90,28 +90,28 @@ void flavorful_test_imports() {
   }
 
   {
-    flavorful_list_bool_t a;
+    test_flavorful_test_list_bool_t a;
     bool a_val[] = {true, false};
     a.ptr = a_val;
     a.len = 2;
 
-    flavorful_list_result_void_void_t b;
-    flavorful_result_void_void_t b_val[2];
+    test_flavorful_test_list_result_void_void_t b;
+    test_flavorful_test_result_void_void_t b_val[2];
     b_val[0].is_err = false;
     b_val[1].is_err = true;
     b.ptr = b_val;
     b.len = 2;
 
-    flavorful_list_test_flavorful_test_my_errno_t c;
+    test_flavorful_test_list_my_errno_t c;
     test_flavorful_test_my_errno_t c_val[2];
     c_val[0] = TEST_FLAVORFUL_TEST_MY_ERRNO_SUCCESS;
     c_val[1] = TEST_FLAVORFUL_TEST_MY_ERRNO_A;
     c.ptr = c_val;
     c.len = 2;
 
-    flavorful_list_bool_t d;
-    flavorful_list_result_void_void_t e;
-    flavorful_list_test_flavorful_test_my_errno_t f;
+    test_flavorful_test_list_bool_t d;
+    test_flavorful_test_list_result_void_void_t e;
+    test_flavorful_test_list_my_errno_t f;
     test_flavorful_test_list_of_variants(&a, &b, &c, &d, &e, &f);
 
     assert(d.len == 2);
@@ -126,9 +126,9 @@ void flavorful_test_imports() {
     assert(f.ptr[0] == TEST_FLAVORFUL_TEST_MY_ERRNO_A);
     assert(f.ptr[1] == TEST_FLAVORFUL_TEST_MY_ERRNO_B);
 
-    flavorful_list_bool_free(&d);
-    flavorful_list_result_void_void_free(&e);
-    flavorful_list_test_flavorful_test_my_errno_free(&f);
+    test_flavorful_test_list_bool_free(&d);
+    test_flavorful_test_list_result_void_void_free(&e);
+    test_flavorful_test_list_my_errno_free(&f);
   }
 }
 
@@ -199,11 +199,11 @@ void exports_test_flavorful_test_list_typedefs(test_flavorful_test_list_typedef_
 }
 
 void exports_test_flavorful_test_list_of_variants(
-    flavorful_list_bool_t *a,
-    flavorful_list_result_void_void_t *b,
-    flavorful_list_test_flavorful_test_my_errno_t *c,
-    flavorful_list_bool_t *ret0,
-    flavorful_list_result_void_void_t *ret1,
-    flavorful_list_test_flavorful_test_my_errno_t *ret2) {
+    test_flavorful_test_list_bool_t *a,
+    test_flavorful_test_list_result_void_void_t *b,
+    test_flavorful_test_list_my_errno_t *c,
+    test_flavorful_test_list_bool_t *ret0,
+    test_flavorful_test_list_result_void_void_t *ret1,
+    test_flavorful_test_list_my_errno_t *ret2) {
   assert(0); // unimplemented
 }

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -14,7 +14,7 @@ uint32_t lists_allocated_bytes(void) {
 void lists_test_imports() {
   {
     uint8_t list[] = {};
-    lists_list_u8_t a;
+    test_lists_test_list_u8_t a;
     a.ptr = list;
     a.len = 0;
     test_lists_test_empty_list_param(&a);
@@ -27,7 +27,7 @@ void lists_test_imports() {
   }
 
   {
-    lists_list_u8_t a;
+    test_lists_test_list_u8_t a;
     test_lists_test_empty_list_result(&a);
     assert(a.len == 0);
   }
@@ -40,7 +40,7 @@ void lists_test_imports() {
 
   {
     uint8_t list[] = {1, 2, 3, 4};
-    lists_list_u8_t a;
+    test_lists_test_list_u8_t a;
     a.ptr = list;
     a.len = 4;
     test_lists_test_list_param(&a);
@@ -57,7 +57,7 @@ void lists_test_imports() {
     lists_string_set(&list[0], "foo");
     lists_string_set(&list[1], "bar");
     lists_string_set(&list[2], "baz");
-    lists_list_string_t a;
+    test_lists_test_list_string_t a;
     a.ptr = list;
     a.len = 3;
     test_lists_test_list_param3(&a);
@@ -69,7 +69,7 @@ void lists_test_imports() {
     lists_string_set(&list1[0], "foo");
     lists_string_set(&list1[1], "bar");
     lists_string_set(&list2[0], "baz");
-    lists_list_list_string_t a;
+    test_lists_test_list_list_string_t a;
     a.ptr[0].len = 2;
     a.ptr[0].ptr = list1;
     a.ptr[1].len = 1;
@@ -79,11 +79,11 @@ void lists_test_imports() {
   }
 
   {
-    lists_list_u8_t a;
+    test_lists_test_list_u8_t a;
     test_lists_test_list_result(&a);
     assert(a.len == 5);
     assert(memcmp(a.ptr, "\x01\x02\x03\x04\x05", 5) == 0);
-    lists_list_u8_free(&a);
+    test_lists_test_list_u8_free(&a);
   }
 
   {
@@ -95,38 +95,38 @@ void lists_test_imports() {
   }
 
   {
-    lists_list_string_t a;
+    test_lists_test_list_string_t a;
     test_lists_test_list_result3(&a);
     assert(a.len == 2);
     assert(a.ptr[0].len == 6);
     assert(a.ptr[1].len == 6);
     assert(memcmp(a.ptr[0].ptr, "hello,", 6) == 0);
     assert(memcmp(a.ptr[1].ptr, "world!", 6) == 0);
-    lists_list_string_free(&a);
+    test_lists_test_list_string_free(&a);
   }
 
   {
-    lists_list_u8_t a, b;
+    test_lists_test_list_u8_t a, b;
     a.len = 0;
     a.ptr = (unsigned char*) "";
     test_lists_test_list_roundtrip(&a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_list_u8_free(&b);
+    test_lists_test_list_u8_free(&b);
 
     a.len = 1;
     a.ptr = (unsigned char*) "x";
     test_lists_test_list_roundtrip(&a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_list_u8_free(&b);
+    test_lists_test_list_u8_free(&b);
 
     a.len = 5;
     a.ptr = (unsigned char*) "hello";
     test_lists_test_list_roundtrip(&a, &b);
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
-    lists_list_u8_free(&b);
+    test_lists_test_list_u8_free(&b);
   }
 
   {
@@ -158,77 +158,77 @@ void lists_test_imports() {
   {
     uint8_t u8[2] = {0, UCHAR_MAX};
     int8_t s8[2] = {SCHAR_MIN, SCHAR_MAX};
-    lists_list_u8_t list_u8 = { u8, 2 };
-    lists_list_s8_t list_s8 = { s8, 2 };
-    lists_list_u8_t list_u8_out;
-    lists_list_s8_t list_s8_out;
+    test_lists_test_list_u8_t list_u8 = { u8, 2 };
+    test_lists_test_list_s8_t list_s8 = { s8, 2 };
+    test_lists_test_list_u8_t list_u8_out;
+    test_lists_test_list_s8_t list_s8_out;
     test_lists_test_list_minmax8(&list_u8, &list_s8, &list_u8_out, &list_s8_out);
     assert(list_u8_out.len == 2 && list_u8_out.ptr[0] == 0 && list_u8_out.ptr[1] == UCHAR_MAX);
     assert(list_s8_out.len == 2 && list_s8_out.ptr[0] == SCHAR_MIN && list_s8_out.ptr[1] == SCHAR_MAX);
-    lists_list_u8_free(&list_u8_out);
-    lists_list_s8_free(&list_s8_out);
+    test_lists_test_list_u8_free(&list_u8_out);
+    test_lists_test_list_s8_free(&list_s8_out);
   }
 
   {
     uint16_t u16[2] = {0, USHRT_MAX};
     int16_t s16[2] = {SHRT_MIN, SHRT_MAX};
-    lists_list_u16_t list_u16 = { u16, 2 };
-    lists_list_s16_t list_s16 = { s16, 2 };
-    lists_list_u16_t list_u16_out;
-    lists_list_s16_t list_s16_out;
+    test_lists_test_list_u16_t list_u16 = { u16, 2 };
+    test_lists_test_list_s16_t list_s16 = { s16, 2 };
+    test_lists_test_list_u16_t list_u16_out;
+    test_lists_test_list_s16_t list_s16_out;
     test_lists_test_list_minmax16(&list_u16, &list_s16, &list_u16_out, &list_s16_out);
     assert(list_u16_out.len == 2 && list_u16_out.ptr[0] == 0 && list_u16_out.ptr[1] == USHRT_MAX);
     assert(list_s16_out.len == 2 && list_s16_out.ptr[0] == SHRT_MIN && list_s16_out.ptr[1] == SHRT_MAX);
-    lists_list_u16_free(&list_u16_out);
-    lists_list_s16_free(&list_s16_out);
+    test_lists_test_list_u16_free(&list_u16_out);
+    test_lists_test_list_s16_free(&list_s16_out);
   }
 
   {
     uint32_t u32[2] = {0, UINT_MAX};
     int32_t s32[2] = {INT_MIN, INT_MAX};
-    lists_list_u32_t list_u32 = { u32, 2 };
-    lists_list_s32_t list_s32 = { s32, 2 };
-    lists_list_u32_t list_u32_out;
-    lists_list_s32_t list_s32_out;
+    test_lists_test_list_u32_t list_u32 = { u32, 2 };
+    test_lists_test_list_s32_t list_s32 = { s32, 2 };
+    test_lists_test_list_u32_t list_u32_out;
+    test_lists_test_list_s32_t list_s32_out;
     test_lists_test_list_minmax32(&list_u32, &list_s32, &list_u32_out, &list_s32_out);
     assert(list_u32_out.len == 2 && list_u32_out.ptr[0] == 0 && list_u32_out.ptr[1] == UINT_MAX);
     assert(list_s32_out.len == 2 && list_s32_out.ptr[0] == INT_MIN && list_s32_out.ptr[1] == INT_MAX);
-    lists_list_u32_free(&list_u32_out);
-    lists_list_s32_free(&list_s32_out);
+    test_lists_test_list_u32_free(&list_u32_out);
+    test_lists_test_list_s32_free(&list_s32_out);
   }
 
   {
     uint64_t u64[2] = {0, ULLONG_MAX};
     int64_t s64[2] = {LLONG_MIN, LLONG_MAX};
-    lists_list_u64_t list_u64 = { u64, 2 };
-    lists_list_s64_t list_s64 = { s64, 2 };
-    lists_list_u64_t list_u64_out;
-    lists_list_s64_t list_s64_out;
+    test_lists_test_list_u64_t list_u64 = { u64, 2 };
+    test_lists_test_list_s64_t list_s64 = { s64, 2 };
+    test_lists_test_list_u64_t list_u64_out;
+    test_lists_test_list_s64_t list_s64_out;
     test_lists_test_list_minmax64(&list_u64, &list_s64, &list_u64_out, &list_s64_out);
     assert(list_u64_out.len == 2 && list_u64_out.ptr[0] == 0 && list_u64_out.ptr[1] == ULLONG_MAX);
     assert(list_s64_out.len == 2 && list_s64_out.ptr[0] == LLONG_MIN && list_s64_out.ptr[1] == LLONG_MAX);
-    lists_list_u64_free(&list_u64_out);
-    lists_list_s64_free(&list_s64_out);
+    test_lists_test_list_u64_free(&list_u64_out);
+    test_lists_test_list_s64_free(&list_s64_out);
   }
 
   {
     float f32[4] = {-FLT_MAX, FLT_MAX, -INFINITY, INFINITY};
     double f64[4] = {-DBL_MAX, DBL_MAX, -INFINITY, INFINITY};
-    lists_list_float32_t list_float32 = { f32, 4 };
-    lists_list_float64_t list_float64 = { f64, 4 };
-    lists_list_float32_t list_float32_out;
-    lists_list_float64_t list_float64_out;
+    test_lists_test_list_float32_t list_float32 = { f32, 4 };
+    test_lists_test_list_float64_t list_float64 = { f64, 4 };
+    test_lists_test_list_float32_t list_float32_out;
+    test_lists_test_list_float64_t list_float64_out;
     test_lists_test_list_minmax_float(&list_float32, &list_float64, &list_float32_out, &list_float64_out);
     assert(list_float32_out.len == 4 && list_float32_out.ptr[0] == -FLT_MAX && list_float32_out.ptr[1] == FLT_MAX);
     assert(list_float32_out.ptr[2] == -INFINITY && list_float32_out.ptr[3] == INFINITY);
     assert(list_float64_out.len == 4 && list_float64_out.ptr[0] == -DBL_MAX && list_float64_out.ptr[1] == DBL_MAX);
     assert(list_float64_out.ptr[2] == -INFINITY && list_float64_out.ptr[3] == INFINITY);
-    lists_list_float32_free(&list_float32_out);
-    lists_list_float64_free(&list_float64_out);
+    test_lists_test_list_float32_free(&list_float32_out);
+    test_lists_test_list_float64_free(&list_float64_out);
   }
 }
 
-void exports_test_lists_test_empty_list_param(lists_list_u8_t *a) {
+void exports_test_lists_test_empty_list_param(test_lists_test_list_u8_t *a) {
   assert(a->len == 0);
 }
 
@@ -236,7 +236,7 @@ void exports_test_lists_test_empty_string_param(lists_string_t *a) {
   assert(a->len == 0);
 }
 
-void exports_test_lists_test_empty_list_result(lists_list_u8_t *ret0) {
+void exports_test_lists_test_empty_list_result(test_lists_test_list_u8_t *ret0) {
   ret0->ptr = 0;
   ret0->len = 0;
 }
@@ -246,13 +246,13 @@ void exports_test_lists_test_empty_string_result(lists_string_t *ret0) {
   ret0->len = 0;
 }
 
-void exports_test_lists_test_list_param(lists_list_u8_t *a) {
+void exports_test_lists_test_list_param(test_lists_test_list_u8_t *a) {
   assert(a->len == 4);
   assert(a->ptr[0] == 1);
   assert(a->ptr[1] == 2);
   assert(a->ptr[2] == 3);
   assert(a->ptr[3] == 4);
-  lists_list_u8_free(a);
+  test_lists_test_list_u8_free(a);
 }
 
 void exports_test_lists_test_list_param2(lists_string_t *a) {
@@ -263,7 +263,7 @@ void exports_test_lists_test_list_param2(lists_string_t *a) {
   lists_string_free(a);
 }
 
-void exports_test_lists_test_list_param3(lists_list_string_t *a) {
+void exports_test_lists_test_list_param3(test_lists_test_list_string_t *a) {
   assert(a->len == 3);
   assert(a->ptr[0].len == 3);
   assert(a->ptr[0].ptr[0] == 'f');
@@ -280,10 +280,10 @@ void exports_test_lists_test_list_param3(lists_list_string_t *a) {
   assert(a->ptr[2].ptr[1] == 'a');
   assert(a->ptr[2].ptr[2] == 'z');
 
-  lists_list_string_free(a);
+  test_lists_test_list_string_free(a);
 }
 
-void exports_test_lists_test_list_param4(lists_list_list_string_t *a) {
+void exports_test_lists_test_list_param4(test_lists_test_list_list_string_t *a) {
   assert(a->len == 2);
   assert(a->ptr[0].len == 2);
   assert(a->ptr[1].len == 1);
@@ -303,10 +303,10 @@ void exports_test_lists_test_list_param4(lists_list_list_string_t *a) {
   assert(a->ptr[1].ptr[0].ptr[1] == 'a');
   assert(a->ptr[1].ptr[0].ptr[2] == 'z');
 
-  lists_list_list_string_free(a);
+  test_lists_test_list_list_string_free(a);
 }
 
-void exports_test_lists_test_list_result(lists_list_u8_t *ret0) {
+void exports_test_lists_test_list_result(test_lists_test_list_u8_t *ret0) {
   ret0->ptr = malloc(5);
   ret0->len = 5;
   ret0->ptr[0] = 1;
@@ -320,7 +320,7 @@ void exports_test_lists_test_list_result2(lists_string_t *ret0) {
   lists_string_dup(ret0, "hello!");
 }
 
-void exports_test_lists_test_list_result3(lists_list_string_t *ret0) {
+void exports_test_lists_test_list_result3(test_lists_test_list_string_t *ret0) {
   ret0->len = 2;
   ret0->ptr = malloc(2 * sizeof(lists_string_t));
 
@@ -328,7 +328,7 @@ void exports_test_lists_test_list_result3(lists_list_string_t *ret0) {
   lists_string_dup(&ret0->ptr[1], "world!");
 }
 
-void exports_test_lists_test_list_roundtrip(lists_list_u8_t *a, lists_list_u8_t *ret0) {
+void exports_test_lists_test_list_roundtrip(test_lists_test_list_u8_t *a, test_lists_test_list_u8_t *ret0) {
   *ret0 = *a;
 }
 
@@ -336,22 +336,22 @@ void exports_test_lists_test_string_roundtrip(lists_string_t *a, lists_string_t 
   *ret0 = *a;
 }
 
-void exports_test_lists_test_list_minmax8(lists_list_u8_t *a, lists_list_s8_t *b, lists_list_u8_t *ret0, lists_list_s8_t *ret1) {
+void exports_test_lists_test_list_minmax8(test_lists_test_list_u8_t *a, test_lists_test_list_s8_t *b, test_lists_test_list_u8_t *ret0, test_lists_test_list_s8_t *ret1) {
   assert(0); // unimplemented
 }
 
-void exports_test_lists_test_list_minmax16(lists_list_u16_t *a, lists_list_s16_t *b, lists_list_u16_t *ret0, lists_list_s16_t *ret1) {
+void exports_test_lists_test_list_minmax16(test_lists_test_list_u16_t *a, test_lists_test_list_s16_t *b, test_lists_test_list_u16_t *ret0, test_lists_test_list_s16_t *ret1) {
   assert(0); // unimplemented
 }
 
-void exports_test_lists_test_list_minmax32(lists_list_u32_t *a, lists_list_s32_t *b, lists_list_u32_t *ret0, lists_list_s32_t *ret1) {
+void exports_test_lists_test_list_minmax32(test_lists_test_list_u32_t *a, test_lists_test_list_s32_t *b, test_lists_test_list_u32_t *ret0, test_lists_test_list_s32_t *ret1) {
   assert(0); // unimplemented
 }
 
-void exports_test_lists_test_list_minmax64(lists_list_u64_t *a, lists_list_s64_t *b, lists_list_u64_t *ret0, lists_list_s64_t *ret1) {
+void exports_test_lists_test_list_minmax64(test_lists_test_list_u64_t *a, test_lists_test_list_s64_t *b, test_lists_test_list_u64_t *ret0, test_lists_test_list_s64_t *ret1) {
   assert(0); // unimplemented
 }
 
-void exports_test_lists_test_list_minmax_float(lists_list_float32_t *a, lists_list_float64_t *b, lists_list_float32_t *ret0, lists_list_float64_t *ret1) {
+void exports_test_lists_test_list_minmax_float(test_lists_test_list_float32_t *a, test_lists_test_list_float64_t *b, test_lists_test_list_float32_t *ret0, test_lists_test_list_float64_t *ret1) {
   assert(0); // unimplemented
 }

--- a/tests/runtime/records/wasm.c
+++ b/tests/runtime/records/wasm.c
@@ -10,8 +10,8 @@ void records_test_imports() {
     assert(b == 5);
   }
 
-  records_tuple2_u8_u32_t input;
-  records_tuple2_u32_u8_t output;
+  test_records_test_tuple2_u8_u32_t input;
+  test_records_test_tuple2_u32_u8_t output;
   input.f0 = 1;
   input.f1 = 2;
   test_records_test_swap_tuple(&input, &output);
@@ -57,7 +57,7 @@ void records_test_imports() {
     assert(b.b == (TEST_RECORDS_TEST_F1_A | TEST_RECORDS_TEST_F1_B));
   }
 
-  records_tuple1_u8_t t1, t2;
+  test_records_test_tuple1_u8_t t1, t2;
   t1.f0 = 1;
   test_records_test_tuple1(&t1, &t2);
   assert(t2.f0 == 1);
@@ -68,7 +68,7 @@ void exports_test_records_test_multiple_results(uint8_t *ret0, uint16_t *ret1) {
   *ret1 = 200;
 }
 
-void exports_test_records_test_swap_tuple(records_tuple2_u8_u32_t *a, records_tuple2_u32_u8_t *b) {
+void exports_test_records_test_swap_tuple(test_records_test_tuple2_u8_u32_t *a, test_records_test_tuple2_u32_u8_t *b) {
   b->f0 = a->f1;
   b->f1 = a->f0;
 }
@@ -100,6 +100,6 @@ void exports_test_records_test_roundtrip_record1(test_records_test_r1_t *a, test
   *ret0 = *a;
 }
 
-void exports_test_records_test_tuple1(records_tuple1_u8_t *a, records_tuple1_u8_t *b) {
+void exports_test_records_test_tuple1(test_records_test_tuple1_u8_t *a, test_records_test_tuple1_u8_t *b) {
   b->f0 = a->f0;
 }

--- a/tests/runtime/resources/wasm.c
+++ b/tests/runtime/resources/wasm.c
@@ -11,10 +11,10 @@ struct exports_z_t {
     int32_t a;
 };
 
-resources_own_x_t exports_constructor_x(int32_t a) {
+exports_own_x_t exports_constructor_x(int32_t a) {
     exports_x_t* x_instance = (exports_x_t*)malloc(sizeof(exports_x_t));
     x_instance->a = a;
-    resources_own_x_t x_own = exports_x_new(x_instance);
+    exports_own_x_t x_own = exports_x_new(x_instance);
     return x_own;
 }
 
@@ -26,16 +26,16 @@ void exports_method_x_set_a(exports_x_t* self, int32_t a) {
     self->a = a;
 }
 
-resources_own_x_t exports_static_x_add(resources_own_x_t x, int32_t a) {
+exports_own_x_t exports_static_x_add(exports_own_x_t x, int32_t a) {
     exports_x_t* x_instance = exports_x_rep(x);
     x_instance->a += a;
     return x;
 }
 
-resources_own_z_t exports_constructor_z(int32_t a) {
+exports_own_z_t exports_constructor_z(int32_t a) {
     exports_z_t* z_instance = (exports_z_t*)malloc(sizeof(exports_z_t));
     z_instance->a = a;
-    resources_own_z_t z_own = exports_z_new(z_instance);
+    exports_own_z_t z_own = exports_z_new(z_instance);
     return z_own;
 }
 
@@ -43,7 +43,7 @@ int32_t exports_method_z_get_a(exports_z_t* self) {
     return self->a;
 }
 
-resources_own_z_t exports_add(exports_z_t* a, exports_z_t* b) {
+exports_own_z_t exports_add(exports_z_t* a, exports_z_t* b) {
     int32_t c = a->a + b->a;
     return exports_constructor_z(c);
 }
@@ -57,33 +57,33 @@ void exports_z_destructor(exports_z_t* z) {
 }
 
 bool exports_test_imports(resources_string_t *err) {
-    resources_own_y_t y = imports_constructor_y(10);
-    resources_borrow_y_t borrowed_y = imports_borrow_y(y);
+    imports_own_y_t y = imports_constructor_y(10);
+    imports_borrow_y_t borrowed_y = imports_borrow_y(y);
     assert(imports_method_y_get_a(borrowed_y) == 10);
     imports_method_y_set_a(borrowed_y, 20);
     assert(imports_method_y_get_a(borrowed_y) == 20);
-    
-    resources_own_y_t y2 = imports_static_y_add(y, 10);
-    resources_borrow_y_t borrowed_y2 = imports_borrow_y(y2);
+
+    imports_own_y_t y2 = imports_static_y_add(y, 10);
+    imports_borrow_y_t borrowed_y2 = imports_borrow_y(y2);
     assert(imports_method_y_get_a(borrowed_y2) == 30);
 
     imports_y_drop_own(y);
 
-    // multiple instances 
-    resources_own_y_t y1 = imports_constructor_y(1);
-    resources_own_y_t y2_m = imports_constructor_y(2);
-    resources_borrow_y_t borrowed_y1 = imports_borrow_y(y1);
-    resources_borrow_y_t borrowed_y2_m = imports_borrow_y(y2_m);
+    // multiple instances
+    imports_own_y_t y1 = imports_constructor_y(1);
+    imports_own_y_t y2_m = imports_constructor_y(2);
+    imports_borrow_y_t borrowed_y1 = imports_borrow_y(y1);
+    imports_borrow_y_t borrowed_y2_m = imports_borrow_y(y2_m);
     assert(imports_method_y_get_a(borrowed_y1) == 1);
     assert(imports_method_y_get_a(borrowed_y2_m) == 2);
     imports_method_y_set_a(borrowed_y1, 10);
     imports_method_y_set_a(borrowed_y2_m, 20);
     assert(imports_method_y_get_a(borrowed_y1) == 10);
     assert(imports_method_y_get_a(borrowed_y2_m) == 20);
-    resources_own_y_t y3 = imports_static_y_add(y1, 20);
-    resources_own_y_t y4 = imports_static_y_add(y2_m, 30);
-    resources_borrow_y_t borrowed_y3 = imports_borrow_y(y3);
-    resources_borrow_y_t borrowed_y4 = imports_borrow_y(y4);
+    imports_own_y_t y3 = imports_static_y_add(y1, 20);
+    imports_own_y_t y4 = imports_static_y_add(y2_m, 30);
+    imports_borrow_y_t borrowed_y3 = imports_borrow_y(y3);
+    imports_borrow_y_t borrowed_y4 = imports_borrow_y(y4);
     assert(imports_method_y_get_a(borrowed_y3) == 30);
     assert(imports_method_y_get_a(borrowed_y4) == 50);
     imports_y_drop_own(y1);

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -14,7 +14,7 @@ void variants_test_imports() {
 
 
   {
-    variants_result_u32_float32_t a;
+    test_variants_test_result_u32_float32_t a;
     double b_ok;
     uint8_t b_err;
 
@@ -123,8 +123,8 @@ void variants_test_imports() {
   }
 
   {
-    variants_tuple3_bool_result_void_void_test_variants_test_my_errno_t ret;
-    variants_result_void_void_t b;
+    test_variants_test_tuple3_bool_result_void_void_my_errno_t ret;
+    test_variants_test_result_void_void_t b;
     b.is_err = false;
     test_variants_test_variant_enums(true, &b, TEST_VARIANTS_TEST_MY_ERRNO_SUCCESS, &ret);
     assert(ret.f0 == false);
@@ -140,7 +140,7 @@ bool exports_test_variants_test_roundtrip_option(float *a, uint8_t *ret0) {
   return a != NULL;
 }
 
-bool exports_test_variants_test_roundtrip_result(variants_result_u32_float32_t *a, double *ok, uint8_t *err) {
+bool exports_test_variants_test_roundtrip_result(test_variants_test_result_u32_float32_t *a, double *ok, uint8_t *err) {
   if (a->is_err) {
     *err = a->val.err;
     return false;
@@ -171,9 +171,9 @@ void exports_test_variants_test_variant_typedefs(uint32_t *a, test_variants_test
 
 void exports_test_variants_test_variant_enums(
       bool a,
-      variants_result_void_void_t *b,
+      test_variants_test_result_void_void_t *b,
       test_variants_test_my_errno_t c,
-      variants_tuple3_bool_result_void_void_test_variants_test_my_errno_t *ret) {
+      test_variants_test_tuple3_bool_result_void_void_my_errno_t *ret) {
   assert(0);
 }
 


### PR DESCRIPTION
This commit is an attempt to redo how types are generated and modeled in the C bindings generator. There are a number of existing issues around the C generator related to resources for example, but there are other issues historically that plague the C generator.

This refactoring effectively entirely refactors the generation of types in C. Previously C worked by generating types throughout the bindings process and generating lots of bits at the end of the bindings generation process. This doesn't work for resources because the same resource imported and exported needs different bindings, unlike the one set of bindings generated prior.

The new scheme of generating types looks like:

* All work is now done immediately when a type is visited. This means that helper functions, destructors, etc, are all generated at type generation time. Nothing is deferred until the end of the bindings generation process.
* The split between anonymous and public types in the C generator is removed. Lots of weird infrastructure was present to manage this and the only benefit was that a few types would be omitted from the public header file because they didn't need to be there. Instead this commit takes the strategy of generating all the types all the time, and if they're not used that's no skin off anyone's back.
* When types are generated they now assume that all their dependencies have previously been generated. This makes generation of a reference to a type much easier because it's a simple "that name must be in this map" assertion. This is done by using `LiveTypes` to visit all types for a unit of generation. This topological sorting is then iterated over to emit all types.
* Resources now generate `own` and `borrow` handle types immediately when they're visited. These serve as the canonical versions of these types and then all other references to these handles are done via `typedef`s to ensure that the types all stay the same.
* Anonymous types such as tuples are now duplicated across interfaces. Previously the generator attempted to deduplicate everything into the world namespace but this doesn't work for resources which needs some means of duplicating in some cases. To solve this I went ahead and generated all anonymous types all the time which means that if a WIT files has `tuple<u32, u32>` in two interfaces that'll generate two types despite only needing one.

Overall the generated C bindings are a bit more verbose than before but the generation process is vastly simpler. My hope is that this'll make the C generator less buggy without losing any functionality.

Closes #629
Closes #723
Closes #727
Closes #735
Closes #749