### PR TITLE
refactor(go): re-write to adopt the new C generated types

### DIFF
--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -24,7 +24,6 @@ macro_rules! codegen_test {
 
     ($id:ident $name:tt $test:tt) => {
         #[test]
-        #[ignore] // TODO: needs updates after C was changed
         fn $id() {
             test_helpers::run_world_codegen_test(
                 "guest-go",

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -259,7 +259,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
 
     // FIXME: need to fix flaky Go test
     #[cfg(feature = "go")]
-    if !go.is_empty() && false {
+    if !go.is_empty() {
         let world_name = &resolve.worlds[world].name;
         let out_dir = out_dir.join(format!("go-{}", world_name));
         drop(fs::remove_dir_all(&out_dir));


### PR DESCRIPTION
This re-enables Go tests. 