### PR TITLE
Improve error message in Rust when missing a key in the exports map

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -269,11 +269,11 @@ impl RustWasm {
             return Ok("Stub".to_owned());
         }
         let key = match key {
-            ExportKey::World => "world",
-            ExportKey::Name(name) => name,
+            ExportKey::World => "world".to_owned(),
+            ExportKey::Name(name) => format!("\"{name}\""),
         };
         if self.opts.exports.is_empty() {
-            bail!("no `exports` map provided in configuration but key is required for `{key}`")
+            bail!("no `exports` map provided in configuration - provide an `exports` map a key `{key}`")
         }
         bail!("expected `exports` map to contain key `{key}`")
     }


### PR DESCRIPTION
Given a Rust macro invocation with an implicit world and a missing `exports` map the following error message would be emitted:

```
no `exports` map provided in configuration but key is required for `world`
```

This was confusing as, even to someone experienced in using the macro, it is not clear that there needs to be a key named "world" in the exports.

This changes the error to:

```
no `exports` map provided in configuration - provide an `exports` map with a key `world`
```

This isn't perfect - if you're new to the macro this error is still likely to be confusing, but I believe it's an improvement.

This also changes the error message to include quotes around the key when the key is expected to be a string literal. 

### Future improvements

We may want to move towards even more verbose error messages that aim to be useful to folks completely new to the macro. I think in order to be able to do this though we may wish to move away from using `anyhow` for some errors and offer more structured error handling where the caller can control the verbosity of error reporting.