### PR TITLE
Give the 'path' config meaning when used together with 'inline' in Rust macro

### DIFF
--- a/crates/test-rust-wasm/src/bin/other-dependencies.rs
+++ b/crates/test-rust-wasm/src/bin/other-dependencies.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/other-dependencies/wasm.rs");
+
+fn main() {}

--- a/tests/runtime/other-dependencies/other/world.wit
+++ b/tests/runtime/other-dependencies/other/world.wit
@@ -1,0 +1,3 @@
+package other:test;
+
+interface test {}

--- a/tests/runtime/other-dependencies/wasm.rs
+++ b/tests/runtime/other-dependencies/wasm.rs
@@ -1,0 +1,10 @@
+wit_bindgen::generate!({
+    inline: r#"
+    package test:deps;
+
+    world test {
+        export other:test/test;
+    }
+    "#,
+    path: "tests/runtime/other-dependencies/other",
+});

--- a/tests/runtime/other_dependencies.rs
+++ b/tests/runtime/other_dependencies.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use wasmtime::Store;
+
+wasmtime::component::bindgen!({
+    inline: r#"package test:deps;
+
+    world test {
+        export other:test/test;
+    }"#,
+    path: "tests/runtime/other-dependencies/other"
+});
+
+#[test]
+fn run() -> Result<()> {
+    crate::run_test(
+        "other-dependencies",
+        |_linker| Ok(()),
+        |store, component, linker| Test::instantiate(store, component, linker),
+        |_exports, _store: &mut Store<crate::Wasi<()>>| Ok(()),
+    )
+}


### PR DESCRIPTION
Fixes #742 

Previously, users could only specify 'inline' or 'path' based wit packages. However, the wasmtime component macro allows for 'path' to specify a directory where the inline wit package's dependencies live.

This change brings the same semantics to the wit-bindgen macro.