### PR TITLE
Switch lists runtime test to use default ownership strategy

### DIFF
--- a/tests/runtime/lists.rs
+++ b/tests/runtime/lists.rs
@@ -3,9 +3,6 @@ use wasmtime::Store;
 
 wasmtime::component::bindgen!({
     path: "tests/runtime/lists",
-    ownership: Borrowing {
-        duplicate_if_necessary: true
-    }
 });
 
 #[derive(Default)]
@@ -127,8 +124,17 @@ fn run_test(lists: Lists, store: &mut Store<crate::Wasi<MyImports>>) -> Result<(
     assert_eq!(exports.call_empty_string_result(&mut *store)?, "");
     exports.call_list_param(&mut *store, &[1, 2, 3, 4])?;
     exports.call_list_param2(&mut *store, "foo")?;
-    exports.call_list_param3(&mut *store, &["foo", "bar", "baz"])?;
-    exports.call_list_param4(&mut *store, &[&["foo", "bar"], &["baz"]])?;
+    exports.call_list_param3(
+        &mut *store,
+        &["foo".to_owned(), "bar".to_owned(), "baz".to_owned()],
+    )?;
+    exports.call_list_param4(
+        &mut *store,
+        &[
+            vec!["foo".to_owned(), "bar".to_owned()],
+            vec!["baz".to_owned()],
+        ],
+    )?;
     assert_eq!(exports.call_list_result(&mut *store)?, [1, 2, 3, 4, 5]);
     assert_eq!(exports.call_list_result2(&mut *store)?, "hello!");
     assert_eq!(

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -4,9 +4,6 @@ wit_bindgen::generate!({
         world: Component,
         "test:lists/test": Component
     },
-    ownership: Borrowing {
-        duplicate_if_necessary: false
-    }
 });
 
 struct Component;
@@ -28,8 +25,11 @@ impl Guest for Component {
 
         list_param(&[1, 2, 3, 4]);
         list_param2("foo");
-        list_param3(&["foo", "bar", "baz"]);
-        list_param4(&[&["foo", "bar"], &["baz"]]);
+        list_param3(&["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]);
+        list_param4(&[
+            vec!["foo".to_owned(), "bar".to_owned()],
+            vec!["baz".to_owned()],
+        ]);
         assert_eq!(list_result(), [1, 2, 3, 4, 5]);
         assert_eq!(list_result2(), "hello!");
         assert_eq!(list_result3(), ["hello,", "world!"]);


### PR DESCRIPTION
While looking into #769, I noticed that the lists runtime test was using a `Borrowing` ownership strategy. It seems sensible to me that we'd test the default ownership strategy and add other specialized tests if we want to specifically test `Borrowing`. The `ownership` tests already test alternate ownership strategies and if we're unsatisfied with coverage of these alternate strategies we should add more to the `ownership` test.