### PR TITLE
fix(go, c): escape ret and err

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -2833,6 +2833,10 @@ pub fn to_c_ident(name: &str) -> String {
         "xor" => "xor_".into(),
         "xor_eq" => "xor_eq_".into(),
         "_Packed" => "_Packed_".into(),
+        // ret and err needs to be escaped because they are used as
+        //  variable names for option and result flattening.
+        "ret" => "ret_".into(),
+        "err" => "err_".into(),
         s => s.to_snake_case(),
     }
 }

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -433,7 +433,7 @@ impl InterfaceGenerator<'_> {
                 if is_pointer {
                     prefix.push_str("&");
                 }
-                if name != "err" && name != "ret" {
+                if name != "ret" {
                     param_name = format!("lower_{name}");
                 } else {
                     param_name.push_str(name);

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -362,7 +362,7 @@ fn avoid_keyword(s: &str) -> String {
 }
 
 // a list of Go keywords
-const GOKEYWORDS: [&str; 25] = [
+const GOKEYWORDS: [&str; 26] = [
     "break",
     "default",
     "func",
@@ -388,4 +388,7 @@ const GOKEYWORDS: [&str; 25] = [
     "import",
     "return",
     "var",
+    // not a Go keyword but needs to escape due to
+    // it's used as a variable name that passes to C
+    "ret",
 ];


### PR DESCRIPTION
`"ret"` and `"err"` are preserved as variable names facilitating pointer types and "option" and "result" flattening in the C bindgen. As a result, they should be escaped as parameters and otherwise will cause issues as shown in the added test. This also fixed affliated issue in Go bindgen. 