### PR TITLE
tests(c#): enable tests that pass codegen

### DIFF
--- a/crates/csharp/tests/codegen.rs
+++ b/crates/csharp/tests/codegen.rs
@@ -57,8 +57,6 @@ macro_rules! codegen_test {
                         "simple-http",
                         "simple-lists",
                         "small-anonymous",
-                        "strings",
-                        "smoke-default",
                         "unused-import",
                         "use-across-interfaces",
                         "variants",


### PR DESCRIPTION
I goofed up a rebase on #760 and disabled two tests I turned on previously🤦, both of these tests are passing after #760 and #756