### PR TITLE
c#: Encode version in namespace to support wit versions

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -764,7 +764,7 @@ impl InterfaceGenerator<'_> {
         uwrite!(
             self.csharp_interop_src,
             r#"
-            internal static class {camel_name}Interop
+            internal static class {camel_name}WasmInterop
             {{
                 [DllImport("*", EntryPoint = "{import_name}")]
                 internal static extern {wasm_result_type} wasmImport{camel_name}({wasm_params});
@@ -1580,7 +1580,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
                 uwriteln!(
                     self.src,
-                    "{assignment} {name}Interop.wasmImport{func_name}({operands});"
+                    "{assignment} {name}WasmInterop.wasmImport{func_name}({operands});"
                 );
             }
 

--- a/crates/csharp/tests/codegen.rs
+++ b/crates/csharp/tests/codegen.rs
@@ -35,7 +35,6 @@ macro_rules! codegen_test {
                         "lists",
                         "many-arguments",
                         "multi-return",
-                        "multiversion",
                         "option-result",
                         "records",
                         "rename-interface",

--- a/tests/runtime/numbers/wasm.cs
+++ b/tests/runtime/numbers/wasm.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-using wit_numbers.Wit.imports.test.numbers.Test;
+using wit_numbers.wit.imports.test.numbers.Test;
 
 namespace wit_numbers;
 
@@ -62,7 +62,7 @@ public class NumbersWorldImpl : INumbersWorld
     }
 }
 
-public class TestImpl : wit_numbers.Wit.exports.test.numbers.Test.ITest
+public class TestImpl : wit_numbers.wit.exports.test.numbers.Test.ITest
 {
     static uint SCALAR = 0;
 

--- a/tests/runtime/strings/wasm.cs
+++ b/tests/runtime/strings/wasm.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Diagnostics;
-using wit_strings.Wit.imports.test.strings.Imports;
+using wit_strings.wit.imports.test.strings.Imports;
 
 namespace wit_strings;
 


### PR DESCRIPTION
Prior to this change the multi-version wit was putting the functions from different versions into the same class which was causing the test to fail as there were multiple implementations of the same function:

```
C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\Wit.imports.my.dep.AInterop.cs(25,27): error CS0102: The type 'AInterop' already contains a definition for 'XInterop' [C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\TheWorld.csproj]
C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\Wit.imports.my.dep.AInterop.cs(31,33): error CS0111: Type 'AInterop' already defines a member called 'X' with the same parameter types [C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\TheWorld.csproj]
C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\Wit.imports.my.dep.AInterop.cs(28,36): error CS0111: Type 'AInterop.XInterop' already defines a member called 'wasmImportX' with the same parameter types [C:\Users\jstur\projects\wit-bindgen\target\codegen-tests\guest-csharp-multiversion\foo\TheWorld.csproj]
```

Now the it generates a file for each version (if present) with the functions namespaced by version:

```
wit_foo.wit.imports.my.dep.v0_1_0.A;
```

It also creates a file per version:

![file per version of wit](https://github.com/bytecodealliance/wit-bindgen/assets/648372/983c8d26-68b8-40ed-83c9-2e43c62cb212)


To note:

-  namespaces parts can't start with numbers so put `v` in front.  
- This also lowercases all the names in the namespace, but we had a mixture of upper and lower case so this makes it atleast consistent.  Can maybe follow up to make it more csharp like
