### PR TITLE
c#: Use csharp naming conventions for Interfaces

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -240,7 +240,7 @@ impl WorldGenerator for CSharp {
 
             namespace {namespace} {{
 
-             public interface {name}World {{
+             public interface I{name}World {{
             "
         );
 
@@ -472,7 +472,7 @@ impl WorldGenerator for CSharp {
 
                 namespace {fully_qaulified_namespace};
 
-                 public partial class {stub_class_name} : {interface_name} {{
+                 public partial class {stub_class_name} : I{interface_name} {{
                     {body}
                  }}
                 "
@@ -515,7 +515,7 @@ impl WorldGenerator for CSharp {
 
                     namespace {namespace}.{name};
         
-                    public interface {interface_name} {{
+                    public interface I{interface_name} {{
                         {body}
                     }}
                     "

--- a/tests/runtime/numbers/wasm.cs
+++ b/tests/runtime/numbers/wasm.cs
@@ -5,7 +5,7 @@ using wit_numbers.Wit.imports.test.numbers.Test;
 
 namespace wit_numbers;
 
-public class NumbersWorldImpl : NumbersWorld
+public class NumbersWorldImpl : INumbersWorld
 {
     public static void TestImports()
     {
@@ -62,7 +62,7 @@ public class NumbersWorldImpl : NumbersWorld
     }
 }
 
-public class TestImpl : wit_numbers.Wit.exports.test.numbers.Test.Test
+public class TestImpl : wit_numbers.Wit.exports.test.numbers.Test.ITest
 {
     static uint SCALAR = 0;
 

--- a/tests/runtime/strings/wasm.cs
+++ b/tests/runtime/strings/wasm.cs
@@ -4,7 +4,7 @@ using wit_strings.Wit.imports.test.strings.Imports;
 
 namespace wit_strings;
 
-public class StringsWorldImpl : StringsWorld
+public class StringsWorldImpl : IStringsWorld
 {
     public static void TestImports()
     {


### PR DESCRIPTION
This creates the csharp interfaces according to csharp style guidelines: https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names

> Interface names start with a capital I.