### PR TITLE
feat(go-namespaces): Split generated Go files into multiple packages

### DIFF
--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -1,19 +1,25 @@
 use std::collections::{HashMap, HashSet};
-use std::io::{Read, Write};
+use std::fmt::Write;
+use std::io::{Read, Write as _};
 use std::mem;
 use std::process::Stdio;
 
 use anyhow::Result;
-use heck::{ToKebabCase, ToSnakeCase};
+use heck::ToKebabCase;
 use wit_bindgen_c::imported_types_used_by_exported_interfaces;
 use wit_bindgen_core::wit_parser::{
-    Function, InterfaceId, LiveTypes, Resolve, SizeAlign, Type, TypeId, WorldId, WorldKey,
+    Function, InterfaceId, LiveTypes, Resolve, Type, TypeId, WorldId, WorldKey,
 };
-use wit_bindgen_core::{Direction, Files, Source, WorldGenerator};
+use wit_bindgen_core::{generated_preamble, uwriteln, Direction, Files, Source, WorldGenerator};
+use world::{Packages, TinyGoWorld};
 
 mod bindgen;
 mod imports;
 mod interface;
+mod path;
+mod world;
+
+static C_GEN_FILES_PATH: &'static str = "c_files_";
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
@@ -21,11 +27,18 @@ pub struct Opts {
     /// Whether or not `gofmt` is executed to format generated code.
     #[cfg_attr(feature = "clap", arg(long))]
     pub gofmt: bool,
+
+    /// The optional package name to use for the generated code.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub package_name: Option<String>,
 }
 
 impl Default for Opts {
     fn default() -> Self {
-        Self { gofmt: true } // Set the default value of gofmt to true
+        Self {
+            gofmt: true,        // Set the default value of gofmt to true
+            package_name: None, // Set the default value of package_name to None
+        }
     }
 }
 
@@ -40,21 +53,20 @@ impl Opts {
 
 #[derive(Default)]
 pub struct TinyGo {
+    // the options for the generator provided by the user
     opts: Opts,
+
+    // the generated code
     src: Source,
 
     // the parts immediately precede the import of "C"
     preamble: Source,
 
-    world: String,
+    // the name of the world being generated
+    world: TinyGoWorld,
 
     // import requirements for the generated code
     import_requirements: imports::ImportRequirements,
-
-    sizes: SizeAlign,
-
-    // mapping from interface ID to the name of the interface
-    interface_names: HashMap<InterfaceId, WorldKey>,
 
     // C type names
     c_type_names: HashMap<TypeId, String>,
@@ -69,16 +81,17 @@ pub struct TinyGo {
     // resource interface and the resource destructors
     exported_resources: HashSet<TypeId>,
 
-    // the world ID
-    world_id: Option<WorldId>,
+    /// tracking all the pending Go packages to be generated
+    go_import_packages: Packages,
+    go_export_packages: Packages,
 }
 
 impl TinyGo {
-    fn interface<'a>(
-        &'a mut self,
-        resolve: &'a Resolve,
+    fn interface<'b>(
+        &'b mut self,
+        resolve: &'b Resolve,
         direction: Direction,
-    ) -> interface::InterfaceGenerator<'a> {
+    ) -> interface::InterfaceGenerator {
         interface::InterfaceGenerator {
             src: Source::default(),
             preamble: Source::default(),
@@ -145,10 +158,10 @@ impl TinyGo {
 
 impl WorldGenerator for TinyGo {
     fn preprocess(&mut self, resolve: &Resolve, world: WorldId) {
-        let name = &resolve.worlds[world].name;
-        self.world = name.to_string();
-        self.sizes.fill(resolve);
-        self.world_id = Some(world);
+        self.world = TinyGoWorld::from_world_id(world, resolve);
+
+        self.go_import_packages.prefix_name = self.opts.package_name.clone();
+        self.go_export_packages.prefix_name = self.opts.package_name.clone();
     }
 
     fn import_interface(
@@ -161,20 +174,18 @@ impl WorldGenerator for TinyGo {
         let name_raw = &resolve.name_world_key(name);
         self.src
             .push_str(&format!("// Import functions from {name_raw}\n"));
-        self.interface_names.insert(id, name.clone());
 
         let mut gen = self.interface(resolve, Direction::Import);
         gen.interface = Some((id, name));
+        let (snake, module_path) = gen.start_append_submodule(name);
+
         gen.define_interface_types(id);
 
         for (_name, func) in resolve.interfaces[id].functions.iter() {
             gen.import(resolve, func);
         }
 
-        let src = mem::take(&mut gen.src);
-        let preamble = mem::take(&mut gen.preamble);
-        self.src.push_str(&src);
-        self.preamble.append_src(&preamble);
+        gen.finish_append_submodule(&snake, module_path);
     }
 
     fn import_funcs(
@@ -189,19 +200,18 @@ impl WorldGenerator for TinyGo {
             .push_str(&format!("// Import functions from {name}\n"));
 
         let mut gen = self.interface(resolve, Direction::Import);
+
         gen.define_function_types(funcs);
 
         for (_name, func) in funcs.iter() {
             gen.import(resolve, func);
         }
-        let src = mem::take(&mut gen.src);
-        let preamble = mem::take(&mut gen.preamble);
-        self.src.push_str(&src);
-        self.preamble.append_src(&preamble);
+
+        gen.finish_append_submodule(name, vec!["imports".to_string(), name.to_owned()]);
     }
 
     fn pre_export_interface(&mut self, resolve: &Resolve, _files: &mut Files) -> Result<()> {
-        let world = self.world_id.unwrap();
+        let world = self.world.unwrap_id();
         let live_import_types = imported_types_used_by_exported_interfaces(resolve, world);
         self.c_type_namespaces
             .retain(|k, _| live_import_types.contains(k));
@@ -218,12 +228,12 @@ impl WorldGenerator for TinyGo {
         id: InterfaceId,
         _files: &mut Files,
     ) -> Result<()> {
-        self.interface_names.insert(id, name.clone());
         let name_raw = &resolve.name_world_key(name);
         self.src
             .push_str(&format!("// Export functions from {name_raw}\n"));
 
         let mut gen = self.interface(resolve, Direction::Export);
+        let (snake, module_path) = gen.start_append_submodule(name);
         gen.interface = Some((id, name));
         gen.define_interface_types(id);
 
@@ -231,12 +241,7 @@ impl WorldGenerator for TinyGo {
             gen.export(resolve, func);
         }
 
-        gen.finish();
-
-        let src = mem::take(&mut gen.src);
-        let preamble = mem::take(&mut gen.preamble);
-        self.src.push_str(&src);
-        self.preamble.append_src(&preamble);
+        gen.finish_append_submodule(&snake, module_path);
         Ok(())
     }
 
@@ -257,100 +262,130 @@ impl WorldGenerator for TinyGo {
         for (_name, func) in funcs.iter() {
             gen.export(resolve, func);
         }
-
-        gen.finish();
-
-        let src = mem::take(&mut gen.src);
-        let preamble = mem::take(&mut gen.preamble);
-        self.src.push_str(&src);
-        self.preamble.append_src(&preamble);
+        gen.finish_append_submodule(name, vec!["exports".to_string(), name.to_owned()]);
         Ok(())
     }
 
     fn import_types(
         &mut self,
         resolve: &Resolve,
-        _world: WorldId,
+        world: WorldId,
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
+        let name = &resolve.worlds[world].name;
         let mut gen = self.interface(resolve, Direction::Import);
         let mut live = LiveTypes::default();
         for (_, id) in types {
             live.add_type_id(resolve, *id);
         }
         gen.define_live_types(&live);
-        let src = mem::take(&mut gen.src);
-        self.src.push_str(&src);
+        gen.finish_append_submodule(name, vec!["imports".to_string(), name.to_owned()]);
     }
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
-        // make sure all types are defined on top of the file
-        let src = mem::take(&mut self.src);
-        self.src.push_str(&src);
+        self.go_import_packages.finish(resolve, id, files);
+        self.go_export_packages.finish(resolve, id, files);
 
-        // prepend package and imports header
-        let src = mem::take(&mut self.src);
-        wit_bindgen_core::generated_preamble(&mut self.src, env!("CARGO_PKG_VERSION"));
-        let snake = self.world.to_snake_case();
-        // add package
-        self.src.push_str("package ");
-        self.src.push_str(&snake);
-        self.src.push_str("\n\n");
-
-        // import C
-        self.src.push_str("// #include \"");
-        self.src.push_str(self.world.to_snake_case().as_str());
-        self.src.push_str(".h\"\n");
-        if self.preamble.len() > 0 {
-            self.src.append_src(&self.preamble);
-        }
-        self.src.push_str("import \"C\"\n");
-        let world = &resolve.worlds[id];
-
-        self.import_requirements.generate(
-            snake,
-            files,
-            format!("{}_types.go", world.name.to_kebab_case()),
-        );
-        self.src.push_str(&self.import_requirements.src);
-
-        self.src.push_str(&src);
-
-        if self.opts.gofmt {
-            let mut child = std::process::Command::new("gofmt")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()
-                .expect("failed to spawn gofmt");
-            child
-                .stdin
-                .take()
-                .unwrap()
-                .write_all(self.src.as_bytes())
-                .expect("failed to write to gofmt");
-            self.src.as_mut_string().truncate(0);
-            child
-                .stdout
-                .take()
-                .unwrap()
-                .read_to_string(self.src.as_mut_string())
-                .expect("failed to read from gofmt");
-            let status = child.wait().expect("failed to wait on gofmt");
-            assert!(status.success());
-        }
-        files.push(
-            &format!("{}.go", world.name.to_kebab_case()),
-            self.src.as_bytes(),
-        );
+        // TODO:
+        // 1. import_requirements
+        // 2. opts (gofmt)
 
         let mut opts = wit_bindgen_c::Opts::default();
         opts.no_sig_flattening = true;
         opts.no_object_file = true;
+        opts.c_out_dir = Some(format!("{C_GEN_FILES_PATH}/"));
         opts.build()
             .generate(resolve, id, files)
-            .expect("C generator should be infallible")
+            .expect("C generator should be infallible");
+
+        let mut c_lib: Source = Source::default();
+        let version = env!("CARGO_PKG_VERSION");
+        generated_preamble(&mut c_lib, version);
+        c_lib.push_str(&format!("package {C_GEN_FILES_PATH}\n\n"));
+        uwriteln!(
+            c_lib,
+            "
+        // Go will only compile the C code if there is a C file in the same directory
+        // as the Go file. This file is a dummy Go package that it's only purpose is
+        // to compile the C code and expose it to the Go code. In order to use this Go 
+        // package, you need to import it in your Go code
+        // and then import the C header file using CGo.
+        //
+        // This package is only used internally by wit-bindgen, and it's not meant to
+        // be used by the user. The user should not import this package.
+        "
+        );
+        c_lib.push_str("import \"C\"\n\n");
+        files.push(&format!("{C_GEN_FILES_PATH}/lib.go"), c_lib.as_bytes());
     }
+    // fn finish_(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+    //     // make sure all types are defined on top of the file
+    //     let src = mem::take(&mut self.src);
+    //     self.src.push_str(&src);
+
+    //     // prepend package and imports header
+    //     let src = mem::take(&mut self.src);
+    //     wit_bindgen_core::generated_preamble(&mut self.src, env!("CARGO_PKG_VERSION"));
+    //     let snake = self.world.to_snake_case();
+    //     // add package
+    //     self.src.push_str("package ");
+    //     self.src.push_str(&snake);
+    //     self.src.push_str("\n\n");
+
+    //     // import C
+    //     self.src.push_str("// #include \"");
+    //     self.src.push_str(self.world.to_snake_case().as_str());
+    //     self.src.push_str(".h\"\n");
+    //     if self.preamble.len() > 0 {
+    //         self.src.append_src(&self.preamble);
+    //     }
+    //     self.src.push_str("import \"C\"\n");
+    //     let world = &resolve.worlds[id];
+
+    //     self.import_requirements.generate(
+    //         snake,
+    //         files,
+    //         format!("{}_types.go", world.name.to_kebab_case()),
+    //     );
+    //     self.src.push_str(&self.import_requirements.src);
+
+    //     self.src.push_str(&src);
+
+    //     if self.opts.gofmt {
+    //         let mut child = std::process::Command::new("gofmt")
+    //             .stdin(Stdio::piped())
+    //             .stdout(Stdio::piped())
+    //             .spawn()
+    //             .expect("failed to spawn gofmt");
+    //         child
+    //             .stdin
+    //             .take()
+    //             .unwrap()
+    //             .write_all(self.src.as_bytes())
+    //             .expect("failed to write to gofmt");
+    //         self.src.as_mut_string().truncate(0);
+    //         child
+    //             .stdout
+    //             .take()
+    //             .unwrap()
+    //             .read_to_string(self.src.as_mut_string())
+    //             .expect("failed to read from gofmt");
+    //         let status = child.wait().expect("failed to wait on gofmt");
+    //         assert!(status.success());
+    //     }
+    //     files.push(
+    //         &format!("{}.go", world.name.to_kebab_case()),
+    //         self.src.as_bytes(),
+    //     );
+
+    //     let mut opts = wit_bindgen_c::Opts::default();
+    //     opts.no_sig_flattening = true;
+    //     opts.no_object_file = true;
+    //     opts.build()
+    //         .generate(resolve, id, files)
+    //         .expect("C generator should be infallible")
+    // }
 }
 
 fn avoid_keyword(s: &str) -> String {

--- a/crates/go/src/path.rs
+++ b/crates/go/src/path.rs
@@ -1,5 +1,8 @@
 use heck::ToSnakeCase;
-use wit_bindgen_core::{wit_parser::{WorldKey, Resolve, PackageId}, Direction};
+use wit_bindgen_core::{
+    wit_parser::{PackageId, Resolve, WorldKey},
+    Direction,
+};
 
 pub(crate) trait GoPath {
     fn to_path(&self, resolve: &Resolve, direction: Direction) -> Vec<String>;
@@ -8,18 +11,19 @@ pub(crate) trait GoPath {
 impl GoPath for WorldKey {
     fn to_path(&self, resolve: &Resolve, direction: Direction) -> Vec<String> {
         let mut path = Vec::new();
-        if matches!(direction, Direction::Export) {
-            path.push("exports".to_string());
+        match direction {
+            Direction::Import => path.push("imports".to_string()),
+            Direction::Export => path.push("exports".to_string()),
         }
-        match self {   
+        match self {
             WorldKey::Name(n) => path.push(n.to_snake_case()),
             WorldKey::Interface(id) => {
-            let iface = &resolve.interfaces[*id];
-            let pkg = iface.package.unwrap();
-            let pkgname = resolve.packages[pkg].name.clone();
-            path.push(pkgname.namespace.to_snake_case());
-            path.push(name_package_module(resolve, pkg));
-            path.push(iface.name.as_ref().unwrap().to_snake_case());
+                let iface = &resolve.interfaces[*id];
+                let pkg = iface.package.unwrap();
+                let pkgname = resolve.packages[pkg].name.clone();
+                path.push(pkgname.namespace.to_snake_case());
+                path.push(name_package_module(resolve, pkg));
+                path.push(iface.name.as_ref().unwrap().to_snake_case());
             }
         }
         path

--- a/crates/go/src/world.rs
+++ b/crates/go/src/world.rs
@@ -1,0 +1,191 @@
+use std::{collections::HashMap, mem};
+
+use crate::{
+    interface::{self, InterfaceGenerator},
+    C_GEN_FILES_PATH,
+};
+use heck::{ToSnakeCase, ToUpperCamelCase};
+use wit_bindgen_core::{
+    wit_parser::{Resolve, WorldId},
+    Direction, Files, Source,
+};
+
+/// Bookkeeping for the name of the world being generated and its ID.
+#[derive(Default, Debug, Clone)]
+pub struct TinyGoWorld {
+    name: String,
+    id: Option<WorldId>,
+}
+
+impl TinyGoWorld {
+    pub fn from_world_id(id: WorldId, resolve: &Resolve) -> Self {
+        Self {
+            name: resolve.worlds[id].name.to_string(),
+            id: Some(id),
+        }
+    }
+    pub fn to_snake_case(&self) -> String {
+        self.name.to_snake_case()
+    }
+    pub fn to_upper_camel_case(&self) -> String {
+        self.name.to_upper_camel_case()
+    }
+    pub fn unwrap_id(&self) -> WorldId {
+        self.id.unwrap()
+    }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Bookkeeping for the name of the package being generated
+/// and each package corresponds to either an imported or exported interface
+/// , or all imported functions and types from the world, or all
+/// exported functions from the world.
+#[derive(Default)]
+pub struct Packages {
+    pub prefix_name: Option<String>,
+    packages: HashMap<String, Package>,
+}
+
+pub struct Package {
+    pub src: Source,
+    pub preamble: Source,
+    pub world: TinyGoWorld,
+    pub path: Vec<String>,
+    pub c_files_path: String,
+    pub prefix_name: Option<String>,
+}
+
+impl Packages {
+    pub fn push(
+        &mut self,
+        name: &str,
+        src: Source,
+        preamble: Source,
+        world: &'_ TinyGoWorld,
+        module_path: Vec<String>,
+    ) -> Option<Package> {
+        let prefix_name = self.prefix_name.clone();
+        let c_files_path = get_c_files_path(&module_path);
+        let mut package = Package::new(
+            src,
+            preamble,
+            world.clone(),
+            module_path,
+            c_files_path,
+            prefix_name,
+        );
+
+        let old_package = self.packages.insert(name.to_owned(), package);
+        assert!(old_package.is_none());
+        old_package
+    }
+
+    pub fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+        for (_, mut package) in self {
+            package.finish(resolve, id);
+            let mut path_name = package.path.join("/");
+            path_name.push_str(".wit.go");
+            files.push(&path_name, package.src.as_bytes());
+        }
+    }
+}
+
+fn get_c_files_path(module_path: &[String]) -> String {
+    // for each path in module_path, we will go to the parent directory
+    // and then join the path with the C_GEN_FILES_PATH
+    let mut path = String::new();
+    for _ in 0..module_path.len() - 1 {
+        path.push_str("../");
+    }
+    path.push_str(C_GEN_FILES_PATH);
+    path
+}
+
+impl Package {
+    pub fn new(
+        src: Source,
+        preamble: Source,
+        world: TinyGoWorld,
+        path: Vec<String>,
+        c_files_path: String,
+        prefix_name: Option<String>,
+    ) -> Self {
+        Self {
+            src,
+            preamble,
+            world,
+            path,
+            c_files_path,
+            prefix_name,
+        }
+    }
+
+    pub fn finish(&mut self, resolve: &Resolve, id: WorldId) {
+        let src = mem::take(&mut self.src);
+
+        // generate the preamble
+        wit_bindgen_core::generated_preamble(&mut self.src, env!("CARGO_PKG_VERSION"));
+
+        // generate the package name
+        assert!(self.path.len() > 1);
+        let snake = self.path[self.path.len() - 2].to_snake_case();
+        self.src.push_str("package ");
+        self.src.push_str(&snake);
+        self.src.push_str("\n\n");
+
+        // use the Go exposed C API
+        let prefix_name = match self.prefix_name.take() {
+            Some(name) => name,
+            None => "main".to_owned(),
+        };
+        self.src.push_str(&format!(
+            "import _ \"{prefix_name}/{C_GEN_FILES_PATH}\"\n\n"
+        ));
+
+        // generate CGo preamble
+        self.src.push_str("// #cgo CFLAGS: -I");
+        self.src.push_str(&self.c_files_path);
+        self.src.push_str("\n");
+
+        self.src.push_str("// #include \"");
+        self.src.push_str(self.world.to_snake_case().as_str());
+        self.src.push_str(".h\"\n");
+
+        if self.preamble.len() > 0 {
+            self.src.append_src(&self.preamble);
+        }
+        self.src.push_str("import \"C\"\n");
+        let world = &resolve.worlds[id];
+
+        self.src.push_str(&src);
+    }
+}
+
+impl IntoIterator for Packages {
+    type Item = (String, Package);
+    type IntoIter = std::collections::hash_map::IntoIter<String, Package>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packages.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Packages {
+    type Item = (&'a String, &'a Package);
+    type IntoIter = std::collections::hash_map::Iter<'a, String, Package>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packages.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Packages {
+    type Item = (&'a String, &'a mut Package);
+    type IntoIter = std::collections::hash_map::IterMut<'a, String, Package>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packages.iter_mut()
+    }
+}

--- a/tests/runtime/smoke/wasm.go
+++ b/tests/runtime/smoke/wasm.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	. "wit_smoke_go/gen"
+	exports "smoke/exports"
+	smoke "smoke/imports/test/smoke"
 )
 
 func init() {
 	n := SmokeImpl{}
-	SetSmoke(n)
+	exports.SetSmoke(n)
 }
 
 type SmokeImpl struct{}
 
 func (s SmokeImpl) Thunk() {
-	TestSmokeImportsThunk()
+	smoke.Thunk()
 }
 
 func main() {}


### PR DESCRIPTION
This commit overhauls the `WorldGenerator` file structure in the tinygo bindgen. Key changes include:
- Splitting generated Go files into different packages for each interface, imported functions, and exported functions.
- Simplifying function and symbol names by removing namespaces.
- Adding a `package_name` option to Go bindgen for prefixed package names. Defaults to `main` if not specified.

Internally, the C files are placed at a special Go package named "c_files_", and a dummy Go file is generated to expose the C APIs. Each interface generates a Go package that imports this special "c_files_" package to get the C apis. It still has to import the C header file which is also placed at "c_files_" by setting CFLAGS to locate where that is for that Go package.

This restructuring enhances usability by making symbol and function names more readable and less verbose, significantly improving the user experience.

## TODO

- [ ] Generate a dummy `main` file for each codegen test, and that `main` file needs to import all the generated Go packages.
- [ ] Enable the rest of the runtime tests
- [ ] Figure out how to import Go packages to implement type aliasing
- [ ] More testing with wasi:http