### PR TITLE
Add a runtime test for multiple versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -218,7 +218,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winx",
 ]
 
@@ -346,18 +346,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c22542c0b95bd3302f7ed6839869c561f2324bac2fd5e7e99f5cfa65fdc8b92"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3db903ef2e9c8a4de2ea6db5db052c7857282952f9df604aa55d169e6000d8"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -376,33 +374,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6590feb5a1d6438f974bf6a5ac4dddf69fca14e1f07f3265d880f69e61a94463"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7239038c56fafe77fddc8788fc8533dd6c474dc5bdc5637216404f41ba807330"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 
 [[package]]
 name = "cranelift-control"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dc9c595341404d381d27a3d950160856b35b402275f0c3990cd1ad683c8053"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e3ee532fc4776c69bcedf7e62f9632cbb3f35776fa9a525cdade3195baa3f7"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "serde",
  "serde_derive",
@@ -410,9 +404,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a612c94d09e653662ec37681dc2d6fd2b9856e6df7147be0afc9aabb0abf19df"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -422,15 +415,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85db9830abeb1170b7d29b536ffd55af1d4d26ac8a77570b5d1aca003bf225cc"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 
 [[package]]
 name = "cranelift-native"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301ef0edafeaeda5771a5d2db64ac53e1818ae3111220a185677025fe91db4a1"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -439,9 +430,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0abe8264e4570ac615fc31cef32a3b90a77f7eb97b08331f9dd357b1f500"
+version = "0.104.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -593,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -610,7 +600,7 @@ checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -630,7 +620,7 @@ checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -815,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d3c230ee517ee76b1cc593b52939ff68deda3fae9e41eca426c6b4993df51c4"
 dependencies = [
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -965,7 +955,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1177,7 +1167,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1268,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1321,7 +1311,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winx",
 ]
 
@@ -1401,7 +1391,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1536,9 +1526,8 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154528979a211aa28d969846e883df75705809ed9bcc70aba61460683ea7355b"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1554,14 +1543,13 @@ dependencies = [
  "system-interface",
  "tracing",
  "wasi-common",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasi-common"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d888b611fee7d273dd057dc009d2dd3132736f36710ffd65657ac83628d1e3b"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -1574,7 +1562,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wiggle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1624,9 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e539fded2495422ea3c4dfa7beeddba45904eece182cf315294009e1a323bf"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1658,23 +1645,21 @@ dependencies = [
  "wasmtime-runtime",
  "wasmtime-winch",
  "wat",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660ba9143e15a2acd921820df221b73aee256bd3ca2d208d73d8adc9587ccbb9"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ce373743892002f9391c6741ef0cb0335b55ec899d874f311222b7e36f4594"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "base64",
@@ -1686,15 +1671,14 @@ dependencies = [
  "serde_derive",
  "sha2",
  "toml",
- "windows-sys",
+ "windows-sys 0.52.0",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ef32643324e564e1c359e9044daa06cbf90d7e2d6c99a738d17a12959f01a5"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1707,15 +1691,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c87d06c18d21a4818f354c00a85f4ebc62b2270961cd022968452b0e4dbed9d"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d648c8b4064a7911093b02237cd5569f71ca171d3a0a486bf80600b19e1cba2"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1738,9 +1720,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290a89027688782da8ff60b12bb95695494b1874e0d0ba2ba387d23dace6d70c"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1754,9 +1735,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61eb64fb3e0da883e2df4a13a81d6282e072336e6cb6295021d0f7ab2e352754"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1777,9 +1757,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecf1d3a838b0956b71ad3f8cb80069a228339775bf02dd35d86a5a68bbe443"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cc",
@@ -1787,14 +1766,13 @@ dependencies = [
  "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f485336add49267d8859e8f8084d2d4b9a4b1564496b6f30ba5b168d50c10ceb"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1814,14 +1792,13 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e119affec40edb2fab9044f188759a00c2df9c3017278d047012a2de1efb4f"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "object",
  "once_cell",
@@ -1831,20 +1808,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6d197fcc34ad32ed440e1f9552fd57d1f377d9699d31dee1b5b457322c1f8a"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794b2bb19b99ef8322ff0dd9fe1ba7e19c41036dfb260b3f99ecce128c42ff92"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cc",
@@ -1867,14 +1842,13 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-versioned-export-macros",
  "wasmtime-wmemcheck",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995db8bb56f2cd8d2dc0ed5ffab94ffb435283b0fe6747f80f7aab40b2d06a1"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1885,9 +1859,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c5565959287c21dd0f4277ae3518dd2ae62679f655ee2dbc4396e19d210db"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1896,9 +1869,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd8370078149d49a3a47e93741553fd79b700421464b6a27ca32718192ab130"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1926,14 +1898,13 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wiggle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-winch"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6f945ff9bad96e0a69973d74f193c19f627c8adbf250e7cb73ae7564b6cc8a"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1948,9 +1919,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f328b2d4a690270324756e886ed5be3a4da4c00be0eea48253f4595ad068062b"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "heck",
@@ -1960,9 +1930,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67761d8f8c0b3c13a5d34356274b10a40baba67fe9cfabbfc379a8b414e45de2"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 
 [[package]]
 name = "wast"
@@ -1996,9 +1965,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afb26cd3269289bb314a361ff0a6685e5ce793b62181a9fe3f81ace15051697"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2011,9 +1979,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2868fed7584d2b552fa317104858ded80021d23b073b2d682d3c932a027bd"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "heck",
@@ -2026,9 +1993,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ae1ec11a17ea481539ee9a5719a278c9790d974060fbf71db4b2c05378780b"
+version = "17.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2060,9 +2026,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e58c236a6abdd9ab454552b4f29e16cfa837a86897c1503313b2e62e7609ec"
+version = "0.15.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2080,7 +2045,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2089,13 +2063,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -2105,10 +2094,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2117,10 +2118,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2129,10 +2142,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2141,13 +2166,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "winx"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357bb8e2932df531f83b052264b050b81ba0df90ee5a59b2d1d3949f344f81e5"
 dependencies = [
  "bitflags 2.4.1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2324,8 +2355,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+source = "git+https://github.com/bytecodealliance/wasmtime#523bc959f5264bdf94f569bfeb447632c9d1e830"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ indexmap = "2.0.0"
 
 wasm-encoder = "0.38.1"
 wasm-metadata = "0.10.14"
-wasmtime-wasi = "16.0.0"
 wit-parser = "0.13.0"
 wit-component = "0.19.0"
 
@@ -79,7 +78,7 @@ csharp-mono = ['csharp']
 
 [dev-dependencies]
 heck = { workspace = true }
-wasmtime = { version = "16", features = ['component-model'] }
-wasmtime-wasi = { workspace = true }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", features = ['component-model'] }
+wasmtime-wasi =  { git = "https://github.com/bytecodealliance/wasmtime"}
 test-artifacts = { path = 'crates/test-rust-wasm/artifacts' }
 wit-parser = { workspace = true }

--- a/crates/test-rust-wasm/src/bin/versions.rs
+++ b/crates/test-rust-wasm/src/bin/versions.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/versions/wasm.rs");
+
+fn main() {}

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use heck::ToUpperCamelCase;
 
 use std::borrow::Cow;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
@@ -35,6 +34,7 @@ mod resources;
 mod smoke;
 mod strings;
 mod variants;
+mod versions;
 
 struct MyCtx {}
 

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
 use wasm_encoder::{Encode, Section};
-use wasmtime::component::{Component, Instance, Linker};
-use wasmtime::{Config, Engine, Store};
-use wasmtime_wasi::preview2::{Table, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime::component::{Component, Instance, Linker, ResourceTable};
+use wasmtime::{Config, Engine, Store, Table};
+use wasmtime_wasi::preview2::{WasiCtx, WasiCtxBuilder, WasiView};
 use wit_component::{ComponentEncoder, StringEncoding};
 use wit_parser::{Resolve, WorldId, WorldItem};
 
@@ -38,14 +38,14 @@ mod versions;
 
 struct MyCtx {}
 
-struct Wasi<T: Send>(T, MyCtx, Table, WasiCtx);
+struct Wasi<T: Send>(T, MyCtx, ResourceTable, WasiCtx);
 
 // wasi trait
 impl<T: Send> WasiView for Wasi<T> {
-    fn table(&self) -> &Table {
+    fn table(&self) -> &ResourceTable {
         &self.2
     }
-    fn table_mut(&mut self) -> &mut Table {
+    fn table_mut(&mut self) -> &mut ResourceTable {
         &mut self.2
     }
     fn ctx(&self) -> &WasiCtx {
@@ -95,7 +95,7 @@ where
         add_to_linker(&mut linker)?;
         let state = MyCtx {};
 
-        let table = Table::new();
+        let table = ResourceTable::new();
         let wasi: WasiCtx = WasiCtxBuilder::new().inherit_stdout().args(&[""]).build();
 
         let data = Wasi(T::default(), state, table, wasi);

--- a/tests/runtime/versions.rs
+++ b/tests/runtime/versions.rs
@@ -1,0 +1,56 @@
+use anyhow::{Ok, Result};
+use wasmtime::Store;
+
+wasmtime::component::bindgen!(in "tests/runtime/versions");
+use crate::versions::test::dep0_1_0::test::Host as v1;
+use crate::versions::test::dep0_2_0::test::Host as v2;
+
+#[derive(Default)]
+pub struct MyFoo;
+
+impl v1 for MyFoo {
+    fn x(&mut self) -> wasmtime::Result<f32> {
+        Ok(1.0)
+    }
+
+    fn y(&mut self, a: f32) -> wasmtime::Result<f32> {
+        Ok(1.0 + a)
+    }
+}
+
+impl v2 for MyFoo {
+    fn x(&mut self) -> wasmtime::Result<f32> {
+        Ok(2.0)
+    }
+
+    fn z(&mut self, a: f32, b: f32) -> wasmtime::Result<f32> {
+        Ok(2.0 + a + b)
+    }
+}
+
+#[test]
+fn run() -> Result<()> {
+    crate::run_test(
+        "versions",
+        |linker| Foo::add_to_linker(linker, |x| &mut x.0),
+        |store, component, linker| Foo::instantiate(store, component, linker),
+        run_test,
+    )
+}
+
+fn run_test(exports: Foo, store: &mut Store<crate::Wasi<MyFoo>>) -> Result<()> {
+    // test version 1
+    assert_eq!(exports.test_dep0_1_0_test().call_x(&mut *store)?, 1.0);
+    assert_eq!(exports.test_dep0_1_0_test().call_y(&mut *store, 1.0)?, 2.0);
+
+    // test version 2
+    assert_eq!(exports.test_dep0_2_0_test().call_x(&mut *store)?, 2.0);
+    assert_eq!(
+        exports.test_dep0_2_0_test().call_z(&mut *store, 1.0, 1.0)?,
+        4.0
+    );
+
+    // test imports
+    exports.call_test_imports(&mut *store)?;
+    Ok(())
+}

--- a/tests/runtime/versions/deps/v1/v1.wit
+++ b/tests/runtime/versions/deps/v1/v1.wit
@@ -1,0 +1,6 @@
+package test:dep@0.1.0;
+
+interface test {
+  x: func() -> float32;
+  y: func(a: float32) -> float32;
+}

--- a/tests/runtime/versions/deps/v2/v2.wit
+++ b/tests/runtime/versions/deps/v2/v2.wit
@@ -1,0 +1,6 @@
+package test:dep@0.2.0;
+
+interface test {
+  x: func() -> float32;
+  z: func(a: float32, b: float32) -> float32;
+}

--- a/tests/runtime/versions/wasm.rs
+++ b/tests/runtime/versions/wasm.rs
@@ -1,0 +1,46 @@
+wit_bindgen::generate!({
+    path: "../../tests/runtime/versions",
+    exports: {
+        world: Component,
+        "test:dep/test@0.1.0": Component1,
+        "test:dep/test@0.2.0": Component2,
+    }
+});
+
+use exports::test::dep0_1_0::test::Guest as v1;
+use exports::test::dep0_2_0::test::Guest as v2;
+
+struct Component;
+impl Guest for Component {
+    fn test_imports() {
+        use test::dep0_1_0::test as v1;
+        assert_eq!(v1::x(), 1.0);
+        assert_eq!(v1::y(1.0), 2.0);
+
+        use test::dep0_2_0::test as v2;
+        assert_eq!(v2::x(), 2.0);
+        assert_eq!(v2::z(1.0, 1.0), 4.0);
+    }
+}
+
+struct Component1;
+impl v1 for Component1{ 
+    fn x() -> f32 {
+        1.0
+    }
+
+    fn y(a: f32) -> f32 {
+        1.0+a
+    }
+}
+
+struct Component2;
+impl v2 for Component2{ 
+    fn x() -> f32 {
+        2.0
+    }
+
+    fn z(a: f32, b: f32) -> f32 {
+        2.0+a+b
+    }
+}

--- a/tests/runtime/versions/world.wit
+++ b/tests/runtime/versions/world.wit
@@ -1,0 +1,10 @@
+package test:versions;
+
+world foo {
+  import test:dep/test@0.1.0;
+  import test:dep/test@0.2.0;
+
+  export test:dep/test@0.1.0;
+  export test:dep/test@0.2.0;
+  export test-imports: func();
+}


### PR DESCRIPTION
When working on #781 I noticed there wasn't a runtime test that had versions in the wit files.  This adds test for a wit file that has multiple versions for rust and csharp.

