### PR TITLE
chore(go): remove unused wit-component dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,6 @@ dependencies = [
  "test-helpers",
  "wit-bindgen-c",
  "wit-bindgen-core",
- "wit-component",
 ]
 
 [[package]]

--- a/crates/go/Cargo.toml
+++ b/crates/go/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 wit-bindgen-core = { workspace = true }
-wit-component = { workspace = true }
 anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }


### PR DESCRIPTION
Thanks for all the awesome work on `wit-bindgen` -- in trying to debug some issues with generation (basically, I was trying to find where newer-than-expected WIT definitions might have come from), I found that the `wit-component` dependency in `wit-bindgen-go` doesn't seem to be necessary.

Please feel free to correct me if I've misunderstood somehow!