### PR TITLE
feat(go): added the missing `[resource-drop]` imports for resources

### DIFF
--- a/crates/go/src/bindgen.rs
+++ b/crates/go/src/bindgen.rs
@@ -361,7 +361,8 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
                                         {private_type_name}_mu.Unlock()
                                         {lower_name}_c := (*{c_typedef_target})(unsafe.Pointer(C.malloc(C.size_t(unsafe.Sizeof({c_typedef_target}{{}})))))
                                         {lower_name}_c.__handle = C.int32_t({private_type_name}_next_id)
-                                        {lower_name} := C.{ns}_{snake}_new({lower_name}_c) // pass the pointer directly"
+                                        {lower_name} := C.{ns}_{snake}_new({lower_name}_c) // pass the pointer directly
+                                        set{ty_name}OwningHandler({param}, int32({lower_name}.__handle))"
                                         );
                                 } else {
                                     // need to construct either an own or borrowed C handle type.

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -1032,6 +1032,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         _docs: &wit_bindgen_core::wit_parser::Docs,
     ) {
         let type_name = self.type_name(name, true);
+        let private_type_name = type_name.to_snake_case();
         // for imports, generate a `int32` type for resource handle representation.
         // for exports, generate a map to store unique IDs of resources to their
         // resource interfaces, which are implemented by guest code.
@@ -1079,7 +1080,6 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 self.gen.with_sync_import(true);
                 self.src
                     .push_str(&format!("// resource {type_name} internal bookkeeping"));
-                let private_type_name = type_name.to_snake_case();
                 uwriteln!(
                     self.src,
                     "
@@ -1124,7 +1124,6 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 let namespace = self.c_owner_namespace(id);
                 let snake = name.to_snake_case();
                 let func_name = format!("{}_{}", namespace, snake).to_lower_camel_case();
-                let private_type_name = type_name.to_snake_case();
                 self.src
                     .push_str(&format!("//export {namespace}_{snake}_destructor\n"));
                 uwriteln!(
@@ -1147,7 +1146,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                         owningHandler := get{type_name}OwningHandler(self)
                         var cOwningHandler C.{own}
                         cOwningHandler.__handle = C.int32_t(owningHandler)
-                        C.{private_type_name}_drop_own(cOwningHandler)
+                        C.{ns}_{snake}_drop_own(cOwningHandler)
                     }}
                     ",
                 );

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -28,6 +28,7 @@ pub(crate) struct InterfaceGenerator<'a> {
     // this interface-level tracking is needed to prevent duplicated
     // resource declaration which has been declared in other interfaces
     pub(crate) exported_resources: HashSet<TypeId>,
+    pub(crate) wasm_import_module: Option<&'a str>,
 }
 
 impl InterfaceGenerator<'_> {
@@ -1034,64 +1035,128 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         // for imports, generate a `int32` type for resource handle representation.
         // for exports, generate a map to store unique IDs of resources to their
         // resource interfaces, which are implemented by guest code.
-        if matches!(self.direction, Direction::Import) {
-            self.src.push_str(&format!(
-                "// {type_name} is a handle to imported resource {name}\n"
-            ));
-            self.src.push_str(&format!("type {type_name} int32\n\n"));
-        } else {
-            // generate a typedef struct for export resource
-            let c_typedef_target = self.gen.c_type_names[&id].clone();
+        match self.direction {
+            Direction::Import => {
+                self.src.push_str(&format!(
+                    "// {type_name} is a handle to imported resource {name}\n"
+                ));
+                self.src.push_str(&format!("type {type_name} int32\n\n"));
+                let import_module = self.wasm_import_module.unwrap().to_string();
 
-            self.preamble
-                .push_str(&format!("// typedef struct {c_typedef_target} "));
-            self.preamble.push_str("{");
-            self.preamble.deindent(1);
-            self.preamble.push_str("\n");
-            self.preamble.push_str("//  int32_t __handle; \n");
-            self.preamble.push_str("// ");
-            self.preamble.push_str("} ");
-            self.preamble.push_str(&c_typedef_target);
-            self.preamble.push_str(";\n");
+                uwriteln!(
+                    self.src,
+                    "//go:wasmimport {import_module} [resource-drop]{name}
+                    func _{type_name}_drop(self {type_name})
+                    
+                    func (self {type_name}) Drop() {{
+                        _{type_name}_drop(self)
+                    }}
+                    "
+                );
+            }
+            Direction::Export => {
+                // generate a typedef struct for export resource
+                let c_typedef_target = self.gen.c_type_names[&id].clone();
+                let ns = self.c_namespace_of_resource(id);
+                let snake = self.resolve.types[id].name.as_ref().unwrap();
+                let mut own = ns.clone();
+                own.push_str("_own_");
+                own.push_str(snake);
+                own.push_str("_t");
 
-            // import "sync" for Mutex
-            self.gen.with_sync_import(true);
-            self.src
-                .push_str(&format!("// resource {type_name} internal bookkeeping"));
-            let private_type_name = type_name.to_snake_case();
-            uwriteln!(
-                self.src,
-                "
-                var (
-                    {private_type_name}_pointers = make(map[int32]{type_name})
-                    {private_type_name}_next_id int32 = 0
-                    {private_type_name}_mu sync.Mutex
-                )
-                "
-            );
+                self.preamble
+                    .push_str(&format!("// typedef struct {c_typedef_target} "));
+                self.preamble.push_str("{");
+                self.preamble.deindent(1);
+                self.preamble.push_str("\n");
+                self.preamble.push_str("//  int32_t __handle; \n");
+                self.preamble.push_str("// ");
+                self.preamble.push_str("} ");
+                self.preamble.push_str(&c_typedef_target);
+                self.preamble.push_str(";\n");
 
-            // generate dtors for exported resources
-            let namespace = self.c_owner_namespace(id);
-            let snake = name.to_snake_case();
-            let func_name = format!("{}_{}", namespace, snake).to_lower_camel_case();
-            let private_type_name = type_name.to_snake_case();
-            self.src
-                .push_str(&format!("//export {namespace}_{snake}_destructor\n"));
-            uwriteln!(
-                self.src,
-                "func {func_name}Destructor(self *C.{c_typedef_target}) {{
-                    C.free(unsafe.Pointer(self))
-                    delete({private_type_name}_pointers, int32(self.__handle))
-                }}
-                ",
-            );
+                // import "sync" for Mutex
+                self.gen.with_sync_import(true);
+                self.src
+                    .push_str(&format!("// resource {type_name} internal bookkeeping"));
+                let private_type_name = type_name.to_snake_case();
+                uwriteln!(
+                    self.src,
+                    "
+                    var (
+                        // a map of indexed {type_name} instances
+                        // this is used to retrive the instance from exported C resources
+                        // This establishes a link between the exported C struct and the exported Go struct.
+                        // This map will be recycled when the dtor is called.
+                        {private_type_name}_pointers = make(map[int32]{type_name})
+                        {private_type_name}_next_id int32 = 0
+                        {private_type_name}_mu sync.Mutex
 
-            self.gen.with_import_unsafe(true);
+                        // a map of {type_name} instances to their owning handlers. This is used to
+                        // retrieve the owning handler that is necessary to implement the Drop() method.
+                        // Note that the owning handler only exists after the constructor has been called.
+                        // This map will be recycled when the dtor is called.
+                        {private_type_name}_to_own_handlers sync.Map
+                    )
+                    "
+                );
 
-            // book keep the exported resource type
-            self.exported_resources.insert(id);
-            self.gen.exported_resources.insert(id);
-        }
+                uwriteln!(
+                    self.src,
+                    "
+                    // link the instance to its owning handler
+                    func set{type_name}OwningHandler(self {type_name}, owningHandler int32) {{
+                        {private_type_name}_to_own_handlers.Store(self, owningHandler)
+                    }}
+
+                    // get the owning handler for the instance
+                    func get{type_name}OwningHandler(self {type_name}) int32 {{
+                        owningHandler, ok := {private_type_name}_to_own_handlers.Load(self)
+                        if !ok {{
+                            panic(\"Internal error: owning handler not found\")
+                        }}
+                        return owningHandler.(int32)
+                    }}
+                    "
+                );
+
+                // generate dtors for exported resources
+                let namespace = self.c_owner_namespace(id);
+                let snake = name.to_snake_case();
+                let func_name = format!("{}_{}", namespace, snake).to_lower_camel_case();
+                let private_type_name = type_name.to_snake_case();
+                self.src
+                    .push_str(&format!("//export {namespace}_{snake}_destructor\n"));
+                uwriteln!(
+                    self.src,
+                    "func {func_name}Destructor(self *C.{c_typedef_target}) {{
+                        {private_type_name} := {private_type_name}_pointers[int32(self.__handle)]
+                        {private_type_name}_to_own_handlers.Delete({private_type_name})
+                        delete({private_type_name}_pointers, int32(self.__handle))
+                        C.free(unsafe.Pointer(self))
+                    }}
+                    ",
+                );
+
+                self.gen.with_import_unsafe(true);
+
+                // generate [resource-drop] function
+                uwriteln!(
+                    self.src,
+                    "func Drop{type_name}(self {type_name}) {{
+                        owningHandler := get{type_name}OwningHandler(self)
+                        var cOwningHandler C.{own}
+                        cOwningHandler.__handle = C.int32_t(owningHandler)
+                        C.{private_type_name}_drop_own(cOwningHandler)
+                    }}
+                    ",
+                );
+
+                // book keep the exported resource type
+                self.exported_resources.insert(id);
+                self.gen.exported_resources.insert(id);
+            }
+        };
     }
 
     fn type_flags(

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -78,6 +78,7 @@ impl TinyGo {
         &'a mut self,
         resolve: &'a Resolve,
         direction: Direction,
+        wasm_import_module: Option<&'a str>,
     ) -> interface::InterfaceGenerator<'a> {
         interface::InterfaceGenerator {
             src: Source::default(),
@@ -89,6 +90,7 @@ impl TinyGo {
             export_funcs: Default::default(),
             exported_resources: Default::default(),
             methods: Default::default(),
+            wasm_import_module,
         }
     }
 
@@ -163,7 +165,7 @@ impl WorldGenerator for TinyGo {
             .push_str(&format!("// Import functions from {name_raw}\n"));
         self.interface_names.insert(id, name.clone());
 
-        let mut gen = self.interface(resolve, Direction::Import);
+        let mut gen = self.interface(resolve, Direction::Import, Some(name_raw));
         gen.interface = Some((id, name));
         gen.define_interface_types(id);
 
@@ -188,7 +190,7 @@ impl WorldGenerator for TinyGo {
         self.src
             .push_str(&format!("// Import functions from {name}\n"));
 
-        let mut gen = self.interface(resolve, Direction::Import);
+        let mut gen = self.interface(resolve, Direction::Import, Some("$root"));
         gen.define_function_types(funcs);
 
         for (_name, func) in funcs.iter() {
@@ -223,7 +225,7 @@ impl WorldGenerator for TinyGo {
         self.src
             .push_str(&format!("// Export functions from {name_raw}\n"));
 
-        let mut gen = self.interface(resolve, Direction::Export);
+        let mut gen = self.interface(resolve, Direction::Export, None);
         gen.interface = Some((id, name));
         gen.define_interface_types(id);
 
@@ -251,7 +253,7 @@ impl WorldGenerator for TinyGo {
         self.src
             .push_str(&format!("// Export functions from {name}\n"));
 
-        let mut gen = self.interface(resolve, Direction::Export);
+        let mut gen = self.interface(resolve, Direction::Export, None);
         gen.define_function_types(funcs);
 
         for (_name, func) in funcs.iter() {
@@ -274,7 +276,7 @@ impl WorldGenerator for TinyGo {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut gen = self.interface(resolve, Direction::Import);
+        let mut gen = self.interface(resolve, Direction::Import, Some("$root"));
         let mut live = LiveTypes::default();
         for (_, id) in types {
             live.add_type_id(resolve, *id);

--- a/tests/runtime/resource_borrow_import/wasm.go
+++ b/tests/runtime/resource_borrow_import/wasm.go
@@ -13,7 +13,9 @@ type Import struct{}
 
 func (e Import) Test(v uint32) uint32 {
 	thing := NewThing(v + 1)
+	defer thing.Drop()
 	return TestResourceBorrowImportTestFoo(thing) + 4
+	
 }
 
 func main() {}

--- a/tests/runtime/resource_borrow_simple/wasm.go
+++ b/tests/runtime/resource_borrow_simple/wasm.go
@@ -14,6 +14,7 @@ type Simple struct {}
 func (e Simple) TestImports() {
 	r := NewR()
 	ResourceBorrowSimpleTest(r)
+	r.Drop()
 }
 
 func main() {}

--- a/tests/runtime/resources/wasm.go
+++ b/tests/runtime/resources/wasm.go
@@ -69,6 +69,7 @@ func (e ExportsImpl) TestImports() Result[struct{}, string] {
 		panic("y.GetA() != 5")
 	}
 
+	y.Drop()
 	return Ok[struct{}, string](struct{}{})
 }
 


### PR DESCRIPTION
This commit adds the missing `[resource-drop]` imports for both imported and exported resources in wit-bindgen-go. 

**For import**, it implements a wasmimport directory that declares a drop function as an import. 
```
//go:wasmimport {import_module} [resource-drop]{name}
func _{type_name}_drop(self {type_name})
```
Then the resource can use `Drop()` function to drop their handle. See updated runtime tests for this new update. 

**For exports**, the story is a big different. Although I have implemented `Drop<Resourc Name>()` function for each exported resource, I do not find a use case that could utilize this function. Perhaps I am missing something. Nevertheless, I added this function in the generated code which invokes C's drop function given the `owning` handler type. 



