### PR TITLE
C#: Add implementation for lowering and lifiting flags

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1164,14 +1164,6 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
 
         let name = name.to_upper_camel_case();
 
-        let ty = match flags.repr() {
-            FlagsRepr::U8 => "byte",
-            FlagsRepr::U16 => "ushort",
-            FlagsRepr::U32(1) => "uint",
-            FlagsRepr::U32(2) => "ulong",
-            repr => todo!("flags {repr:?}"),
-        };
-
         let enum_elements = flags
             .flags
             .iter()
@@ -1500,9 +1492,14 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 ty: _,
             } => {
                 if flags.flags.len() > 32 {
-                    results.push(format!("((int){})", operands[0].to_string()));
+                    results.push(format!(
+                        "(int)(((long){}) & uint.MaxValue)",
+                        operands[0].to_string()
+                    ));
+                    results.push(format!("((int)({})) >> 32", operands[0].to_string()));
+                } else {
+                    results.push(format!("(int){}", operands[0].to_string()));
                 }
-                results.push(format!("((int){})", operands[0].to_string()));
             }
 
             Instruction::FlagsLift { flags, name, ty } => {

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1171,7 +1171,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             .map(|(i, flag)| {
                 let flag_name = flag.name.to_shouty_snake_case();
                 let suffix = if matches!(flags.repr(), FlagsRepr::U32(2)) {
-                    "L"
+                    "UL"
                 } else {
                     ""
                 };
@@ -1180,10 +1180,11 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let enum_type = if matches!(flags.repr(), FlagsRepr::U32(2)) {
-            ": long"
-        } else {
-            ""
+        let enum_type = match flags.repr() {
+            FlagsRepr::U32(2) => ": ulong",
+            FlagsRepr::U16 => ": ushort",
+            FlagsRepr::U8 => ": byte",
+            _ => "",
         };
 
         uwrite!(

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -363,14 +363,14 @@ impl WorldGenerator for CSharp {
     
                         private int GetS32(int offset)
                         {{
-                            ReadOnlySpan<byte> span = this;
+                            ReadOnlySpan<byte> span = MemoryMarshal.CreateSpan(ref buffer, {});
 
                             return BitConverter.ToInt32(span.Slice(offset, 4));
                         }}
                         
                         public void SetS32(int offset, int value)
                         {{
-                            Span<byte> span = this;
+                            Span<byte> span = MemoryMarshal.CreateSpan(ref buffer, {});
 
                             BitConverter.TryWriteBytes(span.Slice(offset), value);
                         }}
@@ -394,6 +394,8 @@ impl WorldGenerator for CSharp {
                     ",
                     self.return_area_size,
                     self.return_area_align,
+                    self.return_area_size,
+                    self.return_area_size
                 );
 
                 src.push_str(&ret_area_str);
@@ -582,8 +584,12 @@ impl InterfaceGenerator<'_> {
     fn qualifier(&self, when: bool, ty: &TypeDef) -> String {
         if let TypeOwner::Interface(id) = &ty.owner {
             if let Some(name) = self.gen.interface_names.get(id) {
-                if name != self.name {
-                    return format!("{}.", name);
+                let name_with_interface = format!(
+                    "{name}.I{}",
+                    CSharp::get_class_name_from_qualified_name(name.clone())
+                );
+                if name_with_interface != self.name {
+                    return format!("{}.", name_with_interface);
                 }
             }
         }
@@ -617,7 +623,7 @@ impl InterfaceGenerator<'_> {
                 r#"
                 private unsafe struct ReturnArea
                 {{
-                    private int GetS32(IntPtr ptr, int offset)
+                    public int GetS32(IntPtr ptr, int offset)
                     {{
                         var span = new Span<byte>((void*)ptr, {});
 
@@ -665,14 +671,14 @@ impl InterfaceGenerator<'_> {
     
                         private int GetS32(int offset)
                         {{
-                            ReadOnlySpan<byte> span = this;
+                            ReadOnlySpan<byte> span = MemoryMarshal.CreateSpan(ref buffer, {});
 
                             return BitConverter.ToInt32(span.Slice(offset, 4));
                         }}
                         
                         public void SetS32(int offset, int value)
                         {{
-                            Span<byte> span = this;
+                            Span<byte> span = MemoryMarshal.CreateSpan(ref buffer, {});
 
                             BitConverter.TryWriteBytes(span.Slice(offset), value);
                         }}
@@ -696,6 +702,8 @@ impl InterfaceGenerator<'_> {
                     ",
                 self.gen.return_area_size,
                 self.gen.return_area_align,
+                self.gen.return_area_size,
+                self.gen.return_area_size
             );
 
             self.csharp_interop_src.push_str(&ret_area_str);
@@ -727,7 +735,7 @@ impl InterfaceGenerator<'_> {
             0 => "void".to_string(),
             1 => {
                 let ty = func.results.iter_types().next().unwrap();
-                self.type_name(ty)
+                self.type_name_with_qualifier(ty, true)
             }
             _ => unreachable!(), //TODO
         };
@@ -1164,7 +1172,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             repr => todo!("flags {repr:?}"),
         };
 
-        let flags = flags
+        let enum_elements = flags
             .flags
             .iter()
             .enumerate()
@@ -1175,24 +1183,22 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 } else {
                     ""
                 };
-                format!(
-                    "public static readonly {name} {flag_name} = new {name}(({ty}) (1{suffix} << {i}));"
-                )
+                format!("{flag_name} = 1{suffix} << {i},")
             })
             .collect::<Vec<_>>()
             .join("\n");
 
+        let enum_type = if matches!(flags.repr(), FlagsRepr::U32(2)) {
+            ": long"
+        } else {
+            ""
+        };
+
         uwrite!(
             self.src,
             "
-            public static class {name} {{
-                public readonly {ty} value;
-
-                public {name}({ty} value) {{
-                    this.value = value;
-                }}
-
-                {flags}
+            public enum {name} {enum_type} {{
+                {enum_elements}
             }}
             "
         );
@@ -1426,7 +1432,13 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 .to_owned()
             })),
 
-            Instruction::I32Load { offset } => results.push(format!("returnArea.GetS32({offset})")),
+            Instruction::I32Load { offset } => {
+                if self.gen.in_import {
+                    results.push(format!("returnArea.GetS32(ptr, {offset})"))
+                } else {
+                    results.push(format!("returnArea.GetS32({offset})"))
+                }
+            }
             Instruction::I32Load8U { offset } => {
                 results.push(format!("returnArea.GetU8({offset})"))
             }
@@ -1482,9 +1494,35 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             }
             Instruction::BoolFromI32 => results.push(format!("({} != 0)", operands[0])),
 
-            Instruction::FlagsLower { .. } => todo!("FlagsLower"),
+            Instruction::FlagsLower {
+                flags,
+                name: _,
+                ty: _,
+            } => {
+                if flags.flags.len() > 32 {
+                    results.push(format!("((int){})", operands[0].to_string()));
+                }
+                results.push(format!("((int){})", operands[0].to_string()));
+            }
 
-            Instruction::FlagsLift { .. } => todo!("FlagsLift"),
+            Instruction::FlagsLift { flags, name, ty } => {
+                let id_type = &self.gen.resolve.types[*ty];
+                let qualified_type_name = format!(
+                    "{}{}",
+                    self.gen.qualifier(true, id_type),
+                    name.to_string().to_upper_camel_case()
+                );
+                if flags.flags.len() > 32 {
+                    results.push(format!(
+                        "({})((long)({}) << 32 | (uint)({}))",
+                        qualified_type_name,
+                        operands[0].to_string(),
+                        operands[1].to_string()
+                    ));
+                } else {
+                    results.push(format!("({})({})", qualified_type_name, operands[0]))
+                }
+            }
 
             Instruction::RecordLower { .. } => todo!("RecordLower"),
             Instruction::RecordLift { .. } => todo!("RecordLift"),

--- a/crates/csharp/tests/codegen.rs
+++ b/crates/csharp/tests/codegen.rs
@@ -17,7 +17,6 @@ macro_rules! codegen_test {
                 |resolve, world, files| {
                     if [
                         "conventions",
-                        "flags",
                         "guest-name",
                         "import-and-export-resource",
                         "import-and-export-resource-alias",

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,7 @@ wasm and executed on hosts. The code compiled-to-wasm can be one of:
 * `wasm.rs` - compiled with Rust to WebAssembly
 * `wasm.c` - compiled with Clang
 * `wasm.java` - compiled with TeaVM-WASI
+* `wasm.cs` - compiled with NativeAOT and Mono
 
 Existence of these files indicates that the language should be supported for the
 test, and if a file is missing then it's skipped when running other tests. Each

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,12 @@ To run just `codegen` tests for a single language (replace rust with language of
 cargo test -p wit-bindgen-rust
 ```
 
+To run just `codegen` tests for a single language (replace rust with language of choice: `go`, `c`, `csharp`, etc.) and a single wit file (replace `flags` with whatever wit file should be tested):
+
+```
+cargo test -p wit-bindgen-rust -- flags
+```
+
 To run just `runtime` tests for a single language (replace rust with language of choice: `go`, `c`, `csharp`, etc.):
 
 ```bash


### PR DESCRIPTION
.. and enable the corresponding codegen test.  Implemented in c# as `enum`s.

(contributes to making the `records` runtime test pass)

cc @silesmo @jsturtevant 