### PR TITLE
c: Automatically drop borrows of external resources in exports

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -44,8 +44,8 @@ pub struct ResourceInfo {
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum Enabled {
     #[default]
-    Yes,
     No,
+    Yes,
 }
 
 impl std::fmt::Display for Enabled {
@@ -92,7 +92,7 @@ pub struct Opts {
     pub type_section_suffix: Option<String>,
 
     /// Configure the autodropping of borrows in exported functions.
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = Enabled::Yes))]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub autodrop_borrows: Enabled,
 }
 

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -40,7 +40,8 @@ pub struct ResourceInfo {
     drop_fn: String,
 }
 
-#[derive(Default, Debug, Eq, PartialEq, Clone, Copy, clap::ValueEnum)]
+#[derive(Default, Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum Enabled {
     #[default]
     Yes,

--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -30,6 +30,16 @@ macro_rules! codegen_test {
                 },
                 verify,
             );
+            test_helpers::run_world_codegen_test(
+                "guest-c-autodrop-borrows",
+                $test.as_ref(),
+                |resolve, world, files| {
+                    let mut opts = wit_bindgen_c::Opts::default();
+                    opts.autodrop_borrows = wit_bindgen_c::Enabled::Yes;
+                    opts.build().generate(resolve, world, files).unwrap()
+                },
+                verify,
+            );
         }
     };
 }

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -349,7 +349,6 @@ impl WorldGenerator for TinyGo {
         let mut opts = wit_bindgen_c::Opts::default();
         opts.no_sig_flattening = true;
         opts.no_object_file = true;
-        opts.autodrop_borrows = wit_bindgen_c::Enabled::No;
         opts.build()
             .generate(resolve, id, files)
             .expect("C generator should be infallible")

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -349,6 +349,7 @@ impl WorldGenerator for TinyGo {
         let mut opts = wit_bindgen_c::Opts::default();
         opts.no_sig_flattening = true;
         opts.no_object_file = true;
+        opts.autodrop_borrows = wit_bindgen_c::Enabled::No;
         opts.build()
             .generate(resolve, id, files)
             .expect("C generator should be infallible")


### PR DESCRIPTION
Instead of requiring that the embedder know when it's necessary to drop a borrow of a resource, automatically insert them where necessary. As this isn't always possible to automatically drop borrows with this implementation, the behavior can be disabled with the `--autodrop-borrows=no` flag, going back to the current state of requiring explicit drops for borrows of imported resources given to exports.
