### PR TITLE
add `--rename-world` and `--type-section-suffix` options to C generator

### DIFF
--- a/crates/c/src/component_type_object.rs
+++ b/crates/c/src/component_type_object.rs
@@ -12,7 +12,13 @@ pub fn linking_symbol(name: &str) -> String {
     format!("__component_type_object_force_link_{snake}")
 }
 
-pub fn object(resolve: &Resolve, world: WorldId, encoding: StringEncoding) -> Result<Vec<u8>> {
+pub fn object(
+    resolve: &Resolve,
+    world: WorldId,
+    world_name: &str,
+    encoding: StringEncoding,
+    suffix: Option<&str>,
+) -> Result<Vec<u8>> {
     let mut module = Module::new();
 
     // Build a module with one function that's a "dummy function"
@@ -41,8 +47,7 @@ pub fn object(resolve: &Resolve, world: WorldId, encoding: StringEncoding) -> Re
     // otherwise is attempted to be unique here to ensure that this doesn't get
     // concatenated to other custom sections by LLD by accident since LLD will
     // concatenate custom sections of the same name.
-    let world_name = &resolve.worlds[world].name;
-    let section_name = format!("component-type:{world_name}");
+    let section_name = format!("component-type:{world_name}{}", suffix.unwrap_or(""));
 
     // Add our custom section
     module.section(&CustomSection {


### PR DESCRIPTION
These are both useful for supporting the `wasm32-wasi-preview2` target in `wasi-libc`.

- `--rename-world` lets us give the files more meaningful names than e.g. "imports.h" when generating bindings for `wasi:cli/imports`
- `--type-section-suffix` lets us provide a suffix for the component type custom section name per #788

Ideally, both of those options would be available for all the applicable generators, but for now I'm focused on the C generator given its use in `wasi-libc`.