### PR TITLE
fix(C): Resource name in import should be the original name

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1024,7 +1024,7 @@ void {ns}_{snake}_destructor({ty_name} *rep);
 __attribute__(( __import_module__("[export]{module}"), __import_name__("[resource-new]{name}")))
 extern int32_t __wasm_import_{ns}_{snake}_new(int32_t);
 
-__attribute__((__import_module__("[export]{module}"), __import_name__("[resource-rep]{snake}")))
+__attribute__((__import_module__("[export]{module}"), __import_name__("[resource-rep]{name}")))
 extern int32_t __wasm_import_{ns}_{snake}_rep(int32_t);
 
 {own} {ns}_{snake}_new({ty_name} *rep) {{

--- a/crates/go/src/bindgen.rs
+++ b/crates/go/src/bindgen.rs
@@ -342,7 +342,8 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
                                 let snake = self.interface.resolve.types[resource]
                                     .name
                                     .as_ref()
-                                    .unwrap();
+                                    .unwrap()
+                                    .to_snake_case();
                                 // If the resource is exported, then `type_resource` have created a
                                 // internal bookkeeping map for this resource. We will need to
                                 // use the map to get the resource interface. Otherwise, this resource
@@ -371,14 +372,14 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
                                         Own(_) => {
                                             let mut own = ns.clone();
                                             own.push_str("_own_");
-                                            own.push_str(snake);
+                                            own.push_str(&snake);
                                             own.push_str("_t");
                                             own
                                         }
                                         Borrow(_) => {
                                             let mut borrow = ns.clone();
                                             borrow.push_str("_borrow_");
-                                            borrow.push_str(snake);
+                                            borrow.push_str(&snake);
                                             borrow.push_str("_t");
                                             borrow
                                         }
@@ -639,7 +640,8 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
                                 let snake = self.interface.resolve.types[resource]
                                     .name
                                     .as_ref()
-                                    .unwrap();
+                                    .unwrap()
+                                    .to_snake_case();
                                 if self.interface.gen.exported_resources.contains(&resource) {
                                     let resource_name: String =
                                         self.interface.get_ty(&Type::Id(resource)).to_snake_case();

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -1060,10 +1060,14 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 // generate a typedef struct for export resource
                 let c_typedef_target = self.gen.c_type_names[&id].clone();
                 let ns = self.c_namespace_of_resource(id);
-                let snake = self.resolve.types[id].name.as_ref().unwrap();
+                let snake = self.resolve.types[id]
+                    .name
+                    .as_ref()
+                    .unwrap()
+                    .to_snake_case();
                 let mut own = ns.clone();
                 own.push_str("_own_");
-                own.push_str(snake);
+                own.push_str(&snake);
                 own.push_str("_t");
 
                 // generate a typedef struct for export resource

--- a/tests/runtime/resources/wasm.c
+++ b/tests/runtime/resources/wasm.c
@@ -11,6 +11,10 @@ struct exports_z_t {
     int32_t a;
 };
 
+struct exports_kebab_case_t {
+    int32_t a;
+};
+
 exports_own_x_t exports_constructor_x(int32_t a) {
     exports_x_t* x_instance = (exports_x_t*)malloc(sizeof(exports_x_t));
     x_instance->a = a;
@@ -55,6 +59,23 @@ void exports_x_destructor(exports_x_t* x) {
 void exports_z_destructor(exports_z_t* z) {
     free(z);
 }
+
+exports_own_kebab_case_t exports_constructor_kebab_case(uint32_t a) {
+    exports_kebab_case_t* kc_instance = (exports_kebab_case_t*)malloc(sizeof(exports_kebab_case_t));
+    kc_instance->a = a;
+    exports_own_kebab_case_t kc_own = exports_kebab_case_new(kc_instance);
+    return kc_own;
+}
+
+uint32_t exports_method_kebab_case_get_a(exports_borrow_kebab_case_t self) {
+    return self->a;
+}
+
+uint32_t exports_static_kebab_case_take_owned(exports_own_kebab_case_t k) {
+    return exports_kebab_case_rep(k)->a;
+}
+
+void exports_kebab_case_destructor(exports_kebab_case_t *rep) {}
 
 bool exports_test_imports(resources_string_t *err) {
     imports_own_y_t y = imports_constructor_y(10);

--- a/tests/runtime/resources/wasm.go
+++ b/tests/runtime/resources/wasm.go
@@ -20,12 +20,20 @@ type MyZ struct {
 	a int32
 }
 
+type MyKebabCase struct {
+	a uint32
+}
+
 func (e ExportsImpl) ConstructorX(a int32) ExportsX {
 	return &MyX{a: a}
 }
 
 func (e ExportsImpl) ConstructorZ(a int32) ExportsZ {
 	return &MyZ{a: a}
+}
+
+func (e ExportsImpl) ConstructorKebabCase(a uint32) ExportsKebabCase {
+	return &MyKebabCase{a: a}
 }
 
 func (x *MyX) MethodXGetA() int32 {
@@ -46,6 +54,14 @@ func (z *MyZ) MethodZGetA() int32 {
 
 func (e ExportsImpl) Add(z ExportsZ, b ExportsZ) ExportsZ {
 	return &MyZ{a: z.MethodZGetA() + b.MethodZGetA()}
+}
+
+func (k *MyKebabCase) MethodKebabCaseGetA() uint32 {
+	return k.a
+}
+
+func (e ExportsImpl) StaticKebabCaseTakeOwned(k ExportsKebabCase) uint32 {
+	return k.MethodKebabCaseGetA()
 }
 
 func (e ExportsImpl) TestImports() Result[struct{}, string] {

--- a/tests/runtime/resources/wasm.rs
+++ b/tests/runtime/resources/wasm.rs
@@ -7,10 +7,12 @@ wit_bindgen::generate!({
         "exports": Test,
         "exports/x": ComponentX,
         "exports/z": ComponentZ,
+        "exports/kebab-case": ComponentKebabCase,
     }
 });
 
 use exports::exports::OwnX;
+use exports::exports::OwnKebabCase;
 
 pub struct Test {}
 
@@ -20,6 +22,10 @@ pub struct ComponentX {
 
 pub struct ComponentZ {
     val: i32,
+}
+
+pub struct ComponentKebabCase {
+    val: u32,
 }
 
 impl exports::exports::Guest for Test {
@@ -76,5 +82,18 @@ impl exports::exports::GuestZ for ComponentZ {
     }
     fn get_a(&self) -> i32 {
         self.val
+    }
+}
+
+impl exports::exports::GuestKebabCase for ComponentKebabCase {
+    fn new(a: u32) -> Self {
+        Self { val: a }
+    }
+    fn get_a(&self) -> u32 {
+        self.val
+    }
+
+    fn take_owned(k: OwnKebabCase) -> u32 {
+        k.get_a()
     }
 }

--- a/tests/runtime/resources/world.wit
+++ b/tests/runtime/resources/world.wit
@@ -25,6 +25,12 @@ world resources {
 
     add: func(a: borrow<z>, b: borrow<z>) -> own<z>;
 
+    resource kebab-case {
+      constructor(a: u32);
+      get-a: func() -> u32;
+      take-owned: static func(k: own<kebab-case>) -> u32;
+    }
+
     test-imports: func() -> result<_, string>;
   }
 }


### PR DESCRIPTION
The wrong import name makes an invalid component and `wasm-tools component new` fails

```
    0: import of `[resource-rep]rb_abi_value` is not a valid resource function
```