### PR TITLE
test(c#): Add version runtime test

### DIFF
--- a/crates/csharp/README.txt
+++ b/crates/csharp/README.txt
@@ -1,3 +1,15 @@
 // generate the c# and the component meta module
 
 cargo run c-sharp  --string-encoding utf8 --out-dir testing-csharp tests/codegen/floats.wit
+
+// to run the runtime tests with Native AOT, you need some additional set up
+
+// install emscripten
+curl.exe -OL https://github.com/emscripten-core/emsdk/archive/refs/heads/main.zip
+unzip main.zip
+cd .\emsdk-main\main\emsdk-main
+.\emsdk_env.ps1 activate 3.1.23 --permanant
+
+// install wasi-sdk and set env
+curl.exe -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz | tar xzvf -
+$env:WASI_SDK_PATH="c:\users\jstur\wasi-sdk-20.0+m\"

--- a/tests/runtime/versions/wasm.cs
+++ b/tests/runtime/versions/wasm.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
 using v1 = wit_foo.wit.imports.test.dep.v0_1_0.Test;
 using v2 = wit_foo.wit.imports.test.dep.v0_2_0.Test;
 
-namespace wit_foo;
+namespace wit_foo {
 
 public class FooWorldImpl : IFooWorld
 {
@@ -17,25 +15,32 @@ public class FooWorldImpl : IFooWorld
         Debug.Assert(v2.TestInterop.Z(1.0f, 1.0f) == 4.0f);
     }
 }
-
-public class TestV1Impl : wit_foo.wit.exports.test.dep.v0_1_0.Test.ITest
-{
-    public static float X() {
-        return 1.0f;
-    }
-    
-    static abstract float Y(float a){
-        return a + 1.0f;
-        }
 }
 
-public class TestImpl : wit_foo.wit.exports.test.dep.v0_2_0.Test.ITest
-{
-    public static float X() {
-        return 2.0f;
+namespace wit_foo.wit.exports.test.dep.v0_1_0.Test {
+
+
+    public class TestImpl : wit_foo.wit.exports.test.dep.v0_1_0.Test.ITest
+    {
+        public static float X() {
+            return 1.0f;
+        }
+        
+        public static float Y(float a){
+            return a + 1.0f;
+        }
     }
-    
-    public static float Z(float a, float b){
-        return a + b + 2.0f;
+}
+
+namespace wit_foo.wit.exports.test.dep.v0_2_0.Test {
+    public class TestImpl : wit_foo.wit.exports.test.dep.v0_2_0.Test.ITest
+    {
+        public static float X() {
+            return 2.0f;
+        }
+        
+        public static float Z(float a, float b){
+            return a + b + 2.0f;
+        }
     }
 }

--- a/tests/runtime/versions/wasm.cs
+++ b/tests/runtime/versions/wasm.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using v1 = wit_foo.wit.imports.test.dep.v0_1_0.Test;
+using v2 = wit_foo.wit.imports.test.dep.v0_2_0.Test;
+
+namespace wit_foo;
+
+public class FooWorldImpl : IFooWorld
+{
+    public static void TestImports()
+    {
+        Debug.Assert(v1.TestInterop.X() == 1.0f);
+        Debug.Assert(v1.TestInterop.Y(1.0f) == 2.0f);
+
+        Debug.Assert(v2.TestInterop.X() == 2.0f);
+        Debug.Assert(v2.TestInterop.Z(1.0f, 1.0f) == 4.0f);
+    }
+}
+
+public class TestV1Impl : wit_foo.wit.exports.test.dep.v0_1_0.Test.ITest
+{
+    public static float X() {
+        return 1.0f;
+    }
+    
+    static abstract float Y(float a){
+        return a + 1.0f;
+        }
+}
+
+public class TestImpl : wit_foo.wit.exports.test.dep.v0_2_0.Test.ITest
+{
+    public static float X() {
+        return 2.0f;
+    }
+    
+    public static float Z(float a, float b){
+        return a + b + 2.0f;
+    }
+}


### PR DESCRIPTION
This is the follow up to https://github.com/bytecodealliance/wit-bindgen/pull/787#issuecomment-1858242419 now that #791 has fixed c# imports.

