### PR TITLE
use "<a></a>Content" instead of "<a>Content</a>"

### DIFF
--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -121,7 +121,7 @@ impl WorldGenerator for Markdown {
         let name = resolve.name_world_key(name);
         uwriteln!(
             self.src,
-            "## <a name=\"{}\">Import interface {name}</a>\n",
+            "## <a name=\"{}\"></a>Import interface {name}\n",
             name.to_snake_case()
         );
         self.hrefs
@@ -158,7 +158,7 @@ impl WorldGenerator for Markdown {
         let name = resolve.name_world_key(name);
         uwriteln!(
             self.src,
-            "## <a name=\"{}\">Export interface {name}</a>\n",
+            "## <a name=\"{}\"></a>Export interface {name}\n",
             name.to_snake_case()
         );
         self.hrefs
@@ -261,14 +261,14 @@ impl InterfaceGenerator<'_> {
 
     fn func(&mut self, func: &Function) {
         self.push_str(&format!(
-            "#### <a name=\"{0}\">`",
+            "#### <a name=\"{0}\"></a>`",
             func.name.to_snake_case()
         ));
         self.gen
             .hrefs
             .insert(func.name.clone(), format!("#{}", func.name.to_snake_case()));
         self.push_str(&func.name);
-        self.push_str(": func`</a>");
+        self.push_str(": func`");
         self.push_str("\n\n");
         self.docs(&func.docs);
 
@@ -277,7 +277,7 @@ impl InterfaceGenerator<'_> {
             self.push_str("##### Params\n\n");
             for (name, ty) in func.params.iter() {
                 self.push_str(&format!(
-                    "- <a name=\"{f}.{p}\">`{}`</a>: ",
+                    "- <a name=\"{f}.{p}\"></a>`{}`: ",
                     name,
                     f = func.name.to_snake_case(),
                     p = name.to_snake_case(),
@@ -293,7 +293,7 @@ impl InterfaceGenerator<'_> {
                 Results::Named(params) => {
                     for (name, ty) in params.iter() {
                         self.push_str(&format!(
-                            "- <a name=\"{f}.{p}\">`{}`</a>: ",
+                            "- <a name=\"{f}.{p}\"></a>`{}`: ",
                             name,
                             f = func.name.to_snake_case(),
                             p = name,
@@ -465,7 +465,7 @@ impl InterfaceGenerator<'_> {
             self.types_header_printed = true;
         }
         self.push_str(&format!(
-            "#### <a name=\"{}\">`{} {}`</a>\n",
+            "#### <a name=\"{}\"></a>`{} {}`\n",
             name.to_snake_case(),
             type_,
             name,
@@ -488,7 +488,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.push_str("\n##### Record Fields\n\n");
         for field in record.fields.iter() {
             self.push_str(&format!(
-                "- <a name=\"{r}.{f}\">`{name}`</a>: ",
+                "- <a name=\"{r}.{f}\"></a>`{name}`: ",
                 r = name.to_snake_case(),
                 f = field.name.to_snake_case(),
                 name = field.name,
@@ -521,7 +521,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.push_str("\n##### Tuple Fields\n\n");
         for (i, ty) in tuple.types.iter().enumerate() {
             self.push_str(&format!(
-                "- <a name=\"{r}.{f}\">`{name}`</a>: ",
+                "- <a name=\"{r}.{f}\"></a>`{name}`: ",
                 r = name.to_snake_case(),
                 f = i,
                 name = i,
@@ -542,7 +542,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.push_str("\n##### Flags members\n\n");
         for flag in flags.flags.iter() {
             self.push_str(&format!(
-                "- <a name=\"{r}.{f}\">`{name}`</a>: ",
+                "- <a name=\"{r}.{f}\"></a>`{name}`: ",
                 r = name.to_snake_case(),
                 f = flag.name.to_snake_case(),
                 name = flag.name,
@@ -568,7 +568,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.push_str("\n##### Variant Cases\n\n");
         for case in variant.cases.iter() {
             self.push_str(&format!(
-                "- <a name=\"{v}.{c}\">`{name}`</a>",
+                "- <a name=\"{v}.{c}\"></a>`{name}`",
                 v = name.to_snake_case(),
                 c = case.name.to_snake_case(),
                 name = case.name,
@@ -598,7 +598,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.push_str("\n##### Enum Cases\n\n");
         for case in enum_.cases.iter() {
             self.push_str(&format!(
-                "- <a name=\"{v}.{c}\">`{name}`</a>",
+                "- <a name=\"{v}.{c}\"></a>`{name}`",
                 v = name.to_snake_case(),
                 c = case.name.to_snake_case(),
                 name = case.name,


### PR DESCRIPTION
Why this is a good idea:
- Makes it much easier to apply classless CSS to the resulting HTML
- Conform with ecosystem convention

All of these classless CSS frameworks style all `<a>` tags the same. https://github.com/dbohdan/classless-css

ALL OF THEM treat `<a>` as "a link" even if it has no href. This is usually what you want since you might apply an `onclick` that you want to appear as a phantom link. This isn't the case with `<a name="...">` in the generated HTML from `wit-bindgen markdown`. I suggest instead following a precedent of empty `<a name="...">` tags.

This `<a name=""></a>` thing has been done before. Quite a lot actually. https://github.com/search?q=%2F%3Ca%20name%3D%5B%22%27%5D.%2B%5B%22%27%5D%3E%3C%5C%2Fa%3E%2F&type=code

Consider:

Before:
![image](https://github.com/bytecodealliance/wit-bindgen/assets/61068799/6301f9c3-d7b0-44dc-a3b7-0f0bc6888d3d)

After:
![image](https://github.com/bytecodealliance/wit-bindgen/assets/61068799/867a7e23-c61e-4fcf-a951-f95c7929171b)

Imagine a whole page full of phantom links and you can see why I want to make this change.

This would still preserve the `page.html#the-thing` of the `<a name="the-thing"></a>` while making it compatible with the vast majority of CSS that already exists in the ecosystem of classless whole-page CSS presets.

Yes, you can solve this by using `:any-link { ... }` https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link but realistically I'm not going to open 100+ PRs on projects that are one-and-done and don't get any more attention -- CSS presets rarely seem to get updated after they are pretty enough. It's much easier just to tweak the generation here to conform to ecosystem expectations.

Alternatives:
- Add custom CSS to the generated HTML that accounts for this. This could be as basic as forking one of the existing classless CSS projects and tweaking it and then using the resulting style.css in the generated HTML. But that's more in wit-doc territory, not `wit-bindgen markdown`.