### PR TITLE
Add runtime test for options

### DIFF
--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -45,6 +45,10 @@ name = "results"
 test = false
 
 [[bin]]
+name = "options"
+test = false
+
+[[bin]]
 name = "owning"
 test = false
 

--- a/crates/test-rust-wasm/src/bin/options.rs
+++ b/crates/test-rust-wasm/src/bin/options.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/options/wasm.rs");
+
+fn main() {}

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -16,6 +16,7 @@ mod flavorful;
 mod lists;
 mod many_arguments;
 mod numbers;
+mod options;
 mod other_dependencies;
 mod ownership;
 mod records;

--- a/tests/runtime/options.rs
+++ b/tests/runtime/options.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use wasmtime::Store;
+
+wasmtime::component::bindgen!(in "tests/runtime/options");
+
+#[derive(Default)]
+pub struct MyImports;
+
+impl test::options::test::Host for MyImports {
+    fn option_none_param(&mut self, a: Option<String>) -> Result<()> {
+        assert!(a.is_none());
+        Ok(())
+    }
+  
+    fn option_none_result(&mut self) -> Result<Option<String>> {
+        Ok(None)
+    }
+  
+    fn option_some_param(&mut self, a: Option<String>) -> Result<()> {        
+        assert_eq!(a, Some("foo".to_string()));
+        Ok(())
+    }
+  
+    fn option_some_result(&mut self) -> Result<Option<String>> {
+        Ok(Some("foo".to_string()))
+    }
+
+    fn option_roundtrip(&mut self, a: Option<String>) -> Result<Option<String>> {
+        Ok(a)
+    }
+
+}
+
+#[test]
+fn run() -> Result<()> {
+    crate::run_test(
+        "options",
+        |linker| Options::add_to_linker(linker, |x| &mut x.0),
+        |store, component, linker| Options::instantiate(store, component, linker),
+        run_test,
+    )
+}
+
+fn run_test(exports: Options, store: &mut Store<crate::Wasi<MyImports>>) -> Result<()> {
+    exports.call_test_imports(&mut *store)?;
+    let exports = exports.test_options_test();
+    assert!(exports.call_option_none_result(&mut *store)?.is_none());
+    assert_eq!(exports.call_option_some_result(&mut *store)?, Some("foo".to_string()));
+    exports.call_option_none_param(&mut *store, None)?;
+    exports.call_option_some_param(&mut *store, Some("foo"))?;
+    assert_eq!(exports.call_option_roundtrip(&mut *store,Some("foo"))?, Some("foo".to_string()));
+    Ok(())
+}

--- a/tests/runtime/options.rs
+++ b/tests/runtime/options.rs
@@ -11,16 +11,16 @@ impl test::options::test::Host for MyImports {
         assert!(a.is_none());
         Ok(())
     }
-  
+
     fn option_none_result(&mut self) -> Result<Option<String>> {
         Ok(None)
     }
-  
-    fn option_some_param(&mut self, a: Option<String>) -> Result<()> {        
+
+    fn option_some_param(&mut self, a: Option<String>) -> Result<()> {
         assert_eq!(a, Some("foo".to_string()));
         Ok(())
     }
-  
+
     fn option_some_result(&mut self) -> Result<Option<String>> {
         Ok(Some("foo".to_string()))
     }
@@ -28,7 +28,6 @@ impl test::options::test::Host for MyImports {
     fn option_roundtrip(&mut self, a: Option<String>) -> Result<Option<String>> {
         Ok(a)
     }
-
 }
 
 #[test]
@@ -45,9 +44,15 @@ fn run_test(exports: Options, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
     exports.call_test_imports(&mut *store)?;
     let exports = exports.test_options_test();
     assert!(exports.call_option_none_result(&mut *store)?.is_none());
-    assert_eq!(exports.call_option_some_result(&mut *store)?, Some("foo".to_string()));
+    assert_eq!(
+        exports.call_option_some_result(&mut *store)?,
+        Some("foo".to_string())
+    );
     exports.call_option_none_param(&mut *store, None)?;
     exports.call_option_some_param(&mut *store, Some("foo"))?;
-    assert_eq!(exports.call_option_roundtrip(&mut *store,Some("foo"))?, Some("foo".to_string()));
+    assert_eq!(
+        exports.call_option_roundtrip(&mut *store, Some("foo"))?,
+        Some("foo".to_string())
+    );
     Ok(())
 }

--- a/tests/runtime/options/wasm.rs
+++ b/tests/runtime/options/wasm.rs
@@ -1,0 +1,43 @@
+wit_bindgen::generate!({
+  path: "../../tests/runtime/options",
+  exports: {
+      world: Component,
+      "test:options/test": Component
+  },
+});
+
+struct Component;
+
+impl Guest for Component {
+  fn test_imports() {
+      use test::options::test::*;
+
+      option_none_param(None);
+      option_some_param(Some("foo"));
+      assert!(option_none_result().is_none());
+      assert_eq!(option_some_result(), Some("foo".to_string()));
+      assert_eq!(option_roundtrip(Some("foo")), Some("foo".to_string()));
+  }
+}
+
+impl exports::test::options::test::Guest for Component {
+  fn option_none_param(a: Option<String>) {
+      assert!(a.is_none());
+  }
+
+  fn option_none_result() -> Option<String> {
+      None
+  }
+
+  fn option_some_param(a: Option<String>) {
+      assert_eq!(a, Some("foo".to_string()));
+  }
+
+  fn option_some_result() -> Option<String> {
+      Some("foo".to_string())
+  }
+
+  fn option_roundtrip(a: Option<String>) -> Option<String> {
+      a
+  }
+}

--- a/tests/runtime/options/world.wit
+++ b/tests/runtime/options/world.wit
@@ -1,0 +1,17 @@
+package test:options;
+
+interface test {
+  option-none-param: func(a: option<string>);
+  option-some-param: func(a: option<string>);
+  option-none-result: func() -> option<string>;
+  option-some-result: func() -> option<string>;
+
+  option-roundtrip: func(a: option<string>) -> option<string>;
+}
+
+world options {
+  import test;
+  export test;
+
+  export test-imports: func();
+}


### PR DESCRIPTION
Currently tests for options are embedded in other tests, this adds a dedicated runtime test for options.

cc: @jsturtevant 