### PR TITLE
Fix resource borrow aliasing case

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -432,13 +432,15 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     Handle::Borrow(resource) => ("&", resource),
                     Handle::Own(resource) => ("", resource),
                 };
-                let resource = dealias(resolve, *resource);
+
+                let dealiased_resource = dealias(resolve, *resource);
 
                 results.push(
-                    if let Direction::Export = self.gen.gen.resources[&resource].direction {
+                    if let Direction::Export = self.gen.gen.resources[&dealiased_resource].direction
+                    {
                         match handle {
                             Handle::Borrow(_) => {
-                                let name = resolve.types[resource]
+                                let name = resolve.types[*resource]
                                     .name
                                     .as_deref()
                                     .unwrap()
@@ -449,17 +451,17 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                                 )
                             }
                             Handle::Own(_) => {
-                                let name = self.gen.type_path(resource, true);
+                                let name = self.gen.type_path(dealiased_resource, true);
                                 format!("{name}::from_handle({op} as u32)")
                             }
                         }
                     } else if prefix == "" {
-                        let name = self.gen.type_path(resource, true);
+                        let name = self.gen.type_path(dealiased_resource, true);
                         format!("{name}::from_handle({op} as u32)")
                     } else {
                         let tmp = format!("handle{}", self.tmp());
                         self.handle_decls.push(format!("let {tmp};"));
-                        let name = self.gen.type_path(resource, true);
+                        let name = self.gen.type_path(dealiased_resource, true);
                         format!(
                             "{{\n
                                 {tmp} = {name}::from_handle({op} as u32);

--- a/tests/runtime/resource_alias.rs
+++ b/tests/runtime/resource_alias.rs
@@ -50,9 +50,13 @@ fn run_test(instance: ResourceAlias, store: &mut Store<crate::Wasi<()>>) -> anyh
             .x()
             .call_constructor(&mut *store, 8)?,
     };
+    let y = instance
+        .test_resource_alias_e1()
+        .x()
+        .call_constructor(&mut *store, 8)?;
     let _ = instance
         .test_resource_alias_e2()
-        .call_a(&mut *store, foo_e2, bar_e2)?;
+        .call_a(&mut *store, foo_e2, bar_e2, y)?;
 
     // TODO: how do I test deep equal of ResourceAny type?
     // assert_eq!(

--- a/tests/runtime/resource_alias/wasm.rs
+++ b/tests/runtime/resource_alias/wasm.rs
@@ -32,7 +32,8 @@ impl exports::test::resource_alias::e2::Guest for E2 {
     fn a(
         f: exports::test::resource_alias::e2::Foo,
         g: exports::test::resource_alias::e2::Bar,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias::e2::OwnX> {
+        h: &exports::test::resource_alias::e1::X,
+    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias::e2::OwnY> {
         vec![f.x, g.x]
     }
 }

--- a/tests/runtime/resource_alias/world.wit
+++ b/tests/runtime/resource_alias/world.wit
@@ -11,11 +11,11 @@ interface e1 {
 }
 
 interface e2 {
-  use e1.{x, foo as bar};
+  use e1.{x as y, foo as bar};
 
-  record foo { x: x }
+  record foo { x: y }
 
-  a: func(f: foo, g: bar) -> list<x>;
+  a: func(f: foo, g: bar, h: borrow<y>) -> list<y>;
 }
 
 world resource-alias {


### PR DESCRIPTION
This fixes a bug that came up in WASI-Virt where a borrowed alias of a resource would throw a compilation error.