### PR TITLE
Fix includes of WIT source files to be bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/crates/rust-macro/Cargo.toml
+++ b/crates/rust-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-bindgen-rust-macro"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 repository = 'https://github.com/bytecodealliance/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -176,13 +176,16 @@ impl Config {
         }
         let mut contents = src.parse::<TokenStream>().unwrap();
 
-        // Include a dummy `include_str!` for any files we read so rustc knows that
+        // Include a dummy `include_bytes!` for any files we read so rustc knows that
         // we depend on the contents of those files.
         for file in self.files.iter() {
             contents.extend(
-                format!("const _: &str = include_str!(r#\"{}\"#);\n", file.display())
-                    .parse::<TokenStream>()
-                    .unwrap(),
+                format!(
+                    "const _: &[u8] = include_bytes!(r#\"{}\"#);\n",
+                    file.display()
+                )
+                .parse::<TokenStream>()
+                .unwrap(),
             );
         }
 


### PR DESCRIPTION
Instead of using `include_str!` use `include_bytes!` since the inputs may now be in the wasm binary format instead of source file in utf-8.