### PR TITLE
Require the use of remappings provided via --with

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -270,7 +270,7 @@ impl WorldGenerator for C {
         gen.gen.src.append(&gen.src);
     }
 
-    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         let linking_symbol = component_type_object::linking_symbol(&self.world);
         self.include("<stdlib.h>");
         let snake = self.world.to_snake_case();
@@ -463,6 +463,8 @@ impl WorldGenerator for C {
                 .as_slice(),
             );
         }
+
+        Ok(())
     }
 
     fn pre_export_interface(&mut self, resolve: &Resolve, _files: &mut Files) -> Result<()> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -294,8 +294,7 @@ pub trait WorldGenerator {
         for (name, id) in interfaces {
             self.export_interface(resolve, name, *id, files)?;
         }
-        self.finish(resolve, id, files);
-        Ok(())
+        self.finish(resolve, id, files)
     }
 
     fn finish_imports(&mut self, resolve: &Resolve, world: WorldId, files: &mut Files) {
@@ -348,7 +347,7 @@ pub trait WorldGenerator {
         types: &[(&str, TypeId)],
         files: &mut Files,
     );
-    fn finish(&mut self, resolve: &Resolve, world: WorldId, files: &mut Files);
+    fn finish(&mut self, resolve: &Resolve, world: WorldId, files: &mut Files) -> Result<()>;
 }
 
 /// This is a possible replacement for the `Generator` trait above, currently

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -269,7 +269,7 @@ impl WorldGenerator for CSharp {
         gen.add_world_fragment();
     }
 
-    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         let world = &resolve.worlds[id];
         let world_namespace = self.qualifier();
         let world_namespace = world_namespace.strip_suffix(".").unwrap();
@@ -654,6 +654,8 @@ impl WorldGenerator for CSharp {
                 generate_stub(name.to_string(), files, Stubs::Interface(fragments));
             }
         }
+
+        Ok(())
     }
 }
 

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -286,7 +286,7 @@ impl WorldGenerator for TinyGo {
         self.src.push_str(&src);
     }
 
-    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         // make sure all types are defined on top of the file
         let src = mem::take(&mut self.src);
         self.src.push_str(&src);
@@ -351,7 +351,9 @@ impl WorldGenerator for TinyGo {
         opts.no_object_file = true;
         opts.build()
             .generate(resolve, id, files)
-            .expect("C generator should be infallible")
+            .expect("C generator should be infallible");
+
+        Ok(())
     }
 }
 

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -200,7 +200,7 @@ impl WorldGenerator for Markdown {
         }
     }
 
-    fn finish(&mut self, resolve: &Resolve, world: WorldId, files: &mut Files) {
+    fn finish(&mut self, resolve: &Resolve, world: WorldId, files: &mut Files) -> Result<()> {
         let world = &resolve.worlds[world];
         let parser = Parser::new(&self.src);
         let mut events = Vec::new();
@@ -227,6 +227,8 @@ impl WorldGenerator for Markdown {
             files.push(&format!("{}.md", world.name), self.src.as_bytes());
             files.push(&format!("{}.html", world.name), html_output.as_bytes());
         }
+
+        Ok(())
     }
 }
 

--- a/crates/teavm-java/src/lib.rs
+++ b/crates/teavm-java/src/lib.rs
@@ -177,7 +177,7 @@ impl WorldGenerator for TeaVmJava {
         gen.add_world_fragment();
     }
 
-    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) {
+    fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         let name = world_name(resolve, id);
         let (package, name) = split_qualified_name(&name);
 
@@ -431,6 +431,8 @@ impl WorldGenerator for TeaVmJava {
                 generate_stub(&package, format!("{name}Impl"), fragments, files);
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -158,12 +158,15 @@ fn gen_world(
     let (pkg, _files) = resolve.push_path(&opts.wit)?;
     let world = resolve.select_world(pkg, opts.world.as_deref())?;
     if let Err(e) = generator.generate(&resolve, world, files) {
-        eprintln!(
-            "{e:?}\n\n\
-             help: Specify export implementations using the `--exports` option.\n    \
-             For example: `--exports world=MyWorld,ns:pkg/iface=MyIface`\n    \
-             Alternatively, specify `--stubs` to generate stub implementations."
-        );
+        if e.to_string().starts_with("no `exports` map provided") {
+            bail!(
+                "{e:?}\n\n\
+                help: Specify export implementations using the `--exports` option.\n    \
+                For example: `--exports world=MyWorld,ns:pkg/iface=MyIface`\n    \
+                Alternatively, specify `--stubs` to generate stub implementations."
+            );
+        }
+        bail!("{e:?}");
     }
 
     Ok(())


### PR DESCRIPTION
This is a quick first attempt to address #841.

Alternatively I could update the `Generator` so that `finish` returns an error to eliminate panicking but that would require updating all the language generators for a change currently isiolated to the rust generator.

