### PR TITLE
Avoid string matching on errors

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -276,7 +276,7 @@ impl RustWasm {
             ExportKey::Name(name) => format!("\"{name}\""),
         };
         if self.opts.exports.is_empty() {
-            bail!("no `exports` map provided in configuration - provide an `exports` map a key `{key}`")
+            bail!(MissingExportsMap { key });
         }
         bail!("expected `exports` map to contain key `{key}`")
     }
@@ -869,3 +869,20 @@ impl fmt::Display for RustFlagsRepr {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct MissingExportsMap {
+    key: String,
+}
+
+impl fmt::Display for MissingExportsMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "no `exports` map provided in configuration - provide an `exports` map a key `{key}`",
+            key = self.key,
+        )
+    }
+}
+
+impl std::error::Error for MissingExportsMap {}

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -158,6 +158,7 @@ fn gen_world(
     let (pkg, _files) = resolve.push_path(&opts.wit)?;
     let world = resolve.select_world(pkg, opts.world.as_deref())?;
     if let Err(mut e) = generator.generate(&resolve, world, files) {
+        #[cfg(feature = "rust")]
         if e.is::<wit_bindgen_rust::MissingExportsMap>() {
             e = e.context(
                 "no `--exports` option was found but one was required, \

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -157,16 +157,16 @@ fn gen_world(
     let mut resolve = Resolve::default();
     let (pkg, _files) = resolve.push_path(&opts.wit)?;
     let world = resolve.select_world(pkg, opts.world.as_deref())?;
-    if let Err(e) = generator.generate(&resolve, world, files) {
-        if e.to_string().starts_with("no `exports` map provided") {
-            bail!(
-                "{e:?}\n\n\
-                help: Specify export implementations using the `--exports` option.\n    \
-                For example: `--exports world=MyWorld,ns:pkg/iface=MyIface`\n    \
-                Alternatively, specify `--stubs` to generate stub implementations."
+    if let Err(mut e) = generator.generate(&resolve, world, files) {
+        if e.is::<wit_bindgen_rust::MissingExportsMap>() {
+            e = e.context(
+                "no `--exports` option was found but one was required, \
+                 this can be passed as `--exports world=MyWorld,ns:pkg/iface=MyIface` \
+                 for example\n\
+                Alternatively, specify `--stubs` to generate stub implementations.",
             );
         }
-        bail!("{e:?}");
+        return Err(e);
     }
 
     Ok(())


### PR DESCRIPTION
Use concrete error types for testing for attaching help messages.