### PR TITLE
rust: Fix cases where `with` provides resources

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -9,23 +9,11 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use wit_bindgen_core::abi::{Bitcast, WasmType};
 use wit_bindgen_core::{
-    uwriteln, wit_parser::*, Direction, Files, InterfaceGenerator as _, Source, Types,
-    WorldGenerator,
+    uwriteln, wit_parser::*, Files, InterfaceGenerator as _, Source, Types, WorldGenerator,
 };
 
 mod bindgen;
 mod interface;
-
-#[derive(Default)]
-struct ResourceInfo {
-    // Note that a resource can be both imported and exported (e.g. when
-    // importing and exporting the same interface which contains one or more
-    // resources).  In that case, this field will be `Import` while we're
-    // importing the interface and later change to `Export` while we're
-    // exporting the interface.
-    direction: Direction,
-    owned: bool,
-}
 
 struct InterfaceName {
     /// True when this interface name has been remapped through the use of `with` in the `bindgen!`
@@ -45,12 +33,13 @@ struct RustWasm {
     export_modules: Vec<(String, Vec<String>)>,
     skip: HashSet<String>,
     interface_names: HashMap<InterfaceId, InterfaceName>,
-    resources: HashMap<TypeId, ResourceInfo>,
+    interface_last_seen_as_import: HashMap<InterfaceId, bool>,
     import_funcs_called: bool,
     with_name_counter: usize,
     // Track the with options that were used. Remapped interfaces provided via `with`
     // are required to be used.
     used_with_opts: HashSet<String>,
+    world: Option<WorldId>,
 }
 
 #[cfg(feature = "clap")]
@@ -360,7 +349,7 @@ fn name_package_module(resolve: &Resolve, id: PackageId) -> String {
 }
 
 impl WorldGenerator for RustWasm {
-    fn preprocess(&mut self, resolve: &Resolve, _world: WorldId) {
+    fn preprocess(&mut self, resolve: &Resolve, world: WorldId) {
         wit_bindgen_core::generated_preamble(&mut self.src, env!("CARGO_PKG_VERSION"));
 
         // Render some generator options to assist with debugging and/or to help
@@ -391,6 +380,7 @@ impl WorldGenerator for RustWasm {
             uwriteln!(self.src, "//   * with {with:?}");
         }
         self.types.analyze(resolve);
+        self.world = Some(world);
     }
 
     fn import_interface(
@@ -400,6 +390,7 @@ impl WorldGenerator for RustWasm {
         id: InterfaceId,
         _files: &mut Files,
     ) {
+        self.interface_last_seen_as_import.insert(id, true);
         let wasm_import_module = resolve.name_world_key(name);
         let mut gen = self.interface(
             Identifier::Interface(id, name),
@@ -442,6 +433,7 @@ impl WorldGenerator for RustWasm {
         id: InterfaceId,
         _files: &mut Files,
     ) -> Result<()> {
+        self.interface_last_seen_as_import.insert(id, false);
         let mut gen = self.interface(Identifier::Interface(id, name), None, resolve, false);
         let (snake, module_path) = gen.start_append_submodule(name);
         if gen.gen.name_interface(resolve, id, name, true) {
@@ -450,6 +442,31 @@ impl WorldGenerator for RustWasm {
         gen.types(id);
         gen.generate_exports(resolve.interfaces[id].functions.values())?;
         gen.finish_append_submodule(&snake, module_path);
+
+        if self.opts.stubs {
+            let (pkg, name) = match name {
+                WorldKey::Name(name) => (None, name),
+                WorldKey::Interface(id) => {
+                    let interface = &resolve.interfaces[*id];
+                    (
+                        Some(interface.package.unwrap()),
+                        interface.name.as_ref().unwrap(),
+                    )
+                }
+            };
+            for (resource, funcs) in group_by_resource(resolve.interfaces[id].functions.values()) {
+                let world_id = self.world.unwrap();
+                let mut gen = self.interface(Identifier::World(world_id), None, resolve, false);
+                let pkg = pkg.map(|pid| {
+                    let namespace = resolve.packages[pid].name.namespace.clone();
+                    let package_module = name_package_module(resolve, pid);
+                    (namespace, package_module)
+                });
+                gen.generate_stub(resource, pkg, name, true, &funcs);
+                let stub = gen.finish();
+                self.src.push_str(&stub);
+            }
+        }
         Ok(())
     }
 
@@ -464,6 +481,16 @@ impl WorldGenerator for RustWasm {
         gen.generate_exports(funcs.iter().map(|f| f.1))?;
         let src = gen.finish();
         self.src.push_str(&src);
+
+        if self.opts.stubs {
+            for (resource, funcs) in group_by_resource(funcs.iter().map(|f| f.1)) {
+                let mut gen = self.interface(Identifier::World(world), None, resolve, false);
+                let world = &resolve.worlds[world];
+                gen.generate_stub(resource, None, &world.name, false, &funcs);
+                let stub = gen.finish();
+                self.src.push_str(&stub);
+            }
+        }
         Ok(())
     }
 
@@ -541,50 +568,6 @@ impl WorldGenerator for RustWasm {
 
         if self.opts.stubs {
             self.src.push_str("\n#[derive(Debug)]\npub struct Stub;\n");
-            let world_id = world;
-            let world = &resolve.worlds[world];
-            let mut funcs = Vec::new();
-            for (name, export) in world.exports.iter() {
-                let (pkg, name) = match name {
-                    WorldKey::Name(name) => (None, name),
-                    WorldKey::Interface(id) => {
-                        let interface = &resolve.interfaces[*id];
-                        (
-                            Some(interface.package.unwrap()),
-                            interface.name.as_ref().unwrap(),
-                        )
-                    }
-                };
-                match export {
-                    WorldItem::Function(func) => {
-                        funcs.push(func);
-                    }
-                    WorldItem::Interface(id) => {
-                        for (resource, funcs) in
-                            group_by_resource(resolve.interfaces[*id].functions.values())
-                        {
-                            let mut gen =
-                                self.interface(Identifier::World(world_id), None, resolve, false);
-                            let pkg = pkg.map(|pid| {
-                                let namespace = resolve.packages[pid].name.namespace.clone();
-                                let package_module = name_package_module(resolve, pid);
-                                (namespace, package_module)
-                            });
-                            gen.generate_stub(resource, pkg, name, true, &funcs);
-                            let stub = gen.finish();
-                            self.src.push_str(&stub);
-                        }
-                    }
-                    WorldItem::Type(_) => unreachable!(),
-                }
-            }
-
-            for (resource, funcs) in group_by_resource(funcs.into_iter()) {
-                let mut gen = self.interface(Identifier::World(world_id), None, resolve, false);
-                gen.generate_stub(resource, None, &world.name, false, &funcs);
-                let stub = gen.finish();
-                self.src.push_str(&stub);
-            }
         }
 
         let mut src = mem::take(&mut self.src);

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -33,6 +33,7 @@ struct RustWasm {
     export_modules: Vec<(String, Vec<String>)>,
     skip: HashSet<String>,
     interface_names: HashMap<InterfaceId, InterfaceName>,
+    /// Each imported and exported interface is stored in this map. Value indicates if last use was import.
     interface_last_seen_as_import: HashMap<InterfaceId, bool>,
     import_funcs_called: bool,
     with_name_counter: usize,

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -415,3 +415,45 @@ mod with {
         my::inline::bar::bar(&msg);
     }
 }
+
+mod with_and_resources {
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline;
+
+            interface foo {
+                resource a;
+            }
+
+            interface bar {
+                use foo.{a};
+
+                bar: func(m: a) -> list<a>;
+            }
+
+            world baz {
+                import bar;
+            }
+        ",
+        with: {
+            "my:inline/foo": other::my::inline::foo,
+        },
+    });
+
+    pub mod other {
+        wit_bindgen::generate!({
+            inline: "
+                package my:inline;
+
+                interface foo {
+                    resource a;
+                }
+
+                world dummy {
+                    use foo.{a};
+                    import bar: func(m: a);
+                }
+            ",
+        });
+    }
+}


### PR DESCRIPTION
This commit fixes a bug where if `with` was used to provide a resource then the internal `resources` map wasn't updated correctly. This could lead to "index not found" panics in #832. To fix this I've opted to remove the `resources` map entirely as the `owned` field was already not tracked and this additionally brings the Wasmtime and Rust generators a bit closer together.

Instead now each `InterfaceId` has an entry of whether it was last seen as an export or an import and this is consulted when determining whether a resource is exported or not.

This fix then required shuffling around where the stub implementations are generated to ensure that when the stubs for top-level exported functions are generated the right metadata of "was this interface last seen as an import" is generated correctly.

Closes #832