### PR TITLE
Render the Rust custom section a bit more readably

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -734,7 +734,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     "let {layout} = alloc::Layout::from_size_align_unchecked({vec}.len() * {size}, {align});\n",
                 ));
                 self.push_str(&format!(
-                    "let {result} = if {layout}.size() != 0\n{{\nlet ptr = alloc::alloc({layout});\n",
+                    "let {result} = if {layout}.size() != 0 {{\nlet ptr = alloc::alloc({layout});\n",
                 ));
                 self.push_str(&format!(
                     "if ptr.is_null()\n{{\nalloc::handle_alloc_error({layout});\n}}\nptr\n}}",

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -571,7 +571,15 @@ impl WorldGenerator for RustWasm {
                 line_length = 0;
             }
             match byte {
-                b if b.is_ascii_alphanumeric() || (b.is_ascii_punctuation() && *b != b'\\') => {
+                b'\\' => {
+                    s.push_str("\\\\");
+                    line_length += 2;
+                }
+                b'"' => {
+                    s.push_str("\\\"");
+                    line_length += 2;
+                }
+                b if b.is_ascii_alphanumeric() || b.is_ascii_punctuation() => {
                     s.push(char::from(*byte));
                     line_length += 1;
                 }


### PR DESCRIPTION
Instead of using a large literal of integers instead use a byte string which is a bit more compact and allows rendering some ascii inline where possible.