### PR TITLE
Move most of the `wit-bindgen` crate into generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ dependencies = [
  "anyhow",
  "clap",
  "heck",
+ "indexmap",
  "serde",
  "serde_json",
  "test-helpers",

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -10,14 +10,6 @@
 
 #![no_std]
 
-extern crate alloc;
-
-use alloc::boxed::Box;
-use core::fmt;
-use core::marker;
-use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
-
 /// Generate bindings for an input WIT document.
 ///
 /// This macro is the bread-and-butter of the `wit-bindgen` crate. The macro
@@ -322,10 +314,8 @@ mod cabi_realloc;
 
 #[doc(hidden)]
 pub mod rt {
-    pub use crate::{Resource, RustResource, WasmResource};
 
-    use super::alloc::alloc;
-    use super::alloc::alloc::Layout;
+    extern crate alloc;
 
     /// This function is called from generated bindings and will be deleted by
     /// the linker. The purpose of this function is to force a reference to the
@@ -372,6 +362,8 @@ pub mod rt {
         align: usize,
         new_len: usize,
     ) -> *mut u8 {
+        use self::alloc::alloc::{self, Layout};
+
         let layout;
         let ptr = if old_len == 0 {
             if new_len == 0 {
@@ -398,171 +390,5 @@ pub mod rt {
             }
         }
         return ptr;
-    }
-}
-
-type RawRep<T> = Option<T>;
-
-/// A type which represents a component model resource, either imported or
-/// exported into this component.
-///
-/// This is a low-level wrapper which handles the lifetime of the resource
-/// (namely this has a destructor). The `T` provided defines the component model
-/// intrinsics that this wrapper uses.
-///
-/// One of the chief purposes of this type is to provide `Deref` implementations
-/// to access the underlying data when it is owned.
-///
-/// This type is primarily used in generated code for exported and imported
-/// resources.
-#[repr(transparent)]
-pub struct Resource<T: WasmResource> {
-    // NB: This would ideally be `u32` but it is not. The fact that this has
-    // interior mutability is not exposed in the API of this type except for the
-    // `take_handle` method which is supposed to in theory be private.
-    //
-    // This represents, almost all the time, a valid handle value. When it's
-    // invalid it's stored as `u32::MAX`.
-    handle: AtomicU32,
-    _marker: marker::PhantomData<Box<T>>,
-}
-
-/// A trait which all wasm resources implement, namely providing the ability to
-/// drop a resource.
-///
-/// This generally is implemented by generated code, not user-facing code.
-pub unsafe trait WasmResource {
-    /// Invokes the `[resource-drop]...` intrinsic.
-    unsafe fn drop(handle: u32);
-}
-
-/// A trait which extends [`WasmResource`] used for Rust-defined resources, or
-/// those exported from this component.
-///
-/// This generally is implemented by generated code, not user-facing code.
-pub unsafe trait RustResource: WasmResource {
-    /// Invokes the `[resource-new]...` intrinsic.
-    unsafe fn new(rep: usize) -> u32;
-    /// Invokes the `[resource-rep]...` intrinsic.
-    unsafe fn rep(handle: u32) -> usize;
-}
-
-impl<T: WasmResource> Resource<T> {
-    #[doc(hidden)]
-    pub unsafe fn from_handle(handle: u32) -> Self {
-        debug_assert!(handle != u32::MAX);
-        Self {
-            handle: AtomicU32::new(handle),
-            _marker: marker::PhantomData,
-        }
-    }
-
-    /// Takes ownership of the handle owned by `resource`.
-    ///
-    /// Note that this ideally would be `into_handle` taking `Resource<T>` by
-    /// ownership. The code generator does not enable that in all situations,
-    /// unfortunately, so this is provided instead.
-    ///
-    /// Also note that `take_handle` is in theory only ever called on values
-    /// owned by a generated function. For example a generated function might
-    /// take `Resource<T>` as an argument but then call `take_handle` on a
-    /// reference to that argument. In that sense the dynamic nature of
-    /// `take_handle` should only be exposed internally to generated code, not
-    /// to user code.
-    #[doc(hidden)]
-    pub fn take_handle(resource: &Resource<T>) -> u32 {
-        resource.handle.swap(u32::MAX, Relaxed)
-    }
-
-    #[doc(hidden)]
-    pub fn handle(resource: &Resource<T>) -> u32 {
-        resource.handle.load(Relaxed)
-    }
-
-    /// Creates a new Rust-defined resource from the underlying representation
-    /// `T`.
-    ///
-    /// This will move `T` onto the heap to create a single pointer to represent
-    /// it which is then wrapped up in a component model resource.
-    pub fn new(val: T) -> Resource<T>
-    where
-        T: RustResource,
-    {
-        let rep = Box::into_raw(Box::new(Some(val))) as usize;
-        unsafe {
-            let handle = T::new(rep);
-            Resource::from_handle(handle)
-        }
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn dtor(rep: usize)
-    where
-        T: RustResource,
-    {
-        let _ = Box::from_raw(rep as *mut RawRep<T>);
-    }
-
-    /// Takes back ownership of the object, dropping the resource handle.
-    pub fn into_inner(resource: Self) -> T
-    where
-        T: RustResource,
-    {
-        unsafe {
-            let rep = T::rep(resource.handle.load(Relaxed));
-            RawRep::take(&mut *(rep as *mut RawRep<T>)).unwrap()
-        }
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn lift_borrow<'a>(rep: usize) -> &'a T
-    where
-        T: RustResource,
-    {
-        RawRep::as_ref(&*(rep as *const RawRep<T>)).unwrap()
-    }
-}
-
-impl<T: RustResource> Deref for Resource<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe {
-            let rep = T::rep(self.handle.load(Relaxed));
-            RawRep::as_ref(&*(rep as *const RawRep<T>)).unwrap()
-        }
-    }
-}
-
-impl<T: RustResource> DerefMut for Resource<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe {
-            let rep = T::rep(self.handle.load(Relaxed));
-            RawRep::as_mut(&mut *(rep as *mut RawRep<T>)).unwrap()
-        }
-    }
-}
-
-impl<T: WasmResource> fmt::Debug for Resource<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Resource")
-            .field("handle", &self.handle)
-            .finish()
-    }
-}
-
-impl<T: WasmResource> Drop for Resource<T> {
-    fn drop(&mut self) {
-        unsafe {
-            match self.handle.load(Relaxed) {
-                // If this handle was "taken" then don't do anything in the
-                // destructor.
-                u32::MAX => {}
-
-                // ... but otherwise do actually destroy it with the imported
-                // component model intrinsic as defined through `T`.
-                other => T::drop(other),
-            }
-        }
     }
 }

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -399,41 +399,6 @@ pub mod rt {
         }
         return ptr;
     }
-
-    macro_rules! as_traits {
-        ($(($trait_:ident $func:ident $ty:ident <=> $($tys:ident)*))*) => ($(
-            pub fn $func<T: $trait_>(t: T) -> $ty {
-                t.$func()
-            }
-
-            pub trait $trait_ {
-                fn $func(self) -> $ty;
-            }
-
-            impl<'a, T: Copy + $trait_> $trait_ for &'a T {
-                fn $func(self) -> $ty{
-                    (*self).$func()
-                }
-            }
-
-            $(
-                impl $trait_ for $tys {
-                    #[inline]
-                    fn $func(self) -> $ty {
-                        self as $ty
-                    }
-                }
-            )*
-
-        )*)
-    }
-
-    as_traits! {
-        (AsI64 as_i64 i64 <=> i64 u64)
-        (AsI32 as_i32 i32 <=> i32 u32 i16 u16 i8 u8 char usize)
-        (AsF32 as_f32 f32 <=> f32)
-        (AsF64 as_f64 f64 <=> f64)
-    }
 }
 
 type RawRep<T> = Option<T>;

--- a/crates/rust-macro/src/lib.rs
+++ b/crates/rust-macro/src/lib.rs
@@ -104,7 +104,10 @@ impl Parse for Config {
                     }
                     Opt::With(with) => opts.with.extend(with),
                     Opt::TypeSectionSuffix(suffix) => {
-                        opts.type_section_suffix = Some(suffix.value())
+                        opts.type_section_suffix = Some(suffix.value());
+                    }
+                    Opt::RunCtorsOnceWorkaround(enable) => {
+                        opts.run_ctors_once_workaround = enable.value();
                     }
                 }
             }
@@ -220,6 +223,7 @@ mod kw {
     syn::custom_keyword!(additional_derives);
     syn::custom_keyword!(with);
     syn::custom_keyword!(type_section_suffix);
+    syn::custom_keyword!(run_ctors_once_workaround);
 }
 
 #[derive(Clone)]
@@ -281,6 +285,7 @@ enum Opt {
     AdditionalDerives(Vec<syn::Path>),
     With(HashMap<String, String>),
     TypeSectionSuffix(syn::LitStr),
+    RunCtorsOnceWorkaround(syn::LitBool),
 }
 
 impl Parse for Opt {
@@ -390,6 +395,10 @@ impl Parse for Opt {
             input.parse::<kw::type_section_suffix>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::TypeSectionSuffix(input.parse()?))
+        } else if l.peek(kw::run_ctors_once_workaround) {
+            input.parse::<kw::run_ctors_once_workaround>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::RunCtorsOnceWorkaround(input.parse()?))
         } else {
             Err(l.error())
         }

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -22,6 +22,7 @@ wit-component = { workspace = true }
 wasm-metadata = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
+indexmap = { workspace = true }
 
 [dev-dependencies]
 wit-bindgen = { path = '../guest-rust' }

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -41,13 +41,13 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
 
     fn emit_cleanup(&mut self) {
         for (ptr, layout) in mem::take(&mut self.cleanup) {
-            let alloc = self.gen.path_to_alloc_crate();
+            let alloc = self.gen.path_to_std_alloc_module();
             self.push_str(&format!(
                 "if {layout}.size() != 0 {{\n{alloc}::dealloc({ptr}, {layout});\n}}\n"
             ));
         }
         if self.needs_cleanup_list {
-            let alloc = self.gen.path_to_alloc_crate();
+            let alloc = self.gen.path_to_std_alloc_module();
             self.push_str(&format!(
                 "for (ptr, layout) in cleanup_list {{\n
                     if layout.size() != 0 {{\n
@@ -706,7 +706,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             }
 
             Instruction::ListLower { element, realloc } => {
-                let alloc = self.gen.path_to_alloc_crate();
+                let alloc = self.gen.path_to_std_alloc_module();
                 let body = self.blocks.pop().unwrap();
                 let tmp = self.tmp();
                 let vec = format!("vec{tmp}");

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -41,18 +41,20 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
 
     fn emit_cleanup(&mut self) {
         for (ptr, layout) in mem::take(&mut self.cleanup) {
+            let alloc = self.gen.path_to_alloc_crate();
             self.push_str(&format!(
-                "if {layout}.size() != 0 {{\nalloc::dealloc({ptr}, {layout});\n}}\n"
+                "if {layout}.size() != 0 {{\n{alloc}::dealloc({ptr}, {layout});\n}}\n"
             ));
         }
         if self.needs_cleanup_list {
-            self.push_str(
-                "for (ptr, layout) in cleanup_list {\n
-                    if layout.size() != 0 {\n
-                        alloc::dealloc(ptr, layout);\n
-                    }\n
-                }\n",
-            );
+            let alloc = self.gen.path_to_alloc_crate();
+            self.push_str(&format!(
+                "for (ptr, layout) in cleanup_list {{\n
+                    if layout.size() != 0 {{\n
+                        {alloc}::dealloc(ptr, layout);\n
+                    }}\n
+                }}\n",
+            ));
         }
     }
 
@@ -319,10 +321,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
             Instruction::I64FromU64 | Instruction::I64FromS64 => {
                 let s = operands.pop().unwrap();
-                results.push(format!(
-                    "{rt}::as_i64({s})",
-                    rt = self.gen.gen.runtime_path()
-                ));
+                results.push(format!("{}({s})", self.gen.path_to_as_i64()));
             }
             Instruction::I32FromChar
             | Instruction::I32FromU8
@@ -332,25 +331,16 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::I32FromU32
             | Instruction::I32FromS32 => {
                 let s = operands.pop().unwrap();
-                results.push(format!(
-                    "{rt}::as_i32({s})",
-                    rt = self.gen.gen.runtime_path()
-                ));
+                results.push(format!("{}({s})", self.gen.path_to_as_i32()));
             }
 
             Instruction::F32FromFloat32 => {
                 let s = operands.pop().unwrap();
-                results.push(format!(
-                    "{rt}::as_f32({s})",
-                    rt = self.gen.gen.runtime_path()
-                ));
+                results.push(format!("{}({s})", self.gen.path_to_as_f32()));
             }
             Instruction::F64FromFloat64 => {
                 let s = operands.pop().unwrap();
-                results.push(format!(
-                    "{rt}::as_f64({s})",
-                    rt = self.gen.gen.runtime_path()
-                ));
+                results.push(format!("{}({s})", self.gen.path_to_as_f64()));
             }
             Instruction::Float32FromF32
             | Instruction::Float64FromF64
@@ -366,8 +356,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             Instruction::U64FromI64 => top_as("u64"),
             Instruction::CharFromI32 => {
                 results.push(format!(
-                    "{}::char_lift({} as u32)",
-                    self.gen.gen.runtime_path(),
+                    "{}({} as u32)",
+                    self.gen.path_to_char_lift(),
                     operands[0]
                 ));
             }
@@ -379,8 +369,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             }
             Instruction::BoolFromI32 => {
                 results.push(format!(
-                    "{}::bool_lift({} as u8)",
-                    self.gen.gen.runtime_path(),
+                    "{}({} as u8)",
+                    self.gen.path_to_bool_lift(),
                     operands[0]
                 ));
             }
@@ -410,9 +400,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 ..
             } => {
                 let op = &operands[0];
-                let rt = self.gen.gen.runtime_path();
                 let result = if self.gen.is_exported_resource(*resource) {
-                    format!("{rt}::Resource::take_handle(&{op}) as i32")
+                    let resource = self.gen.path_to_resource();
+                    format!("{resource}::take_handle(&{op}) as i32")
                 } else {
                     format!("({op}).take_handle() as i32")
                 };
@@ -444,8 +434,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                                 .as_deref()
                                 .unwrap()
                                 .to_upper_camel_case();
-                            let rt = self.gen.gen.runtime_path();
-                            format!("{rt}::Resource::<{name}>::lift_borrow({op} as u32 as usize)")
+                            let resource = self.gen.path_to_resource();
+                            format!("{resource}::<{name}>::lift_borrow({op} as u32 as usize)")
                         }
                         Handle::Own(_) => {
                             let name = self.gen.type_path(dealiased_resource, true);
@@ -589,9 +579,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                             let e = {some};
                             Some(e)
                         }}
-                        _ => {rt}::invalid_enum_discriminant(),
+                        _ => {invalid}(),
                     }}",
-                    rt = self.gen.gen.runtime_path(),
+                    invalid = self.gen.path_to_invalid_enum_discriminant(),
                 ));
             }
 
@@ -628,9 +618,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                             let e = {err};
                             Err(e)
                         }}
-                        _ => {rt}::invalid_enum_discriminant(),
+                        _ => {invalid}(),
                     }}",
-                    rt = self.gen.gen.runtime_path(),
+                    invalid = self.gen.path_to_invalid_enum_discriminant(),
                 ));
             }
 
@@ -670,8 +660,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 let tmp = self.tmp();
                 let len = format!("len{}", tmp);
                 self.push_str(&format!("let {} = {} as usize;\n", len, operands[1]));
+                let vec = self.gen.path_to_vec();
                 let result = format!(
-                    "Vec::from_raw_parts({} as *mut _, {1}, {1})",
+                    "{vec}::from_raw_parts({} as *mut _, {1}, {1})",
                     operands[0], len
                 );
                 results.push(result);
@@ -698,25 +689,24 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             }
 
             Instruction::StringLift => {
+                let vec = self.gen.path_to_vec();
                 let tmp = self.tmp();
                 let len = format!("len{}", tmp);
                 uwriteln!(self.src, "let {len} = {} as usize;", operands[1]);
                 uwriteln!(
                     self.src,
-                    "let bytes{tmp} = Vec::from_raw_parts({} as *mut _, {len}, {len});",
+                    "let bytes{tmp} = {vec}::from_raw_parts({} as *mut _, {len}, {len});",
                     operands[0],
                 );
                 if self.gen.gen.opts.raw_strings {
                     results.push(format!("bytes{tmp}"));
                 } else {
-                    results.push(format!(
-                        "{}::string_lift(bytes{tmp})",
-                        self.gen.gen.runtime_path()
-                    ));
+                    results.push(format!("{}(bytes{tmp})", self.gen.path_to_string_lift()));
                 }
             }
 
             Instruction::ListLower { element, realloc } => {
+                let alloc = self.gen.path_to_alloc_crate();
                 let body = self.blocks.pop().unwrap();
                 let tmp = self.tmp();
                 let vec = format!("vec{tmp}");
@@ -731,13 +721,13 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 let size = self.gen.sizes.size(element);
                 let align = self.gen.sizes.align(element);
                 self.push_str(&format!(
-                    "let {layout} = alloc::Layout::from_size_align_unchecked({vec}.len() * {size}, {align});\n",
+                    "let {layout} = {alloc}::Layout::from_size_align_unchecked({vec}.len() * {size}, {align});\n",
                 ));
                 self.push_str(&format!(
-                    "let {result} = if {layout}.size() != 0 {{\nlet ptr = alloc::alloc({layout});\n",
+                    "let {result} = if {layout}.size() != 0 {{\nlet ptr = {alloc}::alloc({layout});\n",
                 ));
                 self.push_str(&format!(
-                    "if ptr.is_null()\n{{\nalloc::handle_alloc_error({layout});\n}}\nptr\n}}",
+                    "if ptr.is_null()\n{{\n{alloc}::handle_alloc_error({layout});\n}}\nptr\n}}",
                 ));
                 self.push_str("else {{\n::core::ptr::null_mut()\n}};\n");
                 self.push_str(&format!("for (i, e) in {vec}.into_iter().enumerate() {{\n",));
@@ -773,8 +763,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     "let {len} = {operand1};\n",
                     operand1 = operands[1]
                 ));
+                let vec = self.gen.path_to_vec();
                 self.push_str(&format!(
-                    "let mut {result} = Vec::with_capacity({len} as usize);\n",
+                    "let mut {result} = {vec}::with_capacity({len} as usize);\n",
                 ));
 
                 uwriteln!(self.src, "for i in 0..{len} {{");
@@ -783,9 +774,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 uwriteln!(self.src, "{result}.push(e{tmp});");
                 uwriteln!(self.src, "}}");
                 results.push(result);
+                let dealloc = self.gen.path_to_cabi_dealloc();
                 self.push_str(&format!(
-                    "{rt}::dealloc({base}, ({len} as usize) * {size}, {align});\n",
-                    rt = self.gen.gen.runtime_path(),
+                    "{dealloc}({base}, ({len} as usize) * {size}, {align});\n",
                 ));
             }
 
@@ -980,17 +971,17 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             Instruction::Malloc { .. } => unimplemented!(),
 
             Instruction::GuestDeallocate { size, align } => {
+                let dealloc = self.gen.path_to_cabi_dealloc();
                 self.push_str(&format!(
-                    "{rt}::dealloc({op}, {size}, {align});\n",
-                    rt = self.gen.gen.runtime_path(),
+                    "{dealloc}({op}, {size}, {align});\n",
                     op = operands[0]
                 ));
             }
 
             Instruction::GuestDeallocateString => {
+                let dealloc = self.gen.path_to_cabi_dealloc();
                 self.push_str(&format!(
-                    "{rt}::dealloc({op0}, ({op1}) as usize, 1);\n",
-                    rt = self.gen.gen.runtime_path(),
+                    "{dealloc}({op0}, ({op1}) as usize, 1);\n",
                     op0 = operands[0],
                     op1 = operands[1],
                 ));
@@ -1043,9 +1034,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     self.push_str(&body);
                     self.push_str("\n}\n");
                 }
+                let dealloc = self.gen.path_to_cabi_dealloc();
                 self.push_str(&format!(
-                    "{rt}::dealloc({base}, ({len} as usize) * {size}, {align});\n",
-                    rt = self.gen.gen.runtime_path(),
+                    "{dealloc}({base}, ({len} as usize) * {size}, {align});\n",
                 ));
             }
         }

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1744,7 +1744,15 @@ impl InterfaceGenerator<'_> {
     }
 
     pub fn path_to_resource(&mut self) -> String {
-        format!("{}::Resource", self.gen.runtime_path())
+        self.path_from_runtime_module(RuntimeItem::ResourceType, "Resource")
+    }
+
+    fn path_to_rust_resource(&mut self) -> String {
+        self.path_from_runtime_module(RuntimeItem::RustResource, "RustResource")
+    }
+
+    fn path_to_wasm_resource(&mut self) -> String {
+        self.path_from_runtime_module(RuntimeItem::ResourceType, "WasmResource")
     }
 
     pub fn path_to_invalid_enum_discriminant(&mut self) -> String {
@@ -1796,14 +1804,6 @@ impl InterfaceGenerator<'_> {
 
     pub fn path_to_string(&mut self) -> String {
         self.path_from_runtime_module(RuntimeItem::StringType, "String")
-    }
-
-    fn path_to_rust_resource(&mut self) -> String {
-        format!("{}::RustResource", self.gen.runtime_path())
-    }
-
-    fn path_to_wasm_resource(&mut self) -> String {
-        format!("{}::WasmResource", self.gen.runtime_path())
     }
 
     pub fn path_to_std_alloc_module(&mut self) -> String {

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -455,10 +455,11 @@ impl InterfaceGenerator<'_> {
 
         self.push_str(" {");
 
-        let run_ctors_once = self.path_to_run_ctors_once();
-        uwrite!(
-            self.src,
-            "
+        if self.gen.opts.run_ctors_once_workaround {
+            let run_ctors_once = self.path_to_run_ctors_once();
+            uwrite!(
+                self.src,
+                "
                 // Before executing any other code, use this function to run all static
                 // constructors, if they have not yet been run. This is a hack required
                 // to work around wasi-libc ctors calling import functions to initialize
@@ -474,7 +475,8 @@ impl InterfaceGenerator<'_> {
                 {run_ctors_once}();
 
             ",
-        );
+            );
+        }
 
         let mut f = FunctionBindgen::new(self, params);
         abi::call(
@@ -1786,7 +1788,7 @@ impl InterfaceGenerator<'_> {
     }
 
     fn path_to_run_ctors_once(&mut self) -> String {
-        format!("{}::run_ctors_once", self.gen.runtime_path())
+        self.path_from_runtime_module(RuntimeItem::RunCtorsOnce, "bool_lift")
     }
 
     pub fn path_to_vec(&mut self) -> String {

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -473,7 +473,6 @@ impl InterfaceGenerator<'_> {
                 // for more details.
                 #[cfg(target_arch=\"wasm32\")]
                 {run_ctors_once}();
-
             ",
             );
         }
@@ -1763,20 +1762,20 @@ impl InterfaceGenerator<'_> {
         self.path_from_runtime_module(RuntimeItem::CabiDealloc, "cabi_dealloc")
     }
 
-    pub fn path_to_as_i64(&mut self) -> String {
-        format!("{}::as_i64", self.gen.runtime_path())
-    }
-
     pub fn path_to_as_i32(&mut self) -> String {
-        format!("{}::as_i32", self.gen.runtime_path())
+        self.path_from_runtime_module(RuntimeItem::AsI32, "as_i32")
     }
 
-    pub fn path_to_as_f64(&mut self) -> String {
-        format!("{}::as_f64", self.gen.runtime_path())
+    pub fn path_to_as_i64(&mut self) -> String {
+        self.path_from_runtime_module(RuntimeItem::AsI64, "as_i64")
     }
 
     pub fn path_to_as_f32(&mut self) -> String {
-        format!("{}::as_f32", self.gen.runtime_path())
+        self.path_from_runtime_module(RuntimeItem::AsF32, "as_f32")
+    }
+
+    pub fn path_to_as_f64(&mut self) -> String {
+        self.path_from_runtime_module(RuntimeItem::AsF64, "as_f64")
     }
 
     pub fn path_to_char_lift(&mut self) -> String {

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -62,6 +62,8 @@ enum RuntimeItem {
     AsI64,
     AsF32,
     AsF64,
+    ResourceType,
+    RustResource,
 }
 
 #[cfg(feature = "clap")]
@@ -349,6 +351,10 @@ impl RustWasm {
             }
         }
         self.src.push_str("}\n");
+
+        if emitted.contains(&RuntimeItem::ResourceType) {
+            self.src.push_str("pub use _rt::Resource;\n");
+        }
     }
 
     fn emit_runtime_item(&mut self, item: RuntimeItem) {
@@ -495,6 +501,182 @@ pub fn run_ctors_once() {
 
             RuntimeItem::AsF64 => {
                 self.emit_runtime_as_trait("f64", &["f64"]);
+            }
+
+            RuntimeItem::ResourceType => {
+                self.src.push_str(
+                    r#"
+type RawRep<T> = Option<T>;
+
+use core::fmt;
+use core::marker;
+use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
+
+/// A type which represents a component model resource, either imported or
+/// exported into this component.
+///
+/// This is a low-level wrapper which handles the lifetime of the resource
+/// (namely this has a destructor). The `T` provided defines the component model
+/// intrinsics that this wrapper uses.
+///
+/// One of the chief purposes of this type is to provide `Deref` implementations
+/// to access the underlying data when it is owned.
+///
+/// This type is primarily used in generated code for exported and imported
+/// resources.
+#[repr(transparent)]
+pub struct Resource<T: WasmResource> {
+    // NB: This would ideally be `u32` but it is not. The fact that this has
+    // interior mutability is not exposed in the API of this type except for the
+    // `take_handle` method which is supposed to in theory be private.
+    //
+    // This represents, almost all the time, a valid handle value. When it's
+    // invalid it's stored as `u32::MAX`.
+    handle: AtomicU32,
+    _marker: marker::PhantomData<T>,
+}
+
+/// A trait which all wasm resources implement, namely providing the ability to
+/// drop a resource.
+///
+/// This generally is implemented by generated code, not user-facing code.
+pub unsafe trait WasmResource {
+    /// Invokes the `[resource-drop]...` intrinsic.
+    unsafe fn drop(handle: u32);
+}
+
+impl<T: WasmResource> Resource<T> {
+    #[doc(hidden)]
+    pub unsafe fn from_handle(handle: u32) -> Self {
+        debug_assert!(handle != u32::MAX);
+        Self {
+            handle: AtomicU32::new(handle),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    /// Takes ownership of the handle owned by `resource`.
+    ///
+    /// Note that this ideally would be `into_handle` taking `Resource<T>` by
+    /// ownership. The code generator does not enable that in all situations,
+    /// unfortunately, so this is provided instead.
+    ///
+    /// Also note that `take_handle` is in theory only ever called on values
+    /// owned by a generated function. For example a generated function might
+    /// take `Resource<T>` as an argument but then call `take_handle` on a
+    /// reference to that argument. In that sense the dynamic nature of
+    /// `take_handle` should only be exposed internally to generated code, not
+    /// to user code.
+    #[doc(hidden)]
+    pub fn take_handle(resource: &Resource<T>) -> u32 {
+        resource.handle.swap(u32::MAX, Relaxed)
+    }
+
+    #[doc(hidden)]
+    pub fn handle(resource: &Resource<T>) -> u32 {
+        resource.handle.load(Relaxed)
+    }
+}
+
+impl<T: WasmResource> fmt::Debug for Resource<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Resource")
+            .field("handle", &self.handle)
+            .finish()
+    }
+}
+
+impl<T: WasmResource> Drop for Resource<T> {
+    fn drop(&mut self) {
+        unsafe {
+            match self.handle.load(Relaxed) {
+                // If this handle was "taken" then don't do anything in the
+                // destructor.
+                u32::MAX => {}
+
+                // ... but otherwise do actually destroy it with the imported
+                // component model intrinsic as defined through `T`.
+                other => T::drop(other),
+            }
+        }
+    }
+}
+                    "#,
+                );
+            }
+            RuntimeItem::RustResource => {
+                self.rt_module.insert(RuntimeItem::ResourceType);
+                self.rt_module.insert(RuntimeItem::AllocCrate);
+                self.src.push_str(
+                    r#"
+use alloc_crate::boxed::Box;
+use core::ops::{Deref, DerefMut};
+
+/// A trait which extends [`WasmResource`] used for Rust-defined resources, or
+/// those exported from this component.
+///
+/// This generally is implemented by generated code, not user-facing code.
+pub unsafe trait RustResource: WasmResource {
+    /// Invokes the `[resource-new]...` intrinsic.
+    unsafe fn new(rep: usize) -> u32;
+    /// Invokes the `[resource-rep]...` intrinsic.
+    unsafe fn rep(handle: u32) -> usize;
+}
+
+impl<T: RustResource> Resource<T> {
+    /// Creates a new Rust-defined resource from the underlying representation
+    /// `T`.
+    ///
+    /// This will move `T` onto the heap to create a single pointer to represent
+    /// it which is then wrapped up in a component model resource.
+    pub fn new(val: T) -> Resource<T> {
+        let rep = Box::into_raw(Box::new(Some(val))) as usize;
+        unsafe {
+            let handle = T::new(rep);
+            Resource::from_handle(handle)
+        }
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn dtor(rep: usize) {
+        let _ = Box::from_raw(rep as *mut RawRep<T>);
+    }
+
+    /// Takes back ownership of the object, dropping the resource handle.
+    pub fn into_inner(resource: Self) -> T {
+        unsafe {
+            let rep = T::rep(resource.handle.load(Relaxed));
+            RawRep::take(&mut *(rep as *mut RawRep<T>)).unwrap()
+        }
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn lift_borrow<'a>(rep: usize) -> &'a T {
+        RawRep::as_ref(&*(rep as *const RawRep<T>)).unwrap()
+    }
+}
+
+impl<T: RustResource> Deref for Resource<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe {
+            let rep = T::rep(self.handle.load(Relaxed));
+            RawRep::as_ref(&*(rep as *const RawRep<T>)).unwrap()
+        }
+    }
+}
+
+impl<T: RustResource> DerefMut for Resource<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe {
+            let rep = T::rep(self.handle.load(Relaxed));
+            RawRep::as_mut(&mut *(rep as *mut RawRep<T>)).unwrap()
+        }
+    }
+}
+                    "#,
+                );
             }
         }
     }

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -249,15 +249,15 @@ mod owned_resource_deref_mut {
             }
         ",
         exports: {
-            "my:inline/foo/bar": Resource
+            "my:inline/foo/bar": MyResource
         }
     });
 
-    pub struct Resource {
+    pub struct MyResource {
         data: u32,
     }
 
-    impl exports::my::inline::foo::GuestBar for Resource {
+    impl exports::my::inline::foo::GuestBar for MyResource {
         fn new(data: u32) -> Self {
             Self { data }
         }
@@ -294,13 +294,13 @@ mod package_with_versions {
             }
         ",
         exports: {
-            "my:inline/foo/bar": Resource
+            "my:inline/foo/bar": MyResource
         }
     });
 
-    pub struct Resource;
+    pub struct MyResource;
 
-    impl exports::my::inline::foo::GuestBar for Resource {
+    impl exports::my::inline::foo::GuestBar for MyResource {
         fn new() -> Self {
             loop {}
         }

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -187,31 +187,6 @@ mod symbol_does_not_conflict {
     }
 }
 
-mod alternative_runtime_path {
-    wit_bindgen::generate!({
-        inline: "
-            package my:inline;
-            world foo {
-                export foobar: func() -> string;
-            }
-        ",
-        runtime_path: "my_rt",
-        exports: {
-            world: Component
-        }
-    });
-
-    pub(crate) use wit_bindgen::rt as my_rt;
-
-    struct Component;
-
-    impl Guest for Component {
-        fn foobar() -> String {
-            String::new()
-        }
-    }
-}
-
 mod alternative_bitflags_path {
     wit_bindgen::generate!({
         inline: "

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -77,6 +77,20 @@ mod strings {
     }
 }
 
+mod run_ctors_once_workaround {
+    wit_bindgen::generate!({
+        inline: "
+            package my:strings;
+
+            world not-used-name {
+                export apply-the-workaround: func();
+            }
+        ",
+        run_ctors_once_workaround: true,
+        stubs,
+    });
+}
+
 /// Like `strings` but with raw_strings`.
 mod raw_strings {
     wit_bindgen::generate!({

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -192,7 +192,7 @@ mod alternative_runtime_path {
         inline: "
             package my:inline;
             world foo {
-                export foobar: func();
+                export foobar: func() -> string;
             }
         ",
         runtime_path: "my_rt",
@@ -206,7 +206,9 @@ mod alternative_runtime_path {
     struct Component;
 
     impl Guest for Component {
-        fn foobar() {}
+        fn foobar() -> String {
+            String::new()
+        }
     }
 }
 

--- a/tests/runtime/resource_alias/wasm.rs
+++ b/tests/runtime/resource_alias/wasm.rs
@@ -19,7 +19,7 @@ pub struct E2 {}
 impl exports::test::resource_alias::e1::Guest for E1 {
     fn a(
         f: exports::test::resource_alias::e1::Foo,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias::e1::OwnX> {
+    ) -> Vec<exports::test::resource_alias::e1::OwnX> {
         vec![f.x]
     }
 }
@@ -33,7 +33,7 @@ impl exports::test::resource_alias::e2::Guest for E2 {
         f: exports::test::resource_alias::e2::Foo,
         g: exports::test::resource_alias::e2::Bar,
         _h: &exports::test::resource_alias::e1::X,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias::e2::OwnY> {
+    ) -> Vec<exports::test::resource_alias::e2::OwnY> {
         vec![f.x, g.x]
     }
 }

--- a/tests/runtime/resource_alias_redux/wasm.rs
+++ b/tests/runtime/resource_alias_redux/wasm.rs
@@ -9,7 +9,9 @@ wit_bindgen::generate!({
     }
 });
 
-use test::resource_alias_redux::resource_alias1::{Thing as ImportThing, a as import_a, Foo as ImportAlias1Foo};
+use test::resource_alias_redux::resource_alias1::{
+    a as import_a, Foo as ImportAlias1Foo, Thing as ImportThing,
+};
 use test::resource_alias_redux::resource_alias2::{b as import_b, Foo as ImportAlias2Foo};
 
 pub struct Test {}
@@ -19,31 +21,33 @@ pub struct MyResourceAlias1 {}
 pub struct MyResourceAlias2 {}
 
 pub struct MyThing {
-    value: Option<ImportThing>
+    value: Option<ImportThing>,
 }
 
 impl exports::test::resource_alias_redux::resource_alias1::Guest for MyResourceAlias1 {
     fn a(
         mut f: exports::test::resource_alias_redux::resource_alias1::Foo,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias_redux::resource_alias1::OwnThing>
-    {
+    ) -> Vec<exports::test::resource_alias_redux::resource_alias1::OwnThing> {
         let foo = ImportAlias1Foo {
-            thing: Option::take(&mut f.thing.value).unwrap()
+            thing: Option::take(&mut f.thing.value).unwrap(),
         };
-        import_a(foo).into_iter().map(|t| {
-            exports::test::resource_alias_redux::resource_alias1::OwnThing::new(MyThing {
-                value: Some(t)
-            }) 
-        }).collect()
+        import_a(foo)
+            .into_iter()
+            .map(|t| {
+                exports::test::resource_alias_redux::resource_alias1::OwnThing::new(MyThing {
+                    value: Some(t),
+                })
+            })
+            .collect()
     }
 }
 impl exports::test::resource_alias_redux::resource_alias1::GuestThing for MyThing {
-    fn new(s: wit_bindgen::rt::string::String) -> Self {
+    fn new(s: String) -> Self {
         Self {
-            value: Some(ImportThing::new(&(s + " Thing")))
+            value: Some(ImportThing::new(&(s + " Thing"))),
         }
     }
-    fn get(&self) -> wit_bindgen::rt::string::String {
+    fn get(&self) -> String {
         self.value.as_ref().unwrap().get() + " Thing.get"
     }
 }
@@ -51,23 +55,25 @@ impl exports::test::resource_alias_redux::resource_alias2::Guest for MyResourceA
     fn b(
         mut f: exports::test::resource_alias_redux::resource_alias2::Foo,
         mut g: exports::test::resource_alias_redux::resource_alias2::Bar,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_alias_redux::resource_alias2::OwnThing>
-    {
+    ) -> Vec<exports::test::resource_alias_redux::resource_alias2::OwnThing> {
         let foo = ImportAlias2Foo {
-            thing: Option::take(&mut f.thing.value).unwrap()
+            thing: Option::take(&mut f.thing.value).unwrap(),
         };
         let bar = ImportAlias1Foo {
-            thing: Option::take(&mut g.thing.value).unwrap()
+            thing: Option::take(&mut g.thing.value).unwrap(),
         };
-        import_b(foo, bar).into_iter().map(|t| {
-            exports::test::resource_alias_redux::resource_alias1::OwnThing::new(MyThing {
-                value: Some(t)
-            }) 
-        }).collect()
+        import_b(foo, bar)
+            .into_iter()
+            .map(|t| {
+                exports::test::resource_alias_redux::resource_alias1::OwnThing::new(MyThing {
+                    value: Some(t),
+                })
+            })
+            .collect()
     }
 }
 impl Guest for Test {
-    fn test(things: wit_bindgen::rt::vec::Vec<Thing>) -> wit_bindgen::rt::vec::Vec<Thing> {
+    fn test(things: Vec<Thing>) -> Vec<Thing> {
         things
     }
 }

--- a/tests/runtime/resource_borrow_in_record/wasm.rs
+++ b/tests/runtime/resource_borrow_in_record/wasm.rs
@@ -8,29 +8,26 @@ wit_bindgen::generate!({
 });
 
 use exports::test::resource_borrow_in_record::test::{Guest, GuestThing, OwnThing};
-use test::resource_borrow_in_record::test::Thing;
 use test::resource_borrow_in_record::test::Foo;
+use test::resource_borrow_in_record::test::Thing;
 
 pub struct Test {}
 
 impl Guest for Test {
     fn test(
-        a: wit_bindgen::rt::vec::Vec<exports::test::resource_borrow_in_record::test::Foo>,
-    ) -> wit_bindgen::rt::vec::Vec<exports::test::resource_borrow_in_record::test::OwnThing> {
-        let foo = a.iter()
-            .map(|a: &exports::test::resource_borrow_in_record::test::Foo| {
-                Foo {
+        a: Vec<exports::test::resource_borrow_in_record::test::Foo>,
+    ) -> Vec<exports::test::resource_borrow_in_record::test::OwnThing> {
+        let foo = a
+            .iter()
+            .map(
+                |a: &exports::test::resource_borrow_in_record::test::Foo| Foo {
                     thing: &a.thing.thing,
-                }
-            })
+                },
+            )
             .collect::<Vec<Foo>>();
         test::resource_borrow_in_record::test::test(&foo)
             .into_iter()
-            .map(|a| {
-                OwnThing::new(
-                    MyThing::from_thing(a),
-                ) 
-            })
+            .map(|a| OwnThing::new(MyThing::from_thing(a)))
             .collect()
     }
 }
@@ -47,12 +44,12 @@ impl MyThing {
 }
 
 impl GuestThing for MyThing {
-    fn new(s: wit_bindgen::rt::string::String) -> Self {
+    fn new(s: String) -> Self {
         Self {
             thing: Thing::new(&format!("{} Thing", s)),
         }
     }
-    fn get(&self) -> wit_bindgen::rt::string::String {
+    fn get(&self) -> String {
         self.thing.get() + " Thing.get"
     }
 }

--- a/tests/runtime/resource_into_inner/wasm.rs
+++ b/tests/runtime/resource_into_inner/wasm.rs
@@ -8,7 +8,6 @@ wit_bindgen::generate!({
 });
 
 use exports::test::resource_into_inner::test::{Guest, GuestThing};
-use wit_bindgen::rt::Resource;
 
 pub struct Test;
 

--- a/tests/runtime/resource_with_lists/wasm.rs
+++ b/tests/runtime/resource_with_lists/wasm.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
     }
 });
 
-use test::resource_with_lists::test::Thing;
 use exports::test::resource_with_lists::test::GuestThing;
+use test::resource_with_lists::test::Thing;
 
 pub struct Test {}
 
@@ -16,27 +16,25 @@ pub struct MyThing {
 }
 
 impl GuestThing for MyThing {
-    fn new(l: wit_bindgen::rt::vec::Vec::<u8>,) -> Self { 
+    fn new(l: Vec<u8>) -> Self {
         let mut result = l.clone();
         result.extend_from_slice(" Thing".as_bytes());
         let result = Thing::new(&result);
-        Self {
-            val: result,
-        }
+        Self { val: result }
     }
-    fn foo(&self,) -> wit_bindgen::rt::vec::Vec::<u8>{ 
+    fn foo(&self) -> Vec<u8> {
         let mut list = self.val.foo().clone();
         list.extend_from_slice(" Thing.foo".as_bytes());
         list
     }
 
-    fn bar(&self,l: wit_bindgen::rt::vec::Vec::<u8>,){ 
+    fn bar(&self, l: Vec<u8>) {
         let mut result = l.clone();
         result.extend_from_slice(" Thing.bar".as_bytes());
         self.val.bar(&result);
     }
-  
-    fn baz(l: wit_bindgen::rt::vec::Vec::<u8>,) -> wit_bindgen::rt::vec::Vec::<u8>{ 
+
+    fn baz(l: Vec<u8>) -> Vec<u8> {
         let mut result = l.clone();
         result.extend_from_slice(" Thing.baz".as_bytes());
         let mut list2 = Thing::baz(&result).clone();

--- a/tests/runtime/resources/wasm.rs
+++ b/tests/runtime/resources/wasm.rs
@@ -11,8 +11,8 @@ wit_bindgen::generate!({
     }
 });
 
-use exports::exports::OwnX;
 use exports::exports::OwnKebabCase;
+use exports::exports::OwnX;
 
 pub struct Test {}
 
@@ -29,8 +29,8 @@ pub struct ComponentKebabCase {
 }
 
 impl exports::exports::Guest for Test {
-    fn add(a: &ComponentZ, b: &ComponentZ) -> wit_bindgen::Resource<ComponentZ> {
-        wit_bindgen::Resource::new(ComponentZ { val: a.val + b.val })
+    fn add(a: &ComponentZ, b: &ComponentZ) -> Resource<ComponentZ> {
+        Resource::new(ComponentZ { val: a.val + b.val })
     }
     fn test_imports() -> Result<(), String> {
         use imports::*;


### PR DESCRIPTION
This PR is borne out of discussion on https://github.com/bytecodealliance/cargo-component/issues/236 where the conclusion was that it'd be best if the generated code that `wit-bindgen` emits is largely standalone and doesn't need any extra supporting crate. That enables the `cargo component` generator to not exactly match the `wit-bindgen` crate, if any, going forward.

Given that this PR is the implementation of everything there except the `cabi_realloc` bits. All other runtime bits from the `wit-bindgen` crate have now moved into the generated code itself. Specifically, when needed, a top-level `_rt` module is generated at the macro invocation site. Any references to the runtime now go through that module. This means that `Resource<T>` won't be shared between two invocations of the macro, for example.

I've left behind all the bits in the `wit-bindgen` crate from the current version, 0.19.0, and marked them as "someone please delete them in the future". That should make a future release of this crate as suitable for use with the 0.19.0 release of this generator, meaning that we won't break `cargo component` workflows immediately. Eventually once `cargo component` has upgraded to a release including this PR then the bits can be phased out.