### PR TITLE
Support multiple `--with` arguments in the Rust generator

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -878,7 +878,6 @@ impl WorldGenerator for RustWasm {
         self.types.analyze(resolve);
         self.world = Some(world);
 
-        dbg!(&self.opts.with);
         for (k, v) in self.opts.with.iter() {
             self.with.insert(k.clone(), v.clone());
         }


### PR DESCRIPTION
Don't require one large `--with`, support having multiple arguments.