### PR TITLE
Add `no_std` to `wit-bindgen-rt` crate.

### DIFF
--- a/crates/guest-rust/rt/src/lib.rs
+++ b/crates/guest-rust/rt/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate alloc;
 
 /// For more information about this see `./ci/rebuild-libcabi-realloc.sh`.


### PR DESCRIPTION
We forgot to add this when we refactored `wit-bindgen-rt` into its own crate.