### PR TITLE
Rust: avoid emitting trailing whitespace

### DIFF
--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -38,6 +38,7 @@ pub struct Source {
     s: String,
     indent: usize,
     in_line_comment: bool,
+    continuing_line: bool,
 }
 
 impl Source {
@@ -50,6 +51,15 @@ impl Source {
     pub fn push_str(&mut self, src: &str) {
         let lines = src.lines().collect::<Vec<_>>();
         for (i, line) in lines.iter().enumerate() {
+            if !self.continuing_line {
+                if !line.is_empty() {
+                    for _ in 0..self.indent {
+                        self.s.push_str("  ");
+                    }
+                }
+                self.continuing_line = true;
+            }
+
             let trimmed = line.trim();
             if trimmed.starts_with("//") {
                 self.in_line_comment = true;
@@ -94,10 +104,8 @@ impl Source {
 
     fn newline(&mut self) {
         self.in_line_comment = false;
+        self.continuing_line = false;
         self.s.push('\n');
-        for _ in 0..self.indent {
-            self.s.push_str("  ");
-        }
     }
 
     pub fn as_mut_string(&mut self) -> &mut String {

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -102,6 +102,13 @@ impl Source {
         self.indent -= amt;
     }
 
+    /// Set the indentation level, and return the old level.
+    pub fn set_indent(&mut self, amt: usize) -> usize {
+        let old = self.indent;
+        self.indent = amt;
+        old
+    }
+
     fn newline(&mut self) {
         self.in_line_comment = false;
         self.continuing_line = false;

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -334,11 +334,11 @@ macro_rules! {macro_name} {{
         if self.return_pointer_area_align > 0 {
             uwrite!(
                 self.src,
-                "
+                "\
                     #[repr(align({align}))]
                     struct _RetArea([::core::mem::MaybeUninit::<u8>; {size}]);
                     static mut _RET_AREA: _RetArea = _RetArea([::core::mem::MaybeUninit::uninit(); {size}]);
-                ",
+",
                 align = self.return_pointer_area_align,
                 size = self.return_pointer_area_size,
             );
@@ -393,7 +393,7 @@ macro_rules! {macro_name} {{
         let module = self.finish();
         let path_to_root = self.path_to_root();
         let module = format!(
-            "
+            "\
                 #[allow(clippy::all)]
                 pub mod {snake} {{
                     #[used]
@@ -402,7 +402,7 @@ macro_rules! {macro_name} {{
                     static __FORCE_SECTION_REF: fn() = {path_to_root}__link_custom_section_describing_imports;
                     {module}
                 }}
-            ",
+",
         );
         let map = if self.in_import {
             &mut self.gen.import_modules
@@ -461,11 +461,11 @@ macro_rules! {macro_name} {{
         if import_return_pointer_area_size > 0 {
             uwrite!(
                 self.src,
-                "
+                "\
                     #[repr(align({import_return_pointer_area_align}))]
                     struct RetArea([::core::mem::MaybeUninit::<u8>; {import_return_pointer_area_size}]);
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); {import_return_pointer_area_size}]);
-                ",
+",
             );
         }
         self.src.push_str(&String::from(src));
@@ -485,11 +485,11 @@ macro_rules! {macro_name} {{
         let name_snake = func.name.to_snake_case().replace('.', "_");
         uwrite!(
             self.src,
-            "
+            "\
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
                 pub unsafe fn _export_{name_snake}_cabi<T: {trait_name}>\
-            ",
+",
         );
         let params = self.print_export_sig(func);
         self.push_str(" {");
@@ -498,7 +498,7 @@ macro_rules! {macro_name} {{
             let run_ctors_once = self.path_to_run_ctors_once();
             uwrite!(
                 self.src,
-                "
+                "\
                 // Before executing any other code, use this function to run all static
                 // constructors, if they have not yet been run. This is a hack required
                 // to work around wasi-libc ctors calling import functions to initialize
@@ -512,7 +512,7 @@ macro_rules! {macro_name} {{
                 // for more details.
                 #[cfg(target_arch=\"wasm32\")]
                 {run_ctors_once}();
-            ",
+",
             );
         }
 
@@ -541,11 +541,11 @@ macro_rules! {macro_name} {{
         if abi::guest_export_needs_post_return(self.resolve, func) {
             uwrite!(
                 self.src,
-                "
+                "\
                     #[doc(hidden)]
                     #[allow(non_snake_case)]
                     pub unsafe fn __post_return_{name_snake}<T: {trait_name}>\
-                "
+"
             );
             let params = self.print_post_return_sig(func);
             self.src.push_str("{\n");
@@ -575,10 +575,10 @@ macro_rules! {macro_name} {{
         let export_name = func.core_export_name(wasm_module_export_name.as_deref());
         uwrite!(
             self.src,
-            "
+            "\
                 #[export_name = \"{export_prefix}{export_name}\"]
                 unsafe extern \"C\" fn export_{name_snake}\
-            ",
+",
         );
 
         let params = self.print_export_sig(func);
@@ -594,10 +594,10 @@ macro_rules! {macro_name} {{
             let export_prefix = self.gen.opts.export_prefix.as_deref().unwrap_or("");
             uwrite!(
                 self.src,
-                "
+                "\
                     #[export_name = \"{export_prefix}cabi_post_{export_name}\"]
                     unsafe extern \"C\" fn _post_return_{name_snake}\
-                "
+"
             );
             let params = self.print_post_return_sig(func);
             self.src.push_str("{\n");
@@ -717,8 +717,11 @@ macro_rules! {macro_name} {{
             None => return,
         };
         for line in docs.trim().lines() {
-            self.push_str("/// ");
-            self.push_str(line);
+            self.push_str("///");
+            if !line.is_empty() {
+                self.push_str(" ");
+                self.push_str(line);
+            }
             self.push_str("\n");
         }
     }
@@ -1462,7 +1465,7 @@ macro_rules! {macro_name} {{
             }
             self.push_str(&format!("pub enum {name}"));
             self.print_generics(mode.lifetime);
-            self.push_str("{\n");
+            self.push_str(" {\n");
             for (case_name, docs, payload) in cases.clone() {
                 self.rustdoc(docs);
                 self.push_str(&case_name);

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -739,6 +739,7 @@ macro_rules! __export_{world_name}_impl {{
             "pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; {}] = *b\"\\\n",
             component_type.len()
         ));
+        let old_indent = self.src.set_indent(0);
         let mut line_length = 0;
         let s = self.src.as_mut_string();
         for byte in component_type.iter() {
@@ -771,6 +772,7 @@ macro_rules! __export_{world_name}_impl {{
         }
 
         self.src.push_str("\";\n");
+        self.src.set_indent(old_indent);
 
         if let Some(func_name) = func_name {
             let rt = self.runtime_path().to_string();


### PR DESCRIPTION
This works around what appears to be a bug in rustfmt when generating bindings for wasi-http. If the code is too complex, rustfmt appears to stops formatting, and then abort when it leaves behind trailing whitespace.