### PR TITLE
doc: remove `exports` section from `generate!` options

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -668,55 +668,6 @@
 ///     // By default this set is empty.
 ///     additional_derives: [PartialEq, Eq, Hash, Clone],
 ///
-///     // If the `world` being generated has any exports, then this option is
-///     // required. Each exported interface must have an entry here in addition
-///     // to a `world` key if the world has any top-level exported functions.
-///     //
-///     // Each entry in this map points to a type in Rust. The specified type
-///     // must implement the generated trait.
-///     exports: {
-///         // If the WIT world has top-level function exports, such as:
-///         //
-///         //      world my-world {
-///         //          export foo: func();
-///         //      }
-///         //
-///         // then this option specifies which type implements the world's
-///         // exported functions.
-///         world: MyWorld,
-///
-///         // For each exported interface from a world a key is additionally
-///         // required. Each key must be a string of the form "a:b/c"
-///         // specifying the "WIT path" to the interface. For example:
-///         //
-///         //      package my:package;
-///         //
-///         //      interface my-interface {
-///         //          foo: func();
-///         //      }
-///         //
-///         //      world my-world {
-///         //          export my-interface;
-///         //          export wasi:random/insecure-seed;
-///         //      }
-///         //
-///         // this would require these fields to be specified:
-///         "my:package/my-interface": MyInterface,
-///         "wasi:random/insecure-seed": MyInsecureSeed,
-///
-///         // If an unnamed interface is used then the export's name is the key
-///         // to use:
-///         //
-///         //      world my-world {
-///         //          export foo: interface {
-///         //              some-func: func();
-///         //          }
-///         //      }
-///         //
-///         // would require:
-///         "foo": MyFoo,
-///     },
-///
 ///     // When generating bindings for imports it might be the case that
 ///     // bindings were already generated in a different crate. For example
 ///     // if your world refers to WASI types then the `wasi` crate already


### PR DESCRIPTION
This PR removes the documentation for the `exports` map in the `generate!` macro as the export behavior has changed in #871