### PR TITLE
Allow for multiple generated WasmImportLinkageAttributes

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -478,7 +478,7 @@ impl WorldGenerator for CSharp {
                 /* of WASI libc prevent us doing so. */
                 /* See https://github.com/bytecodealliance/wit-bindgen/issues/777  */
                 /* and https://github.com/WebAssembly/wasi-libc/issues/452 */
-                /* The component model `start` function might be an alternative to this depending on whether it
+                /* The component model `start` function might be an alternative to this depending on whether it */
                 /* has the same constraints as `cabi_realloc` */
                 __attribute__((__weak__, __export_name__("cabi_realloc")))
                 void *cabi_realloc(void *ptr, size_t old_size, size_t align, size_t new_size) {
@@ -586,7 +586,7 @@ impl WorldGenerator for CSharp {
             // temporarily add this attribute until it is available in dotnet 9
             namespace System.Runtime.InteropServices
             {
-                public class WasmImportLinkageAttribute : Attribute {}
+                internal partial class WasmImportLinkageAttribute : Attribute {}
             }
             "#,
         );


### PR DESCRIPTION
When generating c# code for multiple worlds, where might be a clash between multiple generated WasmImportLinkageAttributes.