### PR TITLE
Several tidyings in the C bindings

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1691,7 +1691,7 @@ impl InterfaceGenerator<'_> {
         // canonical ABI.
         uwriteln!(
             self.src.c_adapters,
-            "\n__attribute__((__used__, __export_name__(\"{export_name}\")))"
+            "\n__attribute__((__export_name__(\"{export_name}\")))"
         );
         let name = self.c_func_name(interface_name, func);
         let import_name = self.gen.names.tmp(&format!("__wasm_export_{name}"));
@@ -1733,7 +1733,7 @@ impl InterfaceGenerator<'_> {
         if abi::guest_export_needs_post_return(self.resolve, func) {
             uwriteln!(
                 self.src.c_fns,
-                "__attribute__((__used__, __export_name__(\"cabi_post_{export_name}\")))"
+                "__attribute__((__export_name__(\"cabi_post_{export_name}\")))"
             );
             uwrite!(self.src.c_fns, "void {import_name}_post_return(");
 

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1733,7 +1733,7 @@ impl InterfaceGenerator<'_> {
         if abi::guest_export_needs_post_return(self.resolve, func) {
             uwriteln!(
                 self.src.c_fns,
-                "__attribute__((__export_name__(\"cabi_post_{export_name}\")))"
+                "__attribute__((__weak__, __export_name__(\"cabi_post_{export_name}\")))"
             );
             uwrite!(self.src.c_fns, "void {import_name}_post_return(");
 

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -181,6 +181,7 @@ impl WorldGenerator for C {
             if i == 0 {
                 let name = resolve.name_world_key(name);
                 uwriteln!(gen.src.h_fns, "\n// Imported Functions from `{name}`");
+                uwriteln!(gen.src.c_fns, "\n// Imported Functions from `{name}`");
             }
             gen.import(Some(name), func);
         }
@@ -202,6 +203,7 @@ impl WorldGenerator for C {
         for (i, (_name, func)) in funcs.iter().enumerate() {
             if i == 0 {
                 uwriteln!(gen.src.h_fns, "\n// Imported Functions from `{name}`");
+                uwriteln!(gen.src.c_fns, "\n// Imported Functions from `{name}`");
             }
             gen.import(None, func);
         }
@@ -224,6 +226,7 @@ impl WorldGenerator for C {
             if i == 0 {
                 let name = resolve.name_world_key(name);
                 uwriteln!(gen.src.h_fns, "\n// Exported Functions from `{name}`");
+                uwriteln!(gen.src.c_fns, "\n// Exported Functions from `{name}`");
             }
             gen.export(func, Some(name));
         }
@@ -246,6 +249,7 @@ impl WorldGenerator for C {
         for (i, (_name, func)) in funcs.iter().enumerate() {
             if i == 0 {
                 uwriteln!(gen.src.h_fns, "\n// Exported Functions from `{name}`");
+                uwriteln!(gen.src.c_fns, "\n// Exported Functions from `{name}`");
             }
             gen.export(func, None);
         }
@@ -272,8 +276,11 @@ impl WorldGenerator for C {
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         let linking_symbol = component_type_object::linking_symbol(&self.world);
-        self.include("<stdlib.h>");
         let snake = self.world.to_snake_case();
+        uwriteln!(
+            self.src.c_adapters,
+            "\n// Ensure that the *_component_type.o object is linked in"
+        );
         uwrite!(
             self.src.c_adapters,
             "
@@ -385,9 +392,7 @@ impl WorldGenerator for C {
         let mut c_str = wit_bindgen_core::Source::default();
         wit_bindgen_core::generated_preamble(&mut c_str, version);
         uwriteln!(c_str, "#include \"{snake}.h\"");
-        if c_str.len() > 0 {
-            c_str.push_str("\n");
-        }
+        uwriteln!(c_str, "#include <stdlib.h>");
         c_str.push_str(&self.src.c_defs);
         c_str.push_str(&self.src.c_fns);
 
@@ -395,7 +400,7 @@ impl WorldGenerator for C {
             uwriteln!(
                 h_str,
                 "
-                typedef struct {{\n\
+                typedef struct {snake}_string_t {{\n\
                   {ty} *ptr;\n\
                   size_t len;\n\
                 }} {snake}_string_t;",
@@ -825,6 +830,8 @@ impl C {
     fn print_intrinsics(&mut self) {
         // Note that these intrinsics are declared as `weak` so they can be
         // overridden from some other symbol.
+        self.src.c_fns("\n// Canonical ABI intrinsics");
+        self.src.c_fns("\n");
         self.src.c_fns(
             r#"
                 __attribute__((__weak__, __export_name__("cabi_realloc")))
@@ -918,7 +925,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     fn type_record(&mut self, id: TypeId, _name: &str, record: &Record, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         for field in record.fields.iter() {
             self.docs(&field.docs, SourceType::HDefs);
             self.print_ty(SourceType::HDefs, &field.ty);
@@ -926,8 +933,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             self.src.h_defs(&to_c_ident(&field.name));
             self.src.h_defs(";\n");
         }
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
     }
 
     fn type_resource(&mut self, id: TypeId, name: &str, _docs: &Docs) {
@@ -1097,13 +1103,12 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
     fn type_tuple(&mut self, id: TypeId, _name: &str, tuple: &Tuple, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         for (i, ty) in tuple.types.iter().enumerate() {
             self.print_ty(SourceType::HDefs, ty);
             uwriteln!(self.src.h_defs, " f{i};");
         }
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
     }
 
     fn type_flags(&mut self, id: TypeId, name: &str, flags: &Flags, docs: &Docs) {
@@ -1133,7 +1138,7 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
     fn type_variant(&mut self, id: TypeId, name: &str, variant: &Variant, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         self.src.h_defs(int_repr(variant.tag()));
         self.src.h_defs(" tag;\n");
 
@@ -1154,8 +1159,7 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
             }
             self.src.h_defs("} val;\n");
         }
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
 
         if variant.cases.len() > 0 {
             self.src.h_defs("\n");
@@ -1175,18 +1179,17 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
     fn type_option(&mut self, id: TypeId, _name: &str, payload: &Type, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         self.src.h_defs("bool is_some;\n");
         self.print_ty(SourceType::HDefs, payload);
         self.src.h_defs(" val;\n");
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
     }
 
     fn type_result(&mut self, id: TypeId, _name: &str, result: &Result_, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         self.src.h_defs("bool is_err;\n");
         if result.ok.is_some() || result.err.is_some() {
             self.src.h_defs("union {\n");
@@ -1200,8 +1203,7 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
             }
             self.src.h_defs("} val;\n");
         }
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
     }
 
     fn type_enum(&mut self, id: TypeId, name: &str, enum_: &Enum, docs: &Docs) {
@@ -1246,12 +1248,11 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
     fn type_list(&mut self, id: TypeId, _name: &str, ty: &Type, docs: &Docs) {
         self.src.h_defs("\n");
         self.docs(docs, SourceType::HDefs);
-        self.src.h_defs("typedef struct {\n");
+        self.start_typedef_struct(id);
         self.print_ty(SourceType::HDefs, ty);
         self.src.h_defs(" *ptr;\n");
         self.src.h_defs("size_t len;\n");
-        self.src.h_defs("} ");
-        self.print_typedef_target(id);
+        self.finish_typedef_struct(id);
     }
 
     fn type_builtin(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
@@ -1353,6 +1354,7 @@ impl InterfaceGenerator<'_> {
         }
 
         self.src.h_defs("\ntypedef ");
+        let name = &self.gen.type_names[&ty];
         match kind {
             TypeDefKind::Type(_)
             | TypeDefKind::Flags(_)
@@ -1373,7 +1375,7 @@ impl InterfaceGenerator<'_> {
                 }
             }
             TypeDefKind::Tuple(t) => {
-                self.src.h_defs("struct {\n");
+                self.src.h_defs(&format!("struct {name} {{\n"));
                 for (i, t) in t.types.iter().enumerate() {
                     let ty = self.gen.type_name(t);
                     uwriteln!(self.src.h_defs, "{ty} f{i};");
@@ -1381,18 +1383,15 @@ impl InterfaceGenerator<'_> {
                 self.src.h_defs("}");
             }
             TypeDefKind::Option(t) => {
-                self.src.h_defs("struct {\n");
+                self.src.h_defs(&format!("struct {name} {{\n"));
                 self.src.h_defs("bool is_some;\n");
                 let ty = self.gen.type_name(t);
                 uwriteln!(self.src.h_defs, "{ty} val;");
                 self.src.h_defs("}");
             }
             TypeDefKind::Result(r) => {
-                self.src.h_defs(
-                    "struct {
-                        bool is_err;
-                    ",
-                );
+                self.src.h_defs(&format!("struct {name} {{\n"));
+                self.src.h_defs("bool is_err;\n");
                 let ok_ty = r.ok.as_ref();
                 let err_ty = r.err.as_ref();
                 if ok_ty.is_some() || err_ty.is_some() {
@@ -1410,7 +1409,7 @@ impl InterfaceGenerator<'_> {
                 self.src.h_defs("}");
             }
             TypeDefKind::List(t) => {
-                self.src.h_defs("struct {\n");
+                self.src.h_defs(&format!("struct {name} {{\n"));
                 let ty = self.gen.type_name(t);
                 uwriteln!(self.src.h_defs, "{ty} *ptr;");
                 self.src.h_defs("size_t len;\n");
@@ -1672,6 +1671,8 @@ impl InterfaceGenerator<'_> {
     fn export(&mut self, func: &Function, interface_name: Option<&WorldKey>) {
         let sig = self.resolve.wasm_signature(AbiVariant::GuestExport, func);
 
+        self.src.c_fns("\n");
+
         let core_module_name = interface_name.map(|s| self.resolve.name_world_key(s));
         let export_name = func.core_export_name(core_module_name.as_deref());
 
@@ -1683,7 +1684,7 @@ impl InterfaceGenerator<'_> {
         // canonical ABI.
         uwriteln!(
             self.src.c_adapters,
-            "\n__attribute__((__export_name__(\"{export_name}\")))"
+            "\n__attribute__((__used__, __export_name__(\"{export_name}\")))"
         );
         let name = self.c_func_name(interface_name, func);
         let import_name = self.gen.names.tmp(&format!("__wasm_export_{name}"));
@@ -1725,7 +1726,7 @@ impl InterfaceGenerator<'_> {
         if abi::guest_export_needs_post_return(self.resolve, func) {
             uwriteln!(
                 self.src.c_fns,
-                "__attribute__((__weak__, __export_name__(\"cabi_post_{export_name}\")))"
+                "__attribute__((__used__, __export_name__(\"cabi_post_{export_name}\")))"
             );
             uwrite!(self.src.c_fns, "void {import_name}_post_return(");
 
@@ -1877,6 +1878,18 @@ impl InterfaceGenerator<'_> {
         let name = &self.gen.type_names[&id];
         self.src.h_defs(&name);
         self.src.h_defs(";\n");
+    }
+
+    fn start_typedef_struct(&mut self, id: TypeId) {
+        let name = &self.gen.type_names[&id];
+        self.src.h_defs("typedef struct ");
+        self.src.h_defs(&name);
+        self.src.h_defs(" {\n");
+    }
+
+    fn finish_typedef_struct(&mut self, id: TypeId) {
+        self.src.h_defs("} ");
+        self.print_typedef_target(id);
     }
 
     fn owner_namespace(&self, id: TypeId) -> String {

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -276,6 +276,7 @@ impl WorldGenerator for C {
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         let linking_symbol = component_type_object::linking_symbol(&self.world);
+        self.include("<stdlib.h>");
         let snake = self.world.to_snake_case();
         uwriteln!(
             self.src.c_adapters,
@@ -382,17 +383,15 @@ impl WorldGenerator for C {
         h_str.deindent(1);
         uwriteln!(h_str, "\n#endif\n");
 
-        self.include("<stdint.h>");
-        self.include("<stdbool.h>");
-
-        for include in self.includes.iter() {
-            uwriteln!(h_str, "#include {include}");
-        }
+        uwriteln!(h_str, "#include <stdint.h>");
+        uwriteln!(h_str, "#include <stdbool.h>");
 
         let mut c_str = wit_bindgen_core::Source::default();
         wit_bindgen_core::generated_preamble(&mut c_str, version);
         uwriteln!(c_str, "#include \"{snake}.h\"");
-        uwriteln!(c_str, "#include <stdlib.h>");
+        for include in self.includes.iter() {
+            uwriteln!(c_str, "#include {include}");
+        }
         c_str.push_str(&self.src.c_defs);
         c_str.push_str(&self.src.c_fns);
 

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -304,7 +304,7 @@ impl WorldGenerator for TinyGo {
         self.src.push_str("// #include \"");
         self.src.push_str(self.world.to_snake_case().as_str());
         self.src.push_str(".h\"\n");
-        self.src.push_str("// #include <stdlib.h>\\n");
+        self.src.push_str("// #include <stdlib.h>\n");
         if self.preamble.len() > 0 {
             self.src.append_src(&self.preamble);
         }

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -304,6 +304,7 @@ impl WorldGenerator for TinyGo {
         self.src.push_str("// #include \"");
         self.src.push_str(self.world.to_snake_case().as_str());
         self.src.push_str(".h\"\n");
+        self.src.push_str("// #include <stdlib.h>\\n");
         if self.preamble.len() > 0 {
             self.src.append_src(&self.preamble);
         }

--- a/tests/runtime/resource_import_and_export/wasm.c
+++ b/tests/runtime/resource_import_and_export/wasm.c
@@ -4,7 +4,7 @@
 /* #include <limits.h> */
 /* #include <math.h> */
 /* #include <stdalign.h> */
-/* #include <stdlib.h> */
+#include <stdlib.h>
 #include <string.h>
 
 struct exports_test_resource_import_and_export_test_thing_t {

--- a/tests/runtime/resources/wasm.c
+++ b/tests/runtime/resources/wasm.c
@@ -2,6 +2,7 @@
 #include <limits.h>
 #include <math.h>
 #include <resources.h>
+#include <stdlib.h>
 
 struct exports_x_t {
     int32_t a;

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <variants.h>
+#include <stddef.h>
 
 void variants_test_imports() {
   {


### PR DESCRIPTION
- Add several comments to the C bindings output

- Move the `#include <stdlib.h>` out of the `.h` file and into the `.c` file, since it's for `realloc`/`free` etc. and those are only used in the `.c` file.

- Use named structs inside of typedefs, so that the structs have names in the generated debug info.