### PR TITLE
Avoid clippy warning on generate macro

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -405,7 +405,7 @@ pub unsafe fn bool_lift(val: u8) -> bool {
             _ => panic!(\"invalid bool discriminant\"),
         }
     } else {
-        ::core::mem::transmute::<u8, bool>(val)
+        val != 0
     }
 }
                     ",


### PR DESCRIPTION
Clippy is issuing [a warning](https://rust-lang.github.io/rust-clippy/master/#/transmute_int_to_bool) due to this output by the `generate` macro. I just changed it to the recommended code in the linked page.