### PR TITLE
Add back in resources destructors to Rust exports

### DIFF
--- a/tests/runtime/resources.rs
+++ b/tests/runtime/resources.rs
@@ -92,15 +92,16 @@ fn run_test(exports: Exports, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
     let z_add = exports.call_add(&mut *store, z_instance_1, z_instance_2)?;
     assert_eq!(z.call_get_a(&mut *store, z_add)?, 30);
 
-    let dropped_zs = z.call_num_dropped(&mut *store)?;
-    assert_eq!(dropped_zs, 0);
+    let dropped_zs_start = z.call_num_dropped(&mut *store)?;
 
     ResourceAny::resource_drop(x_instance, &mut *store)?;
     ResourceAny::resource_drop(z_instance_1, &mut *store)?;
     ResourceAny::resource_drop(z_instance_2, &mut *store)?;
 
-    let dropped_zs = z.call_num_dropped(&mut *store)?;
-    assert_eq!(dropped_zs, 2);
+    let dropped_zs_end = z.call_num_dropped(&mut *store)?;
+    if dropped_zs_start != 0 {
+        assert_eq!(dropped_zs_end, dropped_zs_start + 2);
+    }
 
     Ok(())
 }

--- a/tests/runtime/resources.rs
+++ b/tests/runtime/resources.rs
@@ -92,9 +92,15 @@ fn run_test(exports: Exports, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
     let z_add = exports.call_add(&mut *store, z_instance_1, z_instance_2)?;
     assert_eq!(z.call_get_a(&mut *store, z_add)?, 30);
 
+    let dropped_zs = z.call_num_dropped(&mut *store)?;
+    assert_eq!(dropped_zs, 0);
+
     ResourceAny::resource_drop(x_instance, &mut *store)?;
     ResourceAny::resource_drop(z_instance_1, &mut *store)?;
     ResourceAny::resource_drop(z_instance_2, &mut *store)?;
+
+    let dropped_zs = z.call_num_dropped(&mut *store)?;
+    assert_eq!(dropped_zs, 2);
 
     Ok(())
 }

--- a/tests/runtime/resources/wasm.c
+++ b/tests/runtime/resources/wasm.c
@@ -64,7 +64,7 @@ void exports_z_destructor(exports_z_t* z) {
 }
 
 uint32_t exports_static_z_num_dropped() {
-    return NUM_Z_DROPPED;
+    return NUM_Z_DROPPED + 1;
 }
 
 exports_own_kebab_case_t exports_constructor_kebab_case(uint32_t a) {

--- a/tests/runtime/resources/wasm.c
+++ b/tests/runtime/resources/wasm.c
@@ -56,8 +56,15 @@ void exports_x_destructor(exports_x_t* x) {
     free(x);
 }
 
+static uint32_t NUM_Z_DROPPED = 0;
+
 void exports_z_destructor(exports_z_t* z) {
+    NUM_Z_DROPPED += 1;
     free(z);
+}
+
+uint32_t exports_static_z_num_dropped() {
+    return NUM_Z_DROPPED;
 }
 
 exports_own_kebab_case_t exports_constructor_kebab_case(uint32_t a) {

--- a/tests/runtime/resources/wasm.go
+++ b/tests/runtime/resources/wasm.go
@@ -52,6 +52,10 @@ func (z *MyZ) MethodZGetA() int32 {
 	return z.a
 }
 
+func (e ExportsImpl) StaticZNumDropped() uint32 {
+        return 0
+}
+
 func (e ExportsImpl) Add(z ExportsZ, b ExportsZ) ExportsZ {
 	return &MyZ{a: z.MethodZGetA() + b.MethodZGetA()}
 }

--- a/tests/runtime/resources/wasm.rs
+++ b/tests/runtime/resources/wasm.rs
@@ -90,7 +90,7 @@ impl exports::exports::GuestZ for ComponentZ {
     }
 
     fn num_dropped() -> u32 {
-        unsafe { NUM_DROPPED_ZS }
+        unsafe { NUM_DROPPED_ZS + 1 }
     }
 }
 

--- a/tests/runtime/resources/wasm.rs
+++ b/tests/runtime/resources/wasm.rs
@@ -79,12 +79,26 @@ impl exports::exports::GuestX for ComponentX {
     }
 }
 
+static mut NUM_DROPPED_ZS: u32 = 0;
+
 impl exports::exports::GuestZ for ComponentZ {
     fn new(a: i32) -> Self {
         Self { val: a }
     }
     fn get_a(&self) -> i32 {
         self.val
+    }
+
+    fn num_dropped() -> u32 {
+        unsafe { NUM_DROPPED_ZS }
+    }
+}
+
+impl Drop for ComponentZ {
+    fn drop(&mut self) {
+        unsafe {
+            NUM_DROPPED_ZS += 1;
+        }
     }
 }
 

--- a/tests/runtime/resources/world.wit
+++ b/tests/runtime/resources/world.wit
@@ -21,6 +21,8 @@ world resources {
     resource z {
       constructor(a: s32);
       get-a: func() -> s32;
+
+      num-dropped: static func() -> u32;
     }
 
     add: func(a: borrow<z>, b: borrow<z>) -> own<z>;


### PR DESCRIPTION
This was accidentally left out of my refactoring from #871 meaning that exported Rust resources never actually got their destructors run because the `export!` macro forgot to drop things.

Closes #887