### PR TITLE
rust: Don't require mutability for `P64ToP` cast

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -1357,7 +1357,7 @@ fn perform_cast(operand: &str, cast: &Bitcast) -> String {
         // Convert a `MaybeUninit<u64>` holding a pointer value back into
         // the pointer value.
         Bitcast::P64ToP => {
-            format!("{}.as_mut_ptr().cast::<*mut u8>().read()", operand)
+            format!("{}.as_ptr().cast::<*mut u8>().read()", operand)
         }
         // Convert an `i32` or a `usize` into a pointer.
         Bitcast::I32ToP | Bitcast::LToP => {

--- a/tests/codegen/variants-unioning-types.wit
+++ b/tests/codegen/variants-unioning-types.wit
@@ -92,4 +92,10 @@ world a {
     b(f32),
   }
   import f-s64-f32: func(x: v-s64-f32);
+
+  variant v-string-u64 {
+    a(string),
+    b(u64),
+  }
+  export f-string-u64: func(x: v-string-u64);
 }


### PR DESCRIPTION
Arguments to functions aren't declared as mutable so use a method that only needs `&self` which avoids the need to declare tyeps as mutable.

Closes #890