### PR TITLE
Start supporting the `wasm32-wasip2` target

### DIFF
--- a/crates/guest-rust/rt/src/lib.rs
+++ b/crates/guest-rust/rt/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 /// For more information about this see `./ci/rebuild-libcabi-realloc.sh`.
+#[cfg(not(target_env = "p2"))]
 mod cabi_realloc;
 
 /// This function is called from generated bindings and will be deleted by
@@ -13,7 +14,7 @@ mod cabi_realloc;
 ///
 /// For more information about this see `./ci/rebuild-libcabi-realloc.sh`.
 pub fn maybe_link_cabi_realloc() {
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_family = "wasm", not(target_env = "p2")))]
     {
         extern "C" {
             fn cabi_realloc(
@@ -44,6 +45,7 @@ pub fn maybe_link_cabi_realloc() {
 /// `cabi_realloc` module above. It's otherwise never explicitly called.
 ///
 /// For more information about this see `./ci/rebuild-libcabi-realloc.sh`.
+#[cfg(not(target_env = "p2"))]
 pub unsafe fn cabi_realloc(
     old_ptr: *mut u8,
     old_len: usize,

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -808,7 +808,7 @@ pub mod rt {
         wit_bindgen_rt::maybe_link_cabi_realloc();
     }
 
-    #[cfg(feature = "realloc")]
+    #[cfg(all(feature = "realloc", not(target_env = "p2")))]
     pub use wit_bindgen_rt::cabi_realloc;
 
     pub use crate::pre_wit_bindgen_0_20_0::*;

--- a/crates/test-rust-wasm/artifacts/build.rs
+++ b/crates/test-rust-wasm/artifacts/build.rs
@@ -10,17 +10,28 @@ fn main() {
 
     let wasi_adapter = manifest_dir.join("../../../tests/wasi_snapshot_preview1.reactor.wasm");
 
+    let target_to_test = match std::env::var("WIT_BINDGEN_WASI_TEST_TARGET") {
+        Ok(s) => s,
+        Err(_) => "wasm32-wasi".to_string(),
+    };
+
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .current_dir("../../test-rust-wasm")
-        .arg("--target=wasm32-wasi")
+        .arg("--target")
+        .arg(&target_to_test)
         .env("CARGO_TARGET_DIR", &out_dir)
         .env("CARGO_PROFILE_DEV_DEBUG", "1");
     let status = cmd.status().unwrap();
     assert!(status.success());
 
     let mut wasms = Vec::new();
-    for file in out_dir.join("wasm32-wasi/debug").read_dir().unwrap() {
+    for file in out_dir
+        .join(&target_to_test)
+        .join("debug")
+        .read_dir()
+        .unwrap()
+    {
         let file = file.unwrap().path();
         if file.extension().and_then(|s| s.to_str()) != Some("wasm") {
             continue;


### PR DESCRIPTION
This commit adds some initial support for `wasm32-wasip2` in `wit-bindgen`. Everything works as-is but one of the benefits of a new target is that we can move runtime bits such as `cabi_realloc` into the standard library rather than in this crate. This PR sets up infrastructure to test the `wasm32-wasip2` target and additionally assumes rust-lang/rust#122411 for providing the implementation of `cabi_realloc`.