### PR TITLE
rust: Add back in workdaround to call ctors once

### DIFF
--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -13,10 +13,10 @@ Used when compiling Rust programs to the component model.
 
 [dependencies]
 wit-bindgen-rust-macro = { path = "./macro", optional = true, version = "0.22.0" }
-wit-bindgen-rt = { path = "./rt", optional = true, version = "0.22.0" }
+wit-bindgen-rt = { path = "./rt", version = "0.22.0" }
 bitflags = { workspace = true }
 
 [features]
 default = ["macros", "realloc"]
 macros = ["dep:wit-bindgen-rust-macro"]
-realloc = ["dep:wit-bindgen-rt"]
+realloc = []

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -101,8 +101,8 @@ impl Parse for Config {
                     Opt::TypeSectionSuffix(suffix) => {
                         opts.type_section_suffix = Some(suffix.value());
                     }
-                    Opt::RunCtorsOnceWorkaround(enable) => {
-                        opts.run_ctors_once_workaround = enable.value();
+                    Opt::DisableRunCtorsOnceWorkaround(enable) => {
+                        opts.disable_run_ctors_once_workaround = enable.value();
                     }
                     Opt::DefaultBindingsModule(enable) => {
                         opts.default_bindings_module = Some(enable.value());
@@ -227,7 +227,7 @@ mod kw {
     syn::custom_keyword!(additional_derives);
     syn::custom_keyword!(with);
     syn::custom_keyword!(type_section_suffix);
-    syn::custom_keyword!(run_ctors_once_workaround);
+    syn::custom_keyword!(disable_run_ctors_once_workaround);
     syn::custom_keyword!(default_bindings_module);
     syn::custom_keyword!(export_macro_name);
     syn::custom_keyword!(pub_export_macro);
@@ -276,7 +276,7 @@ enum Opt {
     AdditionalDerives(Vec<syn::Path>),
     With(HashMap<String, String>),
     TypeSectionSuffix(syn::LitStr),
-    RunCtorsOnceWorkaround(syn::LitBool),
+    DisableRunCtorsOnceWorkaround(syn::LitBool),
     DefaultBindingsModule(syn::LitStr),
     ExportMacroName(syn::LitStr),
     PubExportMacro(syn::LitBool),
@@ -382,10 +382,10 @@ impl Parse for Opt {
             input.parse::<kw::type_section_suffix>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::TypeSectionSuffix(input.parse()?))
-        } else if l.peek(kw::run_ctors_once_workaround) {
-            input.parse::<kw::run_ctors_once_workaround>()?;
+        } else if l.peek(kw::disable_run_ctors_once_workaround) {
+            input.parse::<kw::disable_run_ctors_once_workaround>()?;
             input.parse::<Token![:]>()?;
-            Ok(Opt::RunCtorsOnceWorkaround(input.parse()?))
+            Ok(Opt::DisableRunCtorsOnceWorkaround(input.parse()?))
         } else if l.peek(kw::default_bindings_module) {
             input.parse::<kw::default_bindings_module>()?;
             input.parse::<Token![:]>()?;

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -782,9 +782,9 @@
 ///     // support the standard library itself depending on this crate one day.
 ///     std_feature,
 ///
-///     // Force a workaround to be emitted for pre-Rust-1.69.0 modules to
-///     // ensure that libc ctors run only once.
-///     run_ctors_once_workaround: true,
+///     // Disable a workaround to force wasm constructors to be run only once
+///     // when exported functions are called.
+///     disable_run_ctors_once_workaround: false,
 /// });
 /// ```
 ///
@@ -803,6 +803,9 @@ pub mod examples;
 
 #[doc(hidden)]
 pub mod rt {
+    #[cfg(target_arch = "wasm32")]
+    pub use wit_bindgen_rt::run_ctors_once;
+
     pub fn maybe_link_cabi_realloc() {
         #[cfg(feature = "realloc")]
         wit_bindgen_rt::maybe_link_cabi_realloc();

--- a/crates/guest-rust/src/pre_wit_bindgen_0_20_0.rs
+++ b/crates/guest-rust/src/pre_wit_bindgen_0_20_0.rs
@@ -19,35 +19,6 @@ use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
 
 pub use alloc_crate::{alloc, boxed, string, vec};
 
-/// Provide a hook for generated export functions to run static
-/// constructors at most once. wit-bindgen-rust generates a call to this
-/// function at the start of all component export functions. Importantly,
-/// it is not called as part of `cabi_realloc`, which is a *core* export
-/// func, but may not execute ctors, because the environment ctor in
-/// wasi-libc (before rust 1.69.0) calls an import func, which is not
-/// permitted by the Component Model when inside realloc.
-///
-/// We intend to remove this once rust 1.69.0 stabilizes.
-#[cfg(target_arch = "wasm32")]
-pub fn run_ctors_once() {
-    static mut RUN: bool = false;
-    unsafe {
-        if !RUN {
-            // This function is synthesized by `wasm-ld` to run all static
-            // constructors. wasm-ld will either provide an implementation
-            // of this symbol, or synthesize a wrapper around each
-            // exported function to (unconditionally) run ctors. By using
-            // this function, the linked module is opting into "manually"
-            // running ctors.
-            extern "C" {
-                fn __wasm_call_ctors();
-            }
-            __wasm_call_ctors();
-            RUN = true;
-        }
-    }
-}
-
 pub unsafe fn dealloc(ptr: i32, size: usize, align: usize) {
     if size == 0 {
         return;

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -519,25 +519,19 @@ macro_rules! {macro_name} {{
         let params = self.print_export_sig(func);
         self.push_str(" {");
 
-        if self.gen.opts.run_ctors_once_workaround {
+        if !self.gen.opts.disable_run_ctors_once_workaround {
             let run_ctors_once = self.path_to_run_ctors_once();
+            // Before executing any other code, use this function to run all
+            // static constructors, if they have not yet been run. This is a
+            // hack required to work around wasi-libc ctors calling import
+            // functions to initialize the environment.
+            //
+            // See
+            // https://github.com/bytecodealliance/preview2-prototyping/issues/99
+            // for more details.
             uwrite!(
                 self.src,
-                "\
-                // Before executing any other code, use this function to run all static
-                // constructors, if they have not yet been run. This is a hack required
-                // to work around wasi-libc ctors calling import functions to initialize
-                // the environment.
-                //
-                // This functionality will be removed once rust 1.69.0 is stable, at which
-                // point wasi-libc will no longer have this behavior.
-                //
-                // See
-                // https://github.com/bytecodealliance/preview2-prototyping/issues/99
-                // for more details.
-                #[cfg(target_arch=\"wasm32\")]
-                {run_ctors_once}();
-",
+                "#[cfg(target_arch=\"wasm32\")]\n{run_ctors_once}();",
             );
         }
 
@@ -1917,7 +1911,7 @@ macro_rules! {macro_name} {{
     }
 
     fn path_to_run_ctors_once(&mut self) -> String {
-        self.path_from_runtime_module(RuntimeItem::RunCtorsOnce, "bool_lift")
+        self.path_from_runtime_module(RuntimeItem::RunCtorsOnce, "run_ctors_once")
     }
 
     pub fn path_to_vec(&mut self) -> String {

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -86,7 +86,7 @@ mod run_ctors_once_workaround {
                 export apply-the-workaround: func();
             }
         ",
-        run_ctors_once_workaround: true,
+        disable_run_ctors_once_workaround: true,
         stubs,
     });
 }


### PR DESCRIPTION
This commit partially reverts some work in #868 where the pieces used to run libc ctors once was removed by default. I erroneously thought that this was no longer necessary but I believe it is still necessary given how everything works today. I've additionally updated comments accordingly.

Closes #894