### PR TITLE
Add `#[dead_code]` to the Rust generated bindings.

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -419,7 +419,7 @@ macro_rules! {macro_name} {{
         let path_to_root = self.path_to_root();
         let module = format!(
             "\
-                #[allow(clippy::all)]
+                #[allow(dead_code, clippy::all)]
                 pub mod {snake} {{
                     #[used]
                     #[doc(hidden)]

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -242,6 +242,11 @@ impl RustWasm {
         emit(&mut self.src, map);
         fn emit(me: &mut Source, module: Module) {
             for (name, submodule) in module.submodules {
+                // Ignore dead-code warnings. If the bindings are only used
+                // within a crate, and not exported to a different crate, some
+                // parts may be unused, and that's ok.
+                uwriteln!(me, "#[allow(dead_code)]");
+
                 uwriteln!(me, "pub mod {name} {{");
                 emit(me, submodule);
                 uwriteln!(me, "}}");


### PR DESCRIPTION
This uses attributes on each `pub mod` instead of one at the top of the file, because wit-bindgen's output can sometimes be nested inside of other constructs.

Fixes #896.