### PR TITLE
Have wit-bindgen-rt optionally provide a re-export of bitflags.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,6 @@ dependencies = [
 name = "wit-bindgen"
 version = "0.22.0"
 dependencies = [
- "bitflags 2.4.2",
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
 ]
@@ -2451,6 +2450,9 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rt"
 version = "0.22.0"
+dependencies = [
+ "bitflags 2.4.2",
+]
 
 [[package]]
 name = "wit-bindgen-rust"

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -13,8 +13,7 @@ Used when compiling Rust programs to the component model.
 
 [dependencies]
 wit-bindgen-rust-macro = { path = "./macro", optional = true, version = "0.22.0" }
-wit-bindgen-rt = { path = "./rt", version = "0.22.0" }
-bitflags = { workspace = true }
+wit-bindgen-rt = { path = "./rt", version = "0.22.0", features = ["bitflags"] }
 
 [features]
 default = ["macros", "realloc"]

--- a/crates/guest-rust/rt/Cargo.toml
+++ b/crates/guest-rust/rt/Cargo.toml
@@ -8,3 +8,7 @@ homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 Runtime support for the `wit-bindgen` crate
 """
+
+[dependencies]
+# Optionally re-export the version of bitflags used by wit-bindgen.
+bitflags = { workspace = true, optional = true }

--- a/crates/guest-rust/rt/src/lib.rs
+++ b/crates/guest-rust/rt/src/lib.rs
@@ -2,6 +2,11 @@
 
 extern crate alloc;
 
+// Re-export `bitflags` so that we can reference it from macros.
+#[cfg(feature = "bitflags")]
+#[doc(hidden)]
+pub use bitflags;
+
 /// For more information about this see `./ci/rebuild-libcabi-realloc.sh`.
 #[cfg(not(target_env = "p2"))]
 mod cabi_realloc;

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -792,9 +792,10 @@
 #[cfg(feature = "macros")]
 pub use wit_bindgen_rust_macro::generate;
 
-// Re-export `bitflags` so that we can reference it from macros.
+// This re-export is no longer needed in new bindings and is only
+// here for compatibility.
 #[doc(hidden)]
-pub use wit_bindgen_rt::bitflags;
+pub use rt::bitflags;
 
 mod pre_wit_bindgen_0_20_0;
 
@@ -803,6 +804,9 @@ pub mod examples;
 
 #[doc(hidden)]
 pub mod rt {
+    // Re-export `bitflags` so that we can reference it from macros.
+    pub use wit_bindgen_rt::bitflags;
+
     #[cfg(target_arch = "wasm32")]
     pub use wit_bindgen_rt::run_ctors_once;
 

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -794,7 +794,7 @@ pub use wit_bindgen_rust_macro::generate;
 
 // Re-export `bitflags` so that we can reference it from macros.
 #[doc(hidden)]
-pub use bitflags;
+pub use wit_bindgen_rt::bitflags;
 
 mod pre_wit_bindgen_0_20_0;
 

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -259,11 +259,11 @@ impl RustWasm {
             .unwrap_or("wit_bindgen::rt")
     }
 
-    fn bitflags_path(&self) -> &str {
+    fn bitflags_path(&self) -> String {
         self.opts
             .bitflags_path
-            .as_deref()
-            .unwrap_or("wit_bindgen::bitflags")
+            .to_owned()
+            .unwrap_or(format!("{}::bitflags", self.runtime_path()))
     }
 
     fn name_interface(


### PR DESCRIPTION
This way, users of wit-bindgen-rt can get the same version of bitflags used by the generated bindings. And it's slightly tidier.

For example, instead of this:

```toml
[dependencies]
wit-bindgen-rt = "0.21.0"
bitflags = "2.4.2"
```

Users can use this:

```toml
[dependencies]
wit-bindgen-rt = { version = "0.21.0", features = ["bitflags"] }
```