### PR TITLE
Update wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-types",
 ]
 
@@ -1397,10 +1397,10 @@ name = "test-helpers"
 version = "0.0.0"
 dependencies = [
  "codegen-macro",
- "wasm-encoder",
+ "wasm-encoder 0.202.0",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -1680,10 +1680,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.201.0"
+name = "wasm-encoder"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
+checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1691,8 +1700,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -1707,13 +1716,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
+dependencies = [
+ "bitflags 2.5.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67e66da702706ba08729a78e3c0079085f6bfcb1a62e4799e97bbf728c2c265"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]
@@ -1745,8 +1765,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.201.0",
+ "wasmparser 0.201.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1803,7 +1823,7 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.201.0",
 ]
 
 [[package]]
@@ -1831,7 +1851,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -1872,8 +1892,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.201.0",
+ "wasmparser 0.201.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1937,7 +1957,7 @@ dependencies = [
  "psm",
  "rustix",
  "sptr",
- "wasm-encoder",
+ "wasm-encoder 0.201.0",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -1963,7 +1983,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.201.0",
 ]
 
 [[package]]
@@ -2019,7 +2039,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -2034,7 +2054,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap",
- "wit-parser",
+ "wit-parser 0.201.0",
 ]
 
 [[package]]
@@ -2054,24 +2074,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "201.0.0"
+version = "202.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef6e1ef34d7da3e2b374fd2b1a9c0227aff6cad596e1b24df9b58d0f6222faa"
+checksum = "1fbcb11204515c953c9b42ede0a46a1c5e17f82af05c4fae201a8efff1b0f4fe"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.202.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.201.0"
+version = "1.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453d5b37a45b98dee4f4cb68015fc73634d7883bbef1c65e6e9c78d454cf3f32"
+checksum = "4de4b15a47135c56a3573406e9977b9518787a6154459b4842a9b9d3d1684848"
 dependencies = [
- "wast 201.0.0",
+ "wast 202.0.0",
 ]
 
 [[package]]
@@ -2150,7 +2170,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.201.0",
  "wasmtime-environ",
 ]
 
@@ -2330,11 +2350,11 @@ dependencies = [
  "clap",
  "heck 0.4.1",
  "test-helpers",
- "wasm-encoder",
+ "wasm-encoder 0.202.0",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -2345,8 +2365,8 @@ dependencies = [
  "clap",
  "heck 0.4.1",
  "test-artifacts",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-c",
@@ -2357,7 +2377,7 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-bindgen-teavm-java",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -2365,7 +2385,7 @@ name = "wit-bindgen-core"
 version = "0.22.0"
 dependencies = [
  "anyhow",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -2376,9 +2396,9 @@ dependencies = [
  "clap",
  "heck 0.4.1",
  "test-helpers",
- "wasm-encoder",
+ "wasm-encoder 0.202.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.202.0",
  "wit-bindgen-core",
  "wit-component",
 ]
@@ -2458,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.201.0"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c0c848a0660a8c22e2fd217929a0191f14476b68962afd2af89fd22e39825"
+checksum = "0c836b1fd9932de0431c1758d8be08212071b6bba0151f7bac826dbc4312a2a9"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -2469,11 +2489,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.202.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.202.0",
  "wat",
- "wit-parser",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -2491,7 +2511,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.201.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744237b488352f4f27bca05a10acb79474415951c450e52ebd0da784c1df2bcc"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ pulldown-cmark = { version = "0.9", default-features = false }
 clap = { version = "4.3.19", features = ["derive"] }
 indexmap = "2.0.0"
 
-wasmparser = "0.201.0"
-wasm-encoder = "0.201.0"
-wasm-metadata = "0.201.0"
-wit-parser = "0.201.0"
-wit-component = "0.201.0"
+wasmparser = "0.202.0"
+wasm-encoder = "0.202.0"
+wasm-metadata = "0.202.0"
+wit-parser = "0.202.0"
+wit-component = "0.202.0"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.22.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.22.0' }

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -560,8 +560,8 @@ impl C {
             Type::S32 => dst.push_str("int32_t"),
             Type::U64 => dst.push_str("uint64_t"),
             Type::S64 => dst.push_str("int64_t"),
-            Type::Float32 => dst.push_str("float"),
-            Type::Float64 => dst.push_str("double"),
+            Type::F32 => dst.push_str("float"),
+            Type::F64 => dst.push_str("double"),
             Type::String => {
                 dst.push_str(&self.world.to_snake_case());
                 dst.push_str("_");
@@ -731,8 +731,8 @@ pub fn push_ty_name(resolve: &Resolve, ty: &Type, src: &mut String) {
         Type::S32 => src.push_str("s32"),
         Type::U64 => src.push_str("u64"),
         Type::S64 => src.push_str("s64"),
-        Type::Float32 => src.push_str("float32"),
-        Type::Float64 => src.push_str("float64"),
+        Type::F32 => src.push_str("float32"),
+        Type::F64 => src.push_str("float64"),
         Type::String => src.push_str("string"),
         Type::Id(id) => {
             let ty = &resolve.types[*id];
@@ -1617,8 +1617,8 @@ impl InterfaceGenerator<'_> {
             | Type::S32
             | Type::U64
             | Type::S64
-            | Type::Float32
-            | Type::Float64
+            | Type::F32
+            | Type::F64
             | Type::Char => {}
         }
     }

--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -747,8 +747,8 @@ fn needs_post_return(resolve: &Resolve, ty: &Type) -> bool {
         | Type::S32
         | Type::U64
         | Type::S64
-        | Type::Float32
-        | Type::Float64
+        | Type::F32
+        | Type::F64
         | Type::Char => false,
     }
 }
@@ -1067,8 +1067,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             Type::S64 => self.emit(&I64FromS64),
             Type::U64 => self.emit(&I64FromU64),
             Type::Char => self.emit(&I32FromChar),
-            Type::Float32 => self.emit(&F32FromFloat32),
-            Type::Float64 => self.emit(&F64FromFloat64),
+            Type::F32 => self.emit(&F32FromFloat32),
+            Type::F64 => self.emit(&F64FromFloat64),
             Type::String => {
                 let realloc = self.list_realloc();
                 self.emit(&StringLower { realloc });
@@ -1256,8 +1256,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             Type::S64 => self.emit(&S64FromI64),
             Type::U64 => self.emit(&U64FromI64),
             Type::Char => self.emit(&CharFromI32),
-            Type::Float32 => self.emit(&Float32FromF32),
-            Type::Float64 => self.emit(&Float64FromF64),
+            Type::F32 => self.emit(&Float32FromF32),
+            Type::F64 => self.emit(&Float64FromF64),
             Type::String => self.emit(&StringLift),
             Type::Id(id) => match &self.resolve.types[id].kind {
                 TypeDefKind::Type(t) => self.lift(t),
@@ -1414,8 +1414,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 self.lower_and_emit(ty, addr, &I32Store { offset })
             }
             Type::U64 | Type::S64 => self.lower_and_emit(ty, addr, &I64Store { offset }),
-            Type::Float32 => self.lower_and_emit(ty, addr, &F32Store { offset }),
-            Type::Float64 => self.lower_and_emit(ty, addr, &F64Store { offset }),
+            Type::F32 => self.lower_and_emit(ty, addr, &F32Store { offset }),
+            Type::F64 => self.lower_and_emit(ty, addr, &F64Store { offset }),
             Type::String => self.write_list_to_memory(ty, addr, offset),
 
             Type::Id(id) => match &self.resolve.types[id].kind {
@@ -1602,8 +1602,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             Type::S16 => self.emit_and_lift(ty, addr, &I32Load16S { offset }),
             Type::U32 | Type::S32 | Type::Char => self.emit_and_lift(ty, addr, &I32Load { offset }),
             Type::U64 | Type::S64 => self.emit_and_lift(ty, addr, &I64Load { offset }),
-            Type::Float32 => self.emit_and_lift(ty, addr, &F32Load { offset }),
-            Type::Float64 => self.emit_and_lift(ty, addr, &F64Load { offset }),
+            Type::F32 => self.emit_and_lift(ty, addr, &F32Load { offset }),
+            Type::F64 => self.emit_and_lift(ty, addr, &F64Load { offset }),
             Type::String => self.read_list_from_memory(ty, addr, offset),
 
             Type::Id(id) => match &self.resolve.types[id].kind {
@@ -1799,8 +1799,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             | Type::Char
             | Type::U64
             | Type::S64
-            | Type::Float32
-            | Type::Float64 => {}
+            | Type::F32
+            | Type::F64 => {}
 
             Type::Id(id) => match &self.resolve.types[id].kind {
                 TypeDefKind::Type(t) => self.deallocate(t, addr, offset),

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1151,8 +1151,8 @@ impl InterfaceGenerator<'_> {
             Type::S16 => "short".to_owned(),
             Type::S32 => "int".to_owned(),
             Type::S64 => "long".to_owned(),
-            Type::Float32 => "float".to_owned(),
-            Type::Float64 => "double".to_owned(),
+            Type::F32 => "float".to_owned(),
+            Type::F64 => "double".to_owned(),
             Type::Char => "uint".to_owned(),
             Type::String => "string".to_owned(),
             Type::Id(id) => {
@@ -1241,8 +1241,8 @@ impl InterfaceGenerator<'_> {
             Type::S16 => "short".into(),
             Type::S32 => "int".into(),
             Type::S64 => "long".into(),
-            Type::Float32 => "float".into(),
-            Type::Float64 => "double".into(),
+            Type::F32 => "float".into(),
+            Type::F64 => "double".into(),
             Type::Char => "uint".into(),
             Type::Id(id) => {
                 let def = &self.resolve.types[*id];
@@ -2332,8 +2332,8 @@ fn is_primitive(ty: &Type) -> bool {
             | Type::S32
             | Type::U64
             | Type::S64
-            | Type::Float32
-            | Type::Float64
+            | Type::F32
+            | Type::F64
     )
 }
 

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -217,8 +217,8 @@ impl InterfaceGenerator<'_> {
             Type::S16 => "int16".into(),
             Type::S32 => "int32".into(),
             Type::S64 => "int64".into(),
-            Type::Float32 => "float32".into(),
-            Type::Float64 => "float64".into(),
+            Type::F32 => "float32".into(),
+            Type::F64 => "float64".into(),
             Type::Char => "rune".into(),
             Type::String => "string".into(),
             Type::Id(id) => {
@@ -259,8 +259,8 @@ impl InterfaceGenerator<'_> {
             Type::S16 => "S16".into(),
             Type::S32 => "S32".into(),
             Type::S64 => "S64".into(),
-            Type::Float32 => "F32".into(),
-            Type::Float64 => "F64".into(),
+            Type::F32 => "F32".into(),
+            Type::F64 => "F64".into(),
             Type::Char => "Byte".into(),
             Type::String => "String".into(),
             Type::Id(id) => {
@@ -1049,7 +1049,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                     self.src,
                     "//go:wasmimport {import_module} [resource-drop]{name}
                     func _{type_name}_drop(self {type_name})
-                    
+
                     func (self {type_name}) Drop() {{
                         _{type_name}_drop(self)
                     }}

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -105,8 +105,8 @@ impl TinyGo {
             Type::S16 => "int16_t".into(),
             Type::S32 => "int32_t".into(),
             Type::S64 => "int64_t".into(),
-            Type::Float32 => "float".into(),
-            Type::Float64 => "double".into(),
+            Type::F32 => "float".into(),
+            Type::F64 => "double".into(),
             Type::Char => "uint32_t".into(),
             Type::String => {
                 format!(

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -333,8 +333,8 @@ impl InterfaceGenerator<'_> {
             Type::S32 => self.push_str("`s32`"),
             Type::U64 => self.push_str("`u64`"),
             Type::S64 => self.push_str("`s64`"),
-            Type::Float32 => self.push_str("`float32`"),
-            Type::Float64 => self.push_str("`float64`"),
+            Type::F32 => self.push_str("`f32`"),
+            Type::F64 => self.push_str("`f64`"),
             Type::Char => self.push_str("`char`"),
             Type::String => self.push_str("`string`"),
             Type::Id(id) => {

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1107,8 +1107,8 @@ macro_rules! {macro_name} {{
             Type::S16 => self.push_str("i16"),
             Type::S32 => self.push_str("i32"),
             Type::S64 => self.push_str("i64"),
-            Type::Float32 => self.push_str("f32"),
-            Type::Float64 => self.push_str("f64"),
+            Type::F32 => self.push_str("f32"),
+            Type::F64 => self.push_str("f64"),
             Type::Char => self.push_str("char"),
             Type::String => {
                 assert_eq!(mode.lists_borrowed, mode.lifetime.is_some());

--- a/crates/teavm-java/src/lib.rs
+++ b/crates/teavm-java/src/lib.rs
@@ -661,8 +661,8 @@ impl InterfaceGenerator<'_> {
             Type::U16 | Type::S16 => "short".into(),
             Type::U32 | Type::S32 | Type::Char => "int".into(),
             Type::U64 | Type::S64 => "long".into(),
-            Type::Float32 => "float".into(),
-            Type::Float64 => "double".into(),
+            Type::F32 => "float".into(),
+            Type::F64 => "double".into(),
             Type::String => "String".into(),
             Type::Id(id) => {
                 let ty = &self.resolve.types[*id];
@@ -735,8 +735,8 @@ impl InterfaceGenerator<'_> {
             Type::U16 | Type::S16 => "Short".into(),
             Type::U32 | Type::S32 | Type::Char => "Integer".into(),
             Type::U64 | Type::S64 => "Long".into(),
-            Type::Float32 => "Float".into(),
-            Type::Float64 => "Double".into(),
+            Type::F32 => "Float".into(),
+            Type::F64 => "Double".into(),
             Type::Id(id) => {
                 let def = &self.resolve.types[*id];
                 match &def.kind {
@@ -2162,8 +2162,8 @@ fn list_element_info(ty: &Type) -> (usize, &'static str) {
         Type::U16 | Type::S16 => (2, "short"),
         Type::U32 | Type::S32 => (4, "int"),
         Type::U64 | Type::S64 => (8, "long"),
-        Type::Float32 => (4, "float"),
-        Type::Float64 => (8, "double"),
+        Type::F32 => (4, "float"),
+        Type::F64 => (8, "double"),
         _ => unreachable!(),
     }
 }
@@ -2207,8 +2207,8 @@ fn is_primitive(ty: &Type) -> bool {
             | Type::S32
             | Type::U64
             | Type::S64
-            | Type::Float32
-            | Type::Float64
+            | Type::F32
+            | Type::F64
     )
 }
 


### PR DESCRIPTION
Mainly a few internal changes of `Float32` naming to `F32` for example. Not all guest generators are updated to remove the "float" terminology entirely yet.