### PR TITLE
fix(tiny-go): fix generated code in type_flags function

### DIFF
--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -1179,17 +1179,19 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         self.src.push_str(&format!("type {name} uint64\n"));
         self.src.push_str("const (\n");
         for (i, flag) in flags.flags.iter().enumerate() {
+            let case_flag = flag.name.to_upper_camel_case();
+
             if i == 0 {
                 self.src.push_str(&format!(
                     "   {name}_{flag} {name} = 1 << iota\n",
                     name = name,
-                    flag = flag.name.to_uppercase(),
+                    flag = case_flag,
                 ));
             } else {
                 self.src.push_str(&format!(
                     "   {name}_{flag}\n",
                     name = name,
-                    flag = flag.name.to_uppercase(),
+                    flag = case_flag,
                 ));
             }
         }

--- a/tests/codegen/flags.wit
+++ b/tests/codegen/flags.wit
@@ -40,6 +40,10 @@ interface %flags {
     b56, b57, b58, b59, b60, b61, b62, b63,
   }
 
+  flags withdashes {
+    with-dashes,
+  }
+
   roundtrip-flag1: func(x: flag1) -> flag1;
   roundtrip-flag2: func(x: flag2) -> flag2;
   roundtrip-flag4: func(x: flag4) -> flag4;


### PR DESCRIPTION
prior to this fix, wit content as follows

```
    /// Flags determining the method of how paths are resolved.
    flags path-flags {
        /// As long as the resolved path corresponds to a symbolic link, it is
        /// expanded.
        symlink-follow,
    }
```

is generated as

(notice the dash between `SYMLINK-FOLLOW`)

```
type WasiFilesystem0_2_0_TypesPathFlags uint64
const (
WasiFilesystem0_2_0_TypesPathFlags_SYMLINK-FOLLOW WasiFilesystem0_2_0_TypesPathFlags = 1 << iota
)
```

After the fix:

```
type WasiFilesystem0_2_0_TypesPathFlags uint64
const (
WasiFilesystem0_2_0_TypesPathFlags_SymlinkFollow WasiFilesystem0_2_0_TypesPathFlags = 1 << iota
)

```