### PR TITLE
feat(go): add the ability to select a `package` name for Go

### DIFF
--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -21,11 +21,18 @@ pub struct Opts {
     /// Whether or not `gofmt` is executed to format generated code.
     #[cfg_attr(feature = "clap", arg(long))]
     pub gofmt: bool,
+
+    /// Rename the Go package in the generated source code.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub rename_package: Option<String>,
 }
 
 impl Default for Opts {
     fn default() -> Self {
-        Self { gofmt: true } // Set the default value of gofmt to true
+        Self {
+            gofmt: true,
+            rename_package: None,
+        } // Set the default value of gofmt to true
     }
 }
 
@@ -147,8 +154,11 @@ impl TinyGo {
 
 impl WorldGenerator for TinyGo {
     fn preprocess(&mut self, resolve: &Resolve, world: WorldId) {
-        let name = &resolve.worlds[world].name;
-        self.world = name.to_string();
+        self.world = self
+            .opts
+            .rename_package
+            .clone()
+            .unwrap_or_else(|| resolve.worlds[world].name.clone());
         self.sizes.fill(resolve);
         self.world_id = Some(world);
     }
@@ -309,13 +319,10 @@ impl WorldGenerator for TinyGo {
             self.src.append_src(&self.preamble);
         }
         self.src.push_str("import \"C\"\n");
-        let world = &resolve.worlds[id];
+        let world = self.world.to_snake_case();
 
-        self.import_requirements.generate(
-            snake,
-            files,
-            format!("{}_types.go", world.name.to_kebab_case()),
-        );
+        self.import_requirements
+            .generate(snake, files, format!("{}_types.go", world));
         self.src.push_str(&self.import_requirements.src);
 
         self.src.push_str(&src);
@@ -342,14 +349,12 @@ impl WorldGenerator for TinyGo {
             let status = child.wait().expect("failed to wait on gofmt");
             assert!(status.success());
         }
-        files.push(
-            &format!("{}.go", world.name.to_kebab_case()),
-            self.src.as_bytes(),
-        );
+        files.push(&format!("{}.go", world), self.src.as_bytes());
 
         let mut opts = wit_bindgen_c::Opts::default();
         opts.no_sig_flattening = true;
         opts.no_object_file = true;
+        opts.rename_world = self.opts.rename_package.clone();
         opts.build()
             .generate(resolve, id, files)
             .expect("C generator should be infallible");

--- a/crates/go/tests/codegen.rs
+++ b/crates/go/tests/codegen.rs
@@ -29,7 +29,7 @@ macro_rules! codegen_test {
 test_helpers::codegen_tests!();
 
 fn verify(dir: &Path, name: &str) {
-    let name = name.to_kebab_case();
+    let name = name.to_snake_case();
     let main = dir.join(format!("{name}.go"));
 
     // The generated go package is named after the world's name.


### PR DESCRIPTION
this commit adds an extra flag on the wit-bindgen tiny-go to be able to rename the package name of the generated Go source code.

it also changes the file names from kebab names to snake names which follow the Go file name conventions.

e.g. `wit-bindgen tiny-go wasi-http/wit --world proxy --rename-package=test` generates

```bash
Generating "test.c"
Generating "test.go"
Generating "test.h"
Generating "test_types.go"
```

where the `test.go` has package name `test`. 