### PR TITLE
Change float32/float64 to f32/f64 in the C bindings generator.

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -731,8 +731,8 @@ pub fn push_ty_name(resolve: &Resolve, ty: &Type, src: &mut String) {
         Type::S32 => src.push_str("s32"),
         Type::U64 => src.push_str("u64"),
         Type::S64 => src.push_str("s64"),
-        Type::F32 => src.push_str("float32"),
-        Type::F64 => src.push_str("float64"),
+        Type::F32 => src.push_str("f32"),
+        Type::F64 => src.push_str("f64"),
         Type::String => src.push_str("string"),
         Type::Id(id) => {
             let ty = &resolve.types[*id];
@@ -2264,10 +2264,10 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
             // f32/f64 have the same representation in the import type and in C,
             // so no conversions necessary.
-            Instruction::F32FromFloat32
-            | Instruction::F64FromFloat64
-            | Instruction::Float32FromF32
-            | Instruction::Float64FromF64 => {
+            Instruction::CoreF32FromF32
+            | Instruction::CoreF64FromF64
+            | Instruction::F32FromCoreF32
+            | Instruction::F64FromCoreF64 => {
                 results.push(operands[0].clone());
             }
 

--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -174,13 +174,13 @@ def_instruction! {
         /// This may be a noop for some implementations, but it's here in case the
         /// native language representation of `f32` is different than the wasm
         /// representation of `f32`.
-        F32FromFloat32 : [1] => [1],
+        CoreF32FromF32 : [1] => [1],
         /// Conversion an interface type `f64` value to a wasm `f64`.
         ///
         /// This may be a noop for some implementations, but it's here in case the
         /// native language representation of `f64` is different than the wasm
         /// representation of `f64`.
-        F64FromFloat64 : [1] => [1],
+        CoreF64FromF64 : [1] => [1],
 
         /// Converts a native wasm `i32` to an interface type `s8`.
         ///
@@ -211,9 +211,9 @@ def_instruction! {
         /// It's safe to assume that the `i32` is indeed a valid unicode code point.
         CharFromI32 : [1] => [1],
         /// Converts a native wasm `f32` to an interface type `f32`.
-        Float32FromF32 : [1] => [1],
+        F32FromCoreF32 : [1] => [1],
         /// Converts a native wasm `f64` to an interface type `f64`.
-        Float64FromF64 : [1] => [1],
+        F64FromCoreF64 : [1] => [1],
 
         /// Creates a `bool` from an `i32` input, trapping if the `i32` isn't
         /// zero or one.
@@ -1067,8 +1067,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             Type::S64 => self.emit(&I64FromS64),
             Type::U64 => self.emit(&I64FromU64),
             Type::Char => self.emit(&I32FromChar),
-            Type::F32 => self.emit(&F32FromFloat32),
-            Type::F64 => self.emit(&F64FromFloat64),
+            Type::F32 => self.emit(&CoreF32FromF32),
+            Type::F64 => self.emit(&CoreF64FromF64),
             Type::String => {
                 let realloc = self.list_realloc();
                 self.emit(&StringLower { realloc });
@@ -1256,8 +1256,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
             Type::S64 => self.emit(&S64FromI64),
             Type::U64 => self.emit(&U64FromI64),
             Type::Char => self.emit(&CharFromI32),
-            Type::F32 => self.emit(&Float32FromF32),
-            Type::F64 => self.emit(&Float64FromF64),
+            Type::F32 => self.emit(&F32FromCoreF32),
+            Type::F64 => self.emit(&F64FromCoreF64),
             Type::String => self.emit(&StringLift),
             Type::Id(id) => match &self.resolve.types[id].kind {
                 TypeDefKind::Type(t) => self.lift(t),

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1779,10 +1779,10 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::I32FromU8
             | Instruction::I32FromS8
             | Instruction::I32FromS32
-            | Instruction::Float32FromF32
-            | Instruction::F32FromFloat32
-            | Instruction::F64FromFloat64
-            | Instruction::Float64FromF64
+            | Instruction::F32FromCoreF32
+            | Instruction::CoreF32FromF32
+            | Instruction::CoreF64FromF64
+            | Instruction::F64FromCoreF64
             | Instruction::S32FromI32
             | Instruction::S64FromI64 => results.push(operands[0].clone()),
 

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -345,16 +345,16 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 results.push(format!("{}({s})", self.gen.path_to_as_i32()));
             }
 
-            Instruction::F32FromFloat32 => {
+            Instruction::CoreF32FromF32 => {
                 let s = operands.pop().unwrap();
                 results.push(format!("{}({s})", self.gen.path_to_as_f32()));
             }
-            Instruction::F64FromFloat64 => {
+            Instruction::CoreF64FromF64 => {
                 let s = operands.pop().unwrap();
                 results.push(format!("{}({s})", self.gen.path_to_as_f64()));
             }
-            Instruction::Float32FromF32
-            | Instruction::Float64FromF64
+            Instruction::F32FromCoreF32
+            | Instruction::F64FromCoreF64
             | Instruction::S32FromI32
             | Instruction::S64FromI64 => {
                 results.push(operands.pop().unwrap());

--- a/crates/teavm-java/src/lib.rs
+++ b/crates/teavm-java/src/lib.rs
@@ -1324,10 +1324,10 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::I32FromS32
             | Instruction::I64FromS64
             | Instruction::I64FromU64
-            | Instruction::F32FromFloat32
-            | Instruction::F64FromFloat64
-            | Instruction::Float32FromF32
-            | Instruction::Float64FromF64 => results.push(operands[0].clone()),
+            | Instruction::CoreF32FromF32
+            | Instruction::CoreF64FromF64
+            | Instruction::F32FromCoreF32
+            | Instruction::F64FromCoreF64 => results.push(operands[0].clone()),
 
             Instruction::Bitcasts { casts } => results.extend(
                 casts

--- a/tests/codegen/floats.wit
+++ b/tests/codegen/floats.wit
@@ -1,10 +1,10 @@
 package foo:foo;
 
 interface floats {
-  float32-param: func(x: float32);
-  float64-param: func(x: float64);
-  float32-result: func() -> float32;
-  float64-result: func() -> float64;
+  f32-param: func(x: f32);
+  f64-param: func(x: f64);
+  f32-result: func() -> f32;
+  f64-result: func() -> f64;
 }
 
 world the-world {

--- a/tests/codegen/issue573.wit
+++ b/tests/codegen/issue573.wit
@@ -108,7 +108,7 @@ world types-example {
     }
 
     export f-f1: func(typedef: t10) -> t10;
-    export f1: func(f: float32, f-list: list<tuple<char, float64>>) -> (val-p1: s64, val2: string);
+    export f1: func(f: f32, f-list: list<tuple<char, f64>>) -> (val-p1: s64, val2: string);
     /// t2 has been renamed with `use self.types-interface.{t2 as t2-renamed}`
     export re-named: func(perm: option<permissions>, e: option<empty>) -> t2-renamed;
     export re-named2: func(tup: tuple<list<u16>>, e: empty) -> tuple<option<u8>, s8>;

--- a/tests/codegen/lists.wit
+++ b/tests/codegen/lists.wit
@@ -9,8 +9,8 @@ interface lists {
   list-s16-param: func(x: list<s16>);
   list-s32-param: func(x: list<s32>);
   list-s64-param: func(x: list<s64>);
-  list-float32-param: func(x: list<float32>);
-  list-float64-param: func(x: list<float64>);
+  list-f32-param: func(x: list<f32>);
+  list-f64-param: func(x: list<f64>);
 
   list-u8-ret: func() -> list<u8>;
   list-u16-ret: func() -> list<u16>;
@@ -20,8 +20,8 @@ interface lists {
   list-s16-ret: func() -> list<s16>;
   list-s32-ret: func() -> list<s32>;
   list-s64-ret: func() -> list<s64>;
-  list-float32-ret: func() -> list<float32>;
-  list-float64-ret: func() -> list<float64>;
+  list-f32-ret: func() -> list<f32>;
+  list-f64-ret: func() -> list<f64>;
 
   tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>;
   string-list-arg: func(a: list<string>);
@@ -72,8 +72,8 @@ interface lists {
     s32,
     u64,
     s64,
-    float32,
-    float64,
+    f32,
+    f64,
     char,
   >>;
   load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes;

--- a/tests/codegen/multi-return.wit
+++ b/tests/codegen/multi-return.wit
@@ -5,7 +5,7 @@ interface multi-return {
   mrb: func() -> ();
   mrc: func() -> u32;
   mrd: func() -> (a: u32);
-  mre: func() -> (a: u32, b: float32);
+  mre: func() -> (a: u32, b: f32);
 }
 
 world the-world {

--- a/tests/codegen/resources.wit
+++ b/tests/codegen/resources.wit
@@ -2,7 +2,7 @@ package my:resources;
 
 interface types {
   resource z {
-    constructor(a: float64);
+    constructor(a: f64);
   }
 }
 
@@ -38,19 +38,19 @@ world resources {
 
   export exports: interface {
     resource x {
-      constructor(a: float64);
-      get-a: func() -> float64;
-      set-a: func(a: float64);
-      add: static func(x: x, a: float64) -> x;
+      constructor(a: f64);
+      get-a: func() -> f64;
+      set-a: func(a: f64);
+      add: static func(x: x, a: f64) -> x;
     }
   }
 
   import imports: interface {
     resource y {
-      constructor(a: float64);
-      get-a: func() -> float64;
-      set-a: func(a: float64);
-      add: static func(y: y, a: float64) -> y;
+      constructor(a: f64);
+      get-a: func() -> f64;
+      set-a: func(a: f64);
+      add: static func(y: y, a: f64) -> y;
     }
   }
 }

--- a/tests/codegen/variants.wit
+++ b/tests/codegen/variants.wit
@@ -34,7 +34,7 @@ interface variants {
     b: option<tuple<u32>>,
     c: option<u32>,
     d: option<e1>,
-    e: option<float32>,
+    e: option<f32>,
     g: option<option<bool>>,
   );
   option-result: func() -> tuple<
@@ -42,22 +42,22 @@ interface variants {
     option<tuple<u32>>,
     option<u32>,
     option<e1>,
-    option<float32>,
+    option<f32>,
     option<option<bool>>,
   >;
 
   variant casts1 {
     a(s32),
-    b(float32),
+    b(f32),
   }
 
   variant casts2 {
-    a(float64),
-    b(float32),
+    a(f64),
+    b(f32),
   }
 
   variant casts3 {
-    a(float64),
+    a(f64),
     b(u64),
   }
 
@@ -67,12 +67,12 @@ interface variants {
   }
 
   variant casts5 {
-    a(float32),
+    a(f32),
     b(s64),
   }
 
   variant casts6 {
-    a(tuple<float32, u32>),
+    a(tuple<f32, u32>),
     b(tuple<u32, u32>),
   }
 

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -214,17 +214,17 @@ void lists_test_imports() {
   {
     float f32[4] = {-FLT_MAX, FLT_MAX, -INFINITY, INFINITY};
     double f64[4] = {-DBL_MAX, DBL_MAX, -INFINITY, INFINITY};
-    lists_list_float32_t list_float32 = { f32, 4 };
-    lists_list_float64_t list_float64 = { f64, 4 };
-    lists_list_float32_t list_float32_out;
-    lists_list_float64_t list_float64_out;
-    test_lists_test_list_minmax_float(&list_float32, &list_float64, &list_float32_out, &list_float64_out);
-    assert(list_float32_out.len == 4 && list_float32_out.ptr[0] == -FLT_MAX && list_float32_out.ptr[1] == FLT_MAX);
-    assert(list_float32_out.ptr[2] == -INFINITY && list_float32_out.ptr[3] == INFINITY);
-    assert(list_float64_out.len == 4 && list_float64_out.ptr[0] == -DBL_MAX && list_float64_out.ptr[1] == DBL_MAX);
-    assert(list_float64_out.ptr[2] == -INFINITY && list_float64_out.ptr[3] == INFINITY);
-    lists_list_float32_free(&list_float32_out);
-    lists_list_float64_free(&list_float64_out);
+    lists_list_f32_t list_f32 = { f32, 4 };
+    lists_list_f64_t list_f64 = { f64, 4 };
+    lists_list_f32_t list_f32_out;
+    lists_list_f64_t list_f64_out;
+    test_lists_test_list_minmax_float(&list_f32, &list_f64, &list_f32_out, &list_f64_out);
+    assert(list_f32_out.len == 4 && list_f32_out.ptr[0] == -FLT_MAX && list_f32_out.ptr[1] == FLT_MAX);
+    assert(list_f32_out.ptr[2] == -INFINITY && list_f32_out.ptr[3] == INFINITY);
+    assert(list_f64_out.len == 4 && list_f64_out.ptr[0] == -DBL_MAX && list_f64_out.ptr[1] == DBL_MAX);
+    assert(list_f64_out.ptr[2] == -INFINITY && list_f64_out.ptr[3] == INFINITY);
+    lists_list_f32_free(&list_f32_out);
+    lists_list_f64_free(&list_f64_out);
   }
 }
 
@@ -352,6 +352,6 @@ void exports_test_lists_test_list_minmax64(lists_list_u64_t *a, lists_list_s64_t
   assert(0); // unimplemented
 }
 
-void exports_test_lists_test_list_minmax_float(lists_list_float32_t *a, lists_list_float64_t *b, lists_list_float32_t *ret0, lists_list_float64_t *ret1) {
+void exports_test_lists_test_list_minmax_float(lists_list_f32_t *a, lists_list_f64_t *b, lists_list_f32_t *ret0, lists_list_f64_t *ret1) {
   assert(0); // unimplemented
 }

--- a/tests/runtime/lists/world.wit
+++ b/tests/runtime/lists/world.wit
@@ -18,8 +18,8 @@ interface test {
   list-minmax16: func(a: list<u16>, b: list<s16>) -> (a: list<u16>, b: list<s16>);
   list-minmax32: func(a: list<u32>, b: list<s32>) -> (a: list<u32>, b: list<s32>);
   list-minmax64: func(a: list<u64>, b: list<s64>) -> (a: list<u64>, b: list<s64>);
-  list-minmax-float: func(a: list<float32>, b: list<float64>)
-    -> (a: list<float32>, b: list<float64>);
+  list-minmax-float: func(a: list<f32>, b: list<f64>)
+    -> (a: list<f32>, b: list<f64>);
 
   list-roundtrip: func(a: list<u8>) -> list<u8>;
 

--- a/tests/runtime/numbers.rs
+++ b/tests/runtime/numbers.rs
@@ -41,11 +41,11 @@ impl test::numbers::test::Host for MyImports {
         Ok(val)
     }
 
-    fn roundtrip_float32(&mut self, val: f32) -> Result<f32> {
+    fn roundtrip_f32(&mut self, val: f32) -> Result<f32> {
         Ok(val)
     }
 
-    fn roundtrip_float64(&mut self, val: f64) -> Result<f64> {
+    fn roundtrip_f64(&mut self, val: f64) -> Result<f64> {
         Ok(val)
     }
 
@@ -156,31 +156,27 @@ fn run_test(exports: Numbers, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
         i64::max_value()
     );
 
-    assert_eq!(exports.call_roundtrip_float32(&mut *store, 1.0)?, 1.0);
+    assert_eq!(exports.call_roundtrip_f32(&mut *store, 1.0)?, 1.0);
     assert_eq!(
-        exports.call_roundtrip_float32(&mut *store, f32::INFINITY)?,
+        exports.call_roundtrip_f32(&mut *store, f32::INFINITY)?,
         f32::INFINITY
     );
     assert_eq!(
-        exports.call_roundtrip_float32(&mut *store, f32::NEG_INFINITY)?,
+        exports.call_roundtrip_f32(&mut *store, f32::NEG_INFINITY)?,
         f32::NEG_INFINITY
     );
-    assert!(exports
-        .call_roundtrip_float32(&mut *store, f32::NAN)?
-        .is_nan());
+    assert!(exports.call_roundtrip_f32(&mut *store, f32::NAN)?.is_nan());
 
-    assert_eq!(exports.call_roundtrip_float64(&mut *store, 1.0)?, 1.0);
+    assert_eq!(exports.call_roundtrip_f64(&mut *store, 1.0)?, 1.0);
     assert_eq!(
-        exports.call_roundtrip_float64(&mut *store, f64::INFINITY)?,
+        exports.call_roundtrip_f64(&mut *store, f64::INFINITY)?,
         f64::INFINITY
     );
     assert_eq!(
-        exports.call_roundtrip_float64(&mut *store, f64::NEG_INFINITY)?,
+        exports.call_roundtrip_f64(&mut *store, f64::NEG_INFINITY)?,
         f64::NEG_INFINITY
     );
-    assert!(exports
-        .call_roundtrip_float64(&mut *store, f64::NAN)?
-        .is_nan());
+    assert!(exports.call_roundtrip_f64(&mut *store, f64::NAN)?.is_nan());
 
     assert_eq!(exports.call_roundtrip_char(&mut *store, 'a')?, 'a');
     assert_eq!(exports.call_roundtrip_char(&mut *store, ' ')?, ' ');

--- a/tests/runtime/numbers/wasm.c
+++ b/tests/runtime/numbers/wasm.c
@@ -35,11 +35,11 @@ int64_t exports_test_numbers_test_roundtrip_s64(int64_t a) {
   return a;
 }
 
-float exports_test_numbers_test_roundtrip_float32(float a) {
+float exports_test_numbers_test_roundtrip_f32(float a) {
   return a;
 }
 
-double exports_test_numbers_test_roundtrip_float64(double a) {
+double exports_test_numbers_test_roundtrip_f64(double a) {
   return a;
 }
 
@@ -91,15 +91,15 @@ void numbers_test_imports() {
   assert(test_numbers_test_roundtrip_s64(LONG_MIN) == LONG_MIN);
   assert(test_numbers_test_roundtrip_s64(LONG_MAX) == LONG_MAX);
 
-  assert(test_numbers_test_roundtrip_float32(1.0) == 1.0);
-  assert(test_numbers_test_roundtrip_float32(INFINITY) == INFINITY);
-  assert(test_numbers_test_roundtrip_float32(-INFINITY) == -INFINITY);
-  assert(isnan(test_numbers_test_roundtrip_float32(NAN)));
+  assert(test_numbers_test_roundtrip_f32(1.0) == 1.0);
+  assert(test_numbers_test_roundtrip_f32(INFINITY) == INFINITY);
+  assert(test_numbers_test_roundtrip_f32(-INFINITY) == -INFINITY);
+  assert(isnan(test_numbers_test_roundtrip_f32(NAN)));
 
-  assert(test_numbers_test_roundtrip_float64(1.0) == 1.0);
-  assert(test_numbers_test_roundtrip_float64(INFINITY) == INFINITY);
-  assert(test_numbers_test_roundtrip_float64(-INFINITY) == -INFINITY);
-  assert(isnan(test_numbers_test_roundtrip_float64(NAN)));
+  assert(test_numbers_test_roundtrip_f64(1.0) == 1.0);
+  assert(test_numbers_test_roundtrip_f64(INFINITY) == INFINITY);
+  assert(test_numbers_test_roundtrip_f64(-INFINITY) == -INFINITY);
+  assert(isnan(test_numbers_test_roundtrip_f64(NAN)));
 
   assert(test_numbers_test_roundtrip_char('a') == 'a');
   assert(test_numbers_test_roundtrip_char(' ') == ' ');

--- a/tests/runtime/numbers/wasm.cs
+++ b/tests/runtime/numbers/wasm.cs
@@ -42,15 +42,15 @@ namespace NumbersWorld
             Debug.Assert(TestInterop.RoundtripS64(Int64.MinValue) == Int64.MinValue);
             Debug.Assert(TestInterop.RoundtripS64(Int64.MaxValue) == Int64.MaxValue);
 
-            Debug.Assert(TestInterop.RoundtripFloat32(1.0f) == 1.0f);
-            Debug.Assert(TestInterop.RoundtripFloat32(Single.PositiveInfinity) == Single.PositiveInfinity);
-            Debug.Assert(TestInterop.RoundtripFloat32(Single.NegativeInfinity) == Single.NegativeInfinity);
-            Debug.Assert(float.IsNaN(TestInterop.RoundtripFloat32(Single.NaN)));
+            Debug.Assert(TestInterop.RoundtripF32(1.0f) == 1.0f);
+            Debug.Assert(TestInterop.RoundtripF32(Single.PositiveInfinity) == Single.PositiveInfinity);
+            Debug.Assert(TestInterop.RoundtripF32(Single.NegativeInfinity) == Single.NegativeInfinity);
+            Debug.Assert(float.IsNaN(TestInterop.RoundtripF32(Single.NaN)));
 
-            Debug.Assert(TestInterop.RoundtripFloat64(1.0) == 1.0);
-            Debug.Assert(TestInterop.RoundtripFloat64(Double.PositiveInfinity) == Double.PositiveInfinity);
-            Debug.Assert(TestInterop.RoundtripFloat64(Double.NegativeInfinity) == Double.NegativeInfinity);
-            Debug.Assert(double.IsNaN(TestInterop.RoundtripFloat64(Double.NaN)));
+            Debug.Assert(TestInterop.RoundtripF64(1.0) == 1.0);
+            Debug.Assert(TestInterop.RoundtripF64(Double.PositiveInfinity) == Double.PositiveInfinity);
+            Debug.Assert(TestInterop.RoundtripF64(Double.NegativeInfinity) == Double.NegativeInfinity);
+            Debug.Assert(double.IsNaN(TestInterop.RoundtripF64(Double.NaN)));
 
             Debug.Assert(TestInterop.RoundtripChar('a') == 'a');
             Debug.Assert(TestInterop.RoundtripChar(' ') == ' ');
@@ -111,12 +111,12 @@ namespace NumbersWorld.wit.exports.test.numbers
             return p0;
         }
 
-        public static float RoundtripFloat32(float p0)
+        public static float RoundtripF32(float p0)
         {
             return p0;
         }
 
-        public static double RoundtripFloat64(double p0)
+        public static double RoundtripF64(double p0)
         {
             return p0;
         }

--- a/tests/runtime/numbers/wasm.go
+++ b/tests/runtime/numbers/wasm.go
@@ -97,27 +97,27 @@ func (i NumbersImpl) TestImports() {
 		panic("roundtrip-s64")
 	}
 
-	if TestNumbersTestRoundtripFloat32(1.0) != 1.0 {
-		panic("roundtrip-float32")
+	if TestNumbersTestRoundtripF32(1.0) != 1.0 {
+		panic("roundtrip-f32")
 	}
-	if TestNumbersTestRoundtripFloat32(math.MaxFloat32) != math.MaxFloat32 {
-		panic("roundtrip-float32")
+	if TestNumbersTestRoundtripF32(math.MaxFloat32) != math.MaxFloat32 {
+		panic("roundtrip-f32")
 	}
-	if TestNumbersTestRoundtripFloat32(math.SmallestNonzeroFloat32) != math.SmallestNonzeroFloat32 {
-		panic("roundtrip-float32")
+	if TestNumbersTestRoundtripF32(math.SmallestNonzeroFloat32) != math.SmallestNonzeroFloat32 {
+		panic("roundtrip-f32")
 	}
 
-	if TestNumbersTestRoundtripFloat64(1.0) != 1.0 {
-		panic("roundtrip-float64")
+	if TestNumbersTestRoundtripF64(1.0) != 1.0 {
+		panic("roundtrip-f64")
 	}
-	if TestNumbersTestRoundtripFloat64(math.MaxFloat64) != math.MaxFloat64 {
-		panic("roundtrip-float64")
+	if TestNumbersTestRoundtripF64(math.MaxFloat64) != math.MaxFloat64 {
+		panic("roundtrip-f64")
 	}
-	if TestNumbersTestRoundtripFloat64(math.SmallestNonzeroFloat64) != math.SmallestNonzeroFloat64 {
-		panic("roundtrip-float64")
+	if TestNumbersTestRoundtripF64(math.SmallestNonzeroFloat64) != math.SmallestNonzeroFloat64 {
+		panic("roundtrip-f64")
 	}
-	if !math.IsNaN(TestNumbersTestRoundtripFloat64(math.NaN())) {
-		panic("roundtrip-float64")
+	if !math.IsNaN(TestNumbersTestRoundtripF64(math.NaN())) {
+		panic("roundtrip-f64")
 	}
 
 	if TestNumbersTestRoundtripChar('a') != 'a' {
@@ -173,11 +173,11 @@ func (o *NumbersImpl) RoundtripS64(a int64) int64 {
 	return a
 }
 
-func (o *NumbersImpl) RoundtripFloat32(a float32) float32 {
+func (o *NumbersImpl) RoundtripF32(a float32) float32 {
 	return a
 }
 
-func (o *NumbersImpl) RoundtripFloat64(a float64) float64 {
+func (o *NumbersImpl) RoundtripF64(a float64) float64 {
 	return a
 }
 

--- a/tests/runtime/numbers/wasm.rs
+++ b/tests/runtime/numbers/wasm.rs
@@ -45,15 +45,15 @@ impl Guest for Component {
         assert_eq!(roundtrip_s64(i64::min_value()), i64::min_value());
         assert_eq!(roundtrip_s64(i64::max_value()), i64::max_value());
 
-        assert_eq!(roundtrip_float32(1.0), 1.0);
-        assert_eq!(roundtrip_float32(f32::INFINITY), f32::INFINITY);
-        assert_eq!(roundtrip_float32(f32::NEG_INFINITY), f32::NEG_INFINITY);
-        assert!(roundtrip_float32(f32::NAN).is_nan());
+        assert_eq!(roundtrip_f32(1.0), 1.0);
+        assert_eq!(roundtrip_f32(f32::INFINITY), f32::INFINITY);
+        assert_eq!(roundtrip_f32(f32::NEG_INFINITY), f32::NEG_INFINITY);
+        assert!(roundtrip_f32(f32::NAN).is_nan());
 
-        assert_eq!(roundtrip_float64(1.0), 1.0);
-        assert_eq!(roundtrip_float64(f64::INFINITY), f64::INFINITY);
-        assert_eq!(roundtrip_float64(f64::NEG_INFINITY), f64::NEG_INFINITY);
-        assert!(roundtrip_float64(f64::NAN).is_nan());
+        assert_eq!(roundtrip_f64(1.0), 1.0);
+        assert_eq!(roundtrip_f64(f64::INFINITY), f64::INFINITY);
+        assert_eq!(roundtrip_f64(f64::NEG_INFINITY), f64::NEG_INFINITY);
+        assert!(roundtrip_f64(f64::NAN).is_nan());
 
         assert_eq!(roundtrip_char('a'), 'a');
         assert_eq!(roundtrip_char(' '), ' ');
@@ -99,11 +99,11 @@ impl exports::test::numbers::test::Guest for Component {
         a
     }
 
-    fn roundtrip_float32(a: f32) -> f32 {
+    fn roundtrip_f32(a: f32) -> f32 {
         a
     }
 
-    fn roundtrip_float64(a: f64) -> f64 {
+    fn roundtrip_f64(a: f64) -> f64 {
         a
     }
 

--- a/tests/runtime/numbers/wit_exports_test_numbers_TestImpl.java
+++ b/tests/runtime/numbers/wit_exports_test_numbers_TestImpl.java
@@ -33,11 +33,11 @@ public class TestImpl {
         return a;
     }
 
-    public static float roundtripFloat32(float a) {
+    public static float roundtripF32(float a) {
         return a;
     }
 
-    public static double roundtripFloat64(double a) {
+    public static double roundtripF64(double a) {
         return a;
     }
 

--- a/tests/runtime/numbers/wit_worlds_NumbersImpl.java
+++ b/tests/runtime/numbers/wit_worlds_NumbersImpl.java
@@ -50,7 +50,7 @@ public class NumbersImpl {
         expect(Test.roundtripF64(1.0) == 1.0);
         expect(Test.roundtripF64(Double.POSITIVE_INFINITY) == Double.POSITIVE_INFINITY);
         expect(Test.roundtripF64(Double.NEGATIVE_INFINITY) == Double.NEGATIVE_INFINITY);
-        expect(Double.isNaN(Test.roundtripFloat64(Double.NaN)));
+        expect(Double.isNaN(Test.roundtripF64(Double.NaN)));
 
         expect(Test.roundtripChar((int) 'a') == (int) 'a');
         expect(Test.roundtripChar((int) ' ') == (int) ' ');

--- a/tests/runtime/numbers/wit_worlds_NumbersImpl.java
+++ b/tests/runtime/numbers/wit_worlds_NumbersImpl.java
@@ -42,14 +42,14 @@ public class NumbersImpl {
         expect(Test.roundtripS64(Long.MIN_VALUE) == Long.MIN_VALUE);
         expect(Test.roundtripS64(Long.MAX_VALUE) == Long.MAX_VALUE);
 
-        expect(Test.roundtripFloat32(1.0F) == 1.0F);
-        expect(Test.roundtripFloat32(Float.POSITIVE_INFINITY) == Float.POSITIVE_INFINITY);
-        expect(Test.roundtripFloat32(Float.NEGATIVE_INFINITY) == Float.NEGATIVE_INFINITY);
-        expect(Float.isNaN(Test.roundtripFloat32(Float.NaN)));
+        expect(Test.roundtripF32(1.0F) == 1.0F);
+        expect(Test.roundtripF32(Float.POSITIVE_INFINITY) == Float.POSITIVE_INFINITY);
+        expect(Test.roundtripF32(Float.NEGATIVE_INFINITY) == Float.NEGATIVE_INFINITY);
+        expect(Float.isNaN(Test.roundtripF32(Float.NaN)));
 
-        expect(Test.roundtripFloat64(1.0) == 1.0);
-        expect(Test.roundtripFloat64(Double.POSITIVE_INFINITY) == Double.POSITIVE_INFINITY);
-        expect(Test.roundtripFloat64(Double.NEGATIVE_INFINITY) == Double.NEGATIVE_INFINITY);
+        expect(Test.roundtripF64(1.0) == 1.0);
+        expect(Test.roundtripF64(Double.POSITIVE_INFINITY) == Double.POSITIVE_INFINITY);
+        expect(Test.roundtripF64(Double.NEGATIVE_INFINITY) == Double.NEGATIVE_INFINITY);
         expect(Double.isNaN(Test.roundtripFloat64(Double.NaN)));
 
         expect(Test.roundtripChar((int) 'a') == (int) 'a');

--- a/tests/runtime/numbers/world.wit
+++ b/tests/runtime/numbers/world.wit
@@ -9,8 +9,8 @@ interface test {
   roundtrip-s32: func(a: s32) -> s32;
   roundtrip-u64: func(a: u64) -> u64;
   roundtrip-s64: func(a: s64) -> s64;
-  roundtrip-float32: func(a: float32) -> float32;
-  roundtrip-float64: func(a: float64) -> float64;
+  roundtrip-f32: func(a: f32) -> f32;
+  roundtrip-f64: func(a: f64) -> f64;
   roundtrip-char: func(a: char) -> char;
 
   set-scalar: func(a: u32);

--- a/tests/runtime/resource_floats/world.wit
+++ b/tests/runtime/resource_floats/world.wit
@@ -2,8 +2,8 @@ package test:resource-floats;
 
 interface test {
   resource float {
-    constructor(v: float64);
-    get: func() -> float64;
+    constructor(v: f64);
+    get: func() -> f64;
   }
 }
 
@@ -12,17 +12,17 @@ world resource-floats {
 
   export exports: interface {
     resource float {
-      constructor(v: float64);
-      get: func() -> float64;
-      add: static func(a: float, b: float64) -> float;
+      constructor(v: f64);
+      get: func() -> f64;
+      add: static func(a: float, b: f64) -> float;
     }
   }
 
   import imports: interface {
     resource float {
-      constructor(v: float64);
-      get: func() -> float64;
-      add: static func(a: float, b: float64) -> float;
+      constructor(v: f64);
+      get: func() -> f64;
+      add: static func(a: float, b: f64) -> float;
     }
   }
 

--- a/tests/runtime/results/world.wit
+++ b/tests/runtime/results/world.wit
@@ -1,17 +1,17 @@
 package test:results;
 
 interface test {
-  string-error: func(a: float32) -> result<float32, string>;
+  string-error: func(a: f32) -> result<f32, string>;
 
   enum e { a, b, c }
-  enum-error: func(a: float64) -> result<float64, e>;
+  enum-error: func(a: f64) -> result<f64, e>;
 
   record e2 { line: u32, column: u32 }
-  record-error: func(a: float64) -> result<float64, e2>;
+  record-error: func(a: f64) -> result<f64, e2>;
 
 
   variant e3 { e1(e), e2(e2) }
-  variant-error: func(a: float64) -> result<float64, e3>;
+  variant-error: func(a: f64) -> result<f64, e3>;
 
   empty-error: func(a: u32) -> result<u32>;
 }

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -15,7 +15,7 @@ void variants_test_imports() {
 
 
   {
-    test_variants_test_result_u32_float32_t a;
+    test_variants_test_result_u32_f32_t a;
     double b_ok;
     uint8_t b_err;
 
@@ -141,7 +141,7 @@ bool exports_test_variants_test_roundtrip_option(float *a, uint8_t *ret0) {
   return a != NULL;
 }
 
-bool exports_test_variants_test_roundtrip_result(exports_test_variants_test_result_u32_float32_t *a, double *ok, uint8_t *err) {
+bool exports_test_variants_test_roundtrip_result(exports_test_variants_test_result_u32_f32_t *a, double *ok, uint8_t *err) {
   if (a->is_err) {
     *err = a->val.err;
     return false;

--- a/tests/runtime/variants/world.wit
+++ b/tests/runtime/variants/world.wit
@@ -1,8 +1,8 @@
 package test:variants;
 
 interface test {
-  roundtrip-option: func(a: option<float32>) -> option<u8>;
-  roundtrip-result: func(a: result<u32, float32>) -> result<float64, u8>;
+  roundtrip-option: func(a: option<f32>) -> option<u8>;
+  roundtrip-result: func(a: result<u32, f32>) -> result<f64, u8>;
 
   enum e1 { a, b }
   roundtrip-enum: func(a: e1) -> e1;
@@ -10,18 +10,18 @@ interface test {
   invert-bool: func(a: bool) -> bool;
 
   variant c1 { a(s32), b(s64) }
-  variant c2 { a(s32), b(float32) }
-  variant c3 { a(s32), b(float64) }
-  variant c4 { a(s64), b(float32) }
-  variant c5 { a(s64), b(float64) }
-  variant c6 { a(float32), b(float64) }
+  variant c2 { a(s32), b(f32) }
+  variant c3 { a(s32), b(f64) }
+  variant c4 { a(s64), b(f32) }
+  variant c5 { a(s64), b(f64) }
+  variant c6 { a(f32), b(f64) }
   type casts = tuple<c1, c2, c3, c4, c5, c6>;
   variant-casts: func(a: casts) -> casts;
 
   variant z1 { a(s32), b }
   variant z2 { a(s64), b }
-  variant z3 { a(float32), b }
-  variant z4 { a(float64), b }
+  variant z3 { a(f32), b }
+  variant z4 { a(f64), b }
   type zeros = tuple<z1, z2, z3, z4>;
   variant-zeros: func(a: zeros) -> zeros;
 

--- a/tests/runtime/versions/deps/v1/v1.wit
+++ b/tests/runtime/versions/deps/v1/v1.wit
@@ -1,6 +1,6 @@
 package test:dep@0.1.0;
 
 interface test {
-  x: func() -> float32;
-  y: func(a: float32) -> float32;
+  x: func() -> f32;
+  y: func(a: f32) -> f32;
 }

--- a/tests/runtime/versions/deps/v2/v2.wit
+++ b/tests/runtime/versions/deps/v2/v2.wit
@@ -1,6 +1,6 @@
 package test:dep@0.2.0;
 
 interface test {
-  x: func() -> float32;
-  z: func(a: float32, b: float32) -> float32;
+  x: func() -> f32;
+  z: func(a: f32, b: f32) -> f32;
 }


### PR DESCRIPTION
Change float32/float64 to f32/f64 in the C bindings generator, in the `Instruction` enum, and in the tests.