### PR TITLE
fix(rust): suppress safety warning on `generate` macro (#922)

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -488,6 +488,7 @@ pub struct Resource<T: WasmResource> {
 /// drop a resource.
 ///
 /// This generally is implemented by generated code, not user-facing code.
+#[allow(clippy::missing_safety_doc)]
 pub unsafe trait WasmResource {
     /// Invokes the `[resource-drop]...` intrinsic.
     unsafe fn drop(handle: u32);


### PR DESCRIPTION
I'm not sure if it'd be better to add the Safety section Clippy is looking for or if it's preferable to ignore the warning, but it seemed like latter might be better, so that's what I opted for.