### PR TITLE
Use a unique name for `libwit_bindgen_cabi_realloc.a` per-crate-version

### DIFF
--- a/crates/guest-rust/rt/build.rs
+++ b/crates/guest-rust/rt/build.rs
@@ -22,10 +22,6 @@ fn main() {
         "wit_bindgen_cabi_realloc{}",
         env!("CARGO_PKG_VERSION").replace(".", "_")
     );
-    let mut src = env::current_dir().unwrap();
-    src.push("src");
-    src.push("libwit_bindgen_cabi_realloc.a");
-
     let dst = out_dir.join(format!("lib{dst_name}.a"));
 
     std::fs::copy(&src, &dst).unwrap();

--- a/crates/guest-rust/rt/build.rs
+++ b/crates/guest-rust/rt/build.rs
@@ -1,6 +1,10 @@
+use std::env;
+use std::path::PathBuf;
+
 fn main() {
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or(String::new());
-    let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or(String::new());
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or(String::new());
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or(String::new());
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     if target_family != "wasm" {
         return;
@@ -10,8 +14,22 @@ fn main() {
         panic!("only wasm32 supports cabi-realloc right now");
     }
 
-    println!("cargo:rustc-link-lib=wit_bindgen_cabi_realloc");
-    let cwd = std::env::current_dir().unwrap();
-    let cwd = cwd.display();
-    println!("cargo:rustc-link-search=native={cwd}/src");
+    let mut src = env::current_dir().unwrap();
+    src.push("src");
+    src.push("libwit_bindgen_cabi_realloc.a");
+
+    let dst_name = format!(
+        "wit_bindgen_cabi_realloc{}",
+        env!("CARGO_PKG_VERSION").replace(".", "_")
+    );
+    let mut src = env::current_dir().unwrap();
+    src.push("src");
+    src.push("libwit_bindgen_cabi_realloc.a");
+
+    let dst = out_dir.join(format!("lib{dst_name}.a"));
+
+    std::fs::copy(&src, &dst).unwrap();
+
+    println!("cargo:rustc-link-lib={dst_name}");
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
 }


### PR DESCRIPTION
This commit updates how the weak `cabi_realloc` symbol is linked. Previously rustc was told to use `-lwit_bindgen_cabi_realloc` with a `-L` pointing to the source directory of the crate which has a precompiled copy. This caused issues, however, when two versions were present in a crate graph but only one was used. With two versions present in a crate graph rustc would use two `-L` flags with directories that both contain the same-named library. Which one was picked depended on the order that rustc passed flags. If only one crate was used, however, then rustc would not pass the rlib for the other crate. This could end up in a situation where with two wit-bindgen versions A and B:

* During linking, A's `libwit_bindgen_cabi_realloc.a` file was used.
* Rustc only passed B's rlib since A wasn't actually used anywhere.
* The linker then tried to load A's version of the actual cabi_realloc symbol, but only B's was present.

The fix in this commit is to uniquely name the library name based on the crate version. This matches how the symbol name is different per crate version, for example.