### PR TITLE
Un-ignore new tests with Rust

### DIFF
--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -5,10 +5,6 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
-        (issue929 $name:tt $test:tt) => {};
-        (issue929_no_import $name:tt $test:tt) => {};
-        (issue929_no_export $name:tt $test:tt) => {};
-        (issue929_only_methods $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({

--- a/crates/rust/tests/codegen_no_std.rs
+++ b/crates/rust/tests/codegen_no_std.rs
@@ -16,10 +16,6 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
-        (issue929 $name:tt $test:tt) => {};
-        (issue929_no_import $name:tt $test:tt) => {};
-        (issue929_no_export $name:tt $test:tt) => {};
-        (issue929_only_methods $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({

--- a/tests/codegen/issue929-no-export.wit
+++ b/tests/codegen/issue929-no-export.wit
@@ -1,4 +1,4 @@
-package foo:bar;
+package foo:bar1;
 
 interface f {
     resource fd;

--- a/tests/codegen/issue929-no-import.wit
+++ b/tests/codegen/issue929-no-import.wit
@@ -1,4 +1,4 @@
-package foo:bar;
+package foo:bar2;
 
 interface f {
     resource fd;

--- a/tests/codegen/issue929-only-methods.wit
+++ b/tests/codegen/issue929-only-methods.wit
@@ -1,4 +1,4 @@
-package foo:bar;
+package foo:bar3;
 
 interface f {
     resource fd {

--- a/tests/codegen/issue929.wit
+++ b/tests/codegen/issue929.wit
@@ -1,4 +1,4 @@
-package foo:bar;
+package foo:bar4;
 
 interface f {
     resource fd;


### PR DESCRIPTION
Due to the way Rust is tested name overlaps between tests doesn't work, so rename some tests to ensure they all have unique names.