### PR TITLE
Fix build of x64 macos binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           os: ubuntu-latest
         - build: x86_64-macos
           os: macos-latest
+          target: x86_64-apple-darwin
         - build: aarch64-macos
           os: macos-latest
           target: aarch64-apple-darwin


### PR DESCRIPTION
Explicitly specify the target to handle GitHub changing the default runner.