### PR TITLE
add resource support to C# generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "anyhow",
  "clap",
  "heck 0.5.0",
+ "indexmap",
  "test-helpers",
  "wasm-encoder 0.206.0",
  "wasm-metadata",

--- a/crates/csharp/Cargo.toml
+++ b/crates/csharp/Cargo.toml
@@ -23,6 +23,7 @@ wasm-metadata = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true }
+indexmap = { workspace = true }
 
 [dev-dependencies]
 test-helpers = { path = '../test-helpers' }

--- a/crates/csharp/src/RepTable.cs
+++ b/crates/csharp/src/RepTable.cs
@@ -1,0 +1,46 @@
+/**
+ * This class is used to assign a unique integer identifier to instances of
+ * exported resources, which the host will use as its "core representation" per
+ * https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#definition-types.
+ * The identifier may be used to retrieve the corresponding instance e.g. when
+ * lifting a handle as part of the canonical ABI implementation.
+ */
+internal class RepTable<T> {
+    private List<object> list = new List<object>();
+    private int? firstVacant = null;
+    
+    private class Vacant {
+        internal int? next;
+
+        internal Vacant(int? next) {
+            this.next = next;
+        }
+    }
+
+    internal int Add(T v) {
+        int rep;
+        if (firstVacant.HasValue) {
+            rep = firstVacant.Value;
+            firstVacant = ((Vacant) list[rep]).next;
+            list[rep] = v;
+        } else {
+            rep = list.Count;
+            list.Add(v);
+        }
+        return rep;
+    }
+
+    internal T Get(int rep) {
+        if (list[rep] is Vacant) {
+            throw new ArgumentException("invalid rep");
+        }
+        return (T) list[rep];
+    }
+
+    internal T Remove(int rep) {
+        var val = Get(rep);
+        list[rep] = new Vacant(firstVacant);
+        firstVacant = rep;
+        return (T) val;
+    }
+}

--- a/crates/csharp/tests/codegen.rs
+++ b/crates/csharp/tests/codegen.rs
@@ -15,66 +15,11 @@ macro_rules! codegen_test {
                 "guest-csharp",
                 $test.as_ref(),
                 |resolve, world, files| {
-                    if [
-                        "conventions",
-                        "guest-name",
-                        "import-and-export-resource",
-                        "import-and-export-resource-alias",
-                        "import-func",
-                        "interface-has-golang-keyword",
-                        "issue544",
-                        "issue551",
-                        "issue569",
-                        "issue573",
-                        "issue607",
-                        "issue668",
-                        "enum-has-golang-keyword",
-                        "just-export",
-                        "lift-lower-foreign",
-                        "lists",
-                        "many-arguments",
-                        "option-result",
-                        "record-has-keyword-used-in-func",
-                        "rename-interface",
-                        "resource-alias",
-                        "resource-borrow-in-record",
-                        "resource-borrow-in-record-export",
-                        "resource-local-alias",
-                        "resource-local-alias-borrow",
-                        "resource-local-alias-borrow-import",
-                        "resource-own-in-other-interface",
-                        "resources",
-                        "resources-in-aggregates",
-                        "resources-with-lists",
-                        "result-empty",
-                        "return-resource-from-export",
-                        "same-names5",
-                        "simple-http",
-                        "small-anonymous",
-                        "unused-import",
-                        "use-across-interfaces",
-                        "worlds-with-types",
-                        "variants-unioning-types",
-                        "go_params",
-                        "wasi-cli",
-                        "wasi-clocks",
-                        "wasi-filesystem",
-                        "wasi-http",
-                        "wasi-io",
-                        "issue929",
-                        "issue929-no-import",
-                        "issue929-no-export",
-                        "issue929-only-methods",
-                    ]
-                    .contains(&$name)
-                    {
-                        return;
-                    }
-                    #[cfg(any(all(target_os = "windows", feature = "aot"), feature = "mono"))]
+                    #[cfg(any(feature = "aot", feature = "mono"))]
                     wit_bindgen_csharp::Opts {
                         generate_stub: true,
                         string_encoding: StringEncoding::UTF8,
-                        #[cfg(all(target_os = "windows", feature = "aot"))]
+                        #[cfg(feature = "aot")]
                         runtime: Default::default(),
                         #[cfg(feature = "mono")]
                         runtime: wit_bindgen_csharp::CSharpRuntime::Mono,
@@ -91,7 +36,7 @@ macro_rules! codegen_test {
 test_helpers::codegen_tests!();
 
 fn verify(dir: &Path, name: &str) {
-    #[cfg(all(target_os = "windows", feature = "aot"))]
+    #[cfg(feature = "aot")]
     aot_verify(dir, name);
 
     #[cfg(feature = "mono")]
@@ -182,7 +127,7 @@ fn mono_verify(dir: &Path, name: &str) {
     let wasm_filename = dir.join(name);
 
     cmd.arg("build")
-        .arg(dir.join(format!("TheWorld.csproj")))
+        .arg(dir.join(format!("TheWorldWorld.csproj")))
         .arg("-c")
         .arg("Debug")
         .arg("-o")

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -129,11 +129,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
             Some("java") => java.push(path),
             Some("rs") => rust.push(path),
             Some("go") => go.push(path),
-            Some("cs") => {
-                if cfg!(windows) {
-                    c_sharp.push(path);
-                }
-            }
+            Some("cs") => c_sharp.push(path),
             _ => {}
         }
     }
@@ -501,7 +497,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
     }
 
     #[cfg(feature = "csharp-mono")]
-    if !c_sharp.is_empty() {
+    if cfg!(windows) && !c_sharp.is_empty() {
         let (resolve, world) = resolve_wit_dir(&dir);
         for path in c_sharp.iter() {
             let world_name = &resolve.worlds[world].name;
@@ -548,7 +544,6 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
                 &assembly_name,
                 world_name,
             );
-            csproj.aot();
 
             // Copy test file to target location to be included in compilation
             let file_name = path.file_name().unwrap();
@@ -571,6 +566,8 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
                 .arg(out_dir.join(format!("{camel}.csproj")))
                 .arg("-c")
                 .arg("Debug")
+                .arg("/p:PlatformTarget=AnyCPU")
+                .arg("--self-contained")
                 .arg("-o")
                 .arg(&out_wasm);
 
@@ -592,10 +589,18 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
             let mut wasm_filename = out_wasm.clone();
             wasm_filename.set_extension("wasm");
 
-            let module = fs::read(&wasm_filename).expect("failed to read wasm file");
+            let module = fs::read(&wasm_filename).with_context(|| {
+                format!("failed to read wasm file: {}", wasm_filename.display())
+            })?;
 
             // Translate the canonical ABI module into a component.
-            let component_type = fs::read(out_dir.join("numbers_component_type.o"))?;
+            let component_type_filename = out_dir.join(format!("{camel}_component_type.o"));
+            let component_type = fs::read(&component_type_filename).with_context(|| {
+                format!(
+                    "failed to read component type file: {}",
+                    component_type_filename.display()
+                )
+            })?;
 
             let mut new_module = wasm_encoder::Module::new();
 
@@ -653,7 +658,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
     }
 
     #[cfg(feature = "csharp-naot")]
-    if !c_sharp.is_empty() {
+    if cfg!(windows) && !c_sharp.is_empty() {
         let (resolve, world) = resolve_wit_dir(&dir);
         for path in c_sharp.iter() {
             let world_name = &resolve.worlds[world].name;

--- a/tests/runtime/resource_aggregates/wasm.cs
+++ b/tests/runtime/resource_aggregates/wasm.cs
@@ -1,0 +1,64 @@
+using Import = ResourceAggregatesWorld.wit.imports.test.resourceAggregates.ITest;
+using Host = ResourceAggregatesWorld.wit.imports.test.resourceAggregates.TestInterop;
+
+namespace ResourceAggregatesWorld.wit.exports.test.resourceAggregates
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public Import.Thing val;
+
+	    public Thing(uint v) {
+		this.val = new Import.Thing(v + 1);
+	    }
+	}
+
+	public static uint Foo(
+	    ITest.R1 r1,
+	    ITest.R2 r2,
+	    ITest.R3 r3,
+	    (ITest.Thing, ITest.R1) t1,
+	    ITest.Thing t2,
+	    ITest.V1 v1,
+	    ITest.V2 v2,
+	    List<ITest.Thing> l1,
+	    List<ITest.Thing> l2,
+	    Option<ITest.Thing> o1,
+	    Option<ITest.Thing> o2,
+	    Result<ITest.Thing, None> result1,
+	    Result<ITest.Thing, None> result2
+	)
+	{
+	    var ir1 = new Import.R1(((Thing) r1.thing).val);
+	    var ir2 = new Import.R2(((Thing) r2.thing).val);
+	    var ir3 = new Import.R3(((Thing) r3.thing1).val, ((Thing) r3.thing2).val);
+	    var it1 = (((Thing) t1.Item1).val, new Import.R1(((Thing) t1.Item2.thing).val));
+	    var it2 = ((Thing) t2).val;
+	    var iv1 = Import.V1.thing(((Thing) v1.AsThing).val);
+	    var iv2 = Import.V2.thing(((Thing) v2.AsThing).val);
+	    var il1 = new List<Import.Thing>();
+	    foreach (var thing in l1)
+	    {
+		il1.Add(((Thing) thing).val);
+	    }
+	    var il2 = new List<Import.Thing>();
+	    foreach (var thing in l2)
+	    {
+		il2.Add(((Thing) thing).val);
+	    }
+	    var io1 = o1.HasValue
+		? new Option<Import.Thing>(((Thing) o1.Value).val)
+		: Option<Import.Thing>.None;
+	    var io2 = o2.HasValue
+		? new Option<Import.Thing>(((Thing) o2.Value).val)
+		: Option<Import.Thing>.None;
+	    var iresult1 = result1.IsOk
+		? Result<Import.Thing, None>.ok(((Thing) result1.AsOk).val)
+		: Result<Import.Thing, None>.err(new None());
+	    var iresult2 = result2.IsOk
+		? Result<Import.Thing, None>.ok(((Thing) result2.AsOk).val)
+		: Result<Import.Thing, None>.err(new None());
+
+	    return Host.Foo(ir1, ir2, ir3, it1, it2, iv1, iv2, il1, il2, io1, io2, iresult1, iresult2) + 4;
+	}
+    }
+}

--- a/tests/runtime/resource_alias/wasm.cs
+++ b/tests/runtime/resource_alias/wasm.cs
@@ -1,0 +1,22 @@
+namespace ResourceAliasWorld.wit.exports.test.resourceAlias
+{
+    public class E1Impl : IE1 {
+	public class X : IE1.X, IE1.IX {
+	    public uint val;
+
+	    public X(uint v) {
+		this.val = v;
+	    }
+	}
+
+	public static List<IE1.X> A(IE1.Foo f) {
+	    return new List<IE1.X>() { f.x };
+	}
+    }
+    
+    public class E2Impl : IE2 {
+	public static List<IE1.X> A(IE2.Foo f, IE1.Foo g, IE1.X h) {
+	    return new List<IE1.X>() { f.x, g.x };
+	}
+    }
+}

--- a/tests/runtime/resource_alias_redux/wasm.cs
+++ b/tests/runtime/resource_alias_redux/wasm.cs
@@ -1,0 +1,58 @@
+using Import1 = ResourceAliasReduxWorld.wit.imports.test.resourceAliasRedux.IResourceAlias1;
+using Import2 = ResourceAliasReduxWorld.wit.imports.test.resourceAliasRedux.IResourceAlias2;
+using Host1 = ResourceAliasReduxWorld.wit.imports.test.resourceAliasRedux.ResourceAlias1Interop;
+using Host2 = ResourceAliasReduxWorld.wit.imports.test.resourceAliasRedux.ResourceAlias2Interop;
+
+namespace ResourceAliasReduxWorld.wit.exports.test.resourceAliasRedux
+{
+    public class ResourceAlias1Impl : IResourceAlias1 {
+	public class Thing : IResourceAlias1.Thing, IResourceAlias1.IThing {
+	    public Import1.Thing val;
+
+	    public Thing(string v) {
+		this.val = new Import1.Thing(v + " Thing");
+	    }
+
+	    public Thing(Import1.Thing v) {
+		this.val = v;
+	    }
+
+	    public string Get() {
+		return this.val.Get() + " Thing.get";
+	    }
+	}
+
+	public static List<IResourceAlias1.Thing> A(IResourceAlias1.Foo f) {
+	    var oldList = Host1.A(new Import1.Foo(((Thing) f.thing).val));
+	    var newList = new List<IResourceAlias1.Thing>();
+	    foreach (var thing in oldList)
+	    {
+		newList.Add(new Thing(thing));
+	    }
+	    return newList;
+	}
+    }
+    
+    public class ResourceAlias2Impl : IResourceAlias2 {
+	public static List<IResourceAlias1.Thing> B(IResourceAlias2.Foo f, IResourceAlias1.Foo g) {
+	    var oldList = Host2.B(
+		new Import2.Foo(((ResourceAlias1Impl.Thing) f.thing).val),
+		new Import1.Foo(((ResourceAlias1Impl.Thing) g.thing).val)
+	    );
+	    var newList = new List<IResourceAlias1.Thing>();
+	    foreach (var thing in oldList)
+	    {
+		newList.Add(new ResourceAlias1Impl.Thing(thing));
+	    }
+	    return newList;
+	}
+    }
+}
+
+namespace ResourceAliasReduxWorld {
+    public class ResourceAliasReduxWorldImpl : IResourceAliasReduxWorld {
+	public static List<Import1.Thing> Test(List<Import1.Thing> things) {
+	    return things;
+	}
+    }
+}

--- a/tests/runtime/resource_borrow_export/wasm.cs
+++ b/tests/runtime/resource_borrow_export/wasm.cs
@@ -1,0 +1,16 @@
+namespace ResourceBorrowExportWorld.wit.exports.test.resourceBorrowExport
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public uint val;
+
+	    public Thing(uint v) {
+		this.val = v + 1;
+	    }
+	}
+
+	public static uint Foo(ITest.Thing v) {
+	    return ((Thing) v).val + 2;
+	}
+    }
+}

--- a/tests/runtime/resource_borrow_import/wasm.cs
+++ b/tests/runtime/resource_borrow_import/wasm.cs
@@ -1,0 +1,11 @@
+using Import = ResourceBorrowImportWorld.wit.imports.test.resourceBorrowImport.ITest;
+using Host = ResourceBorrowImportWorld.wit.imports.test.resourceBorrowImport.TestInterop;
+
+namespace ResourceBorrowImportWorld
+{
+    public class ResourceBorrowImportWorldImpl : IResourceBorrowImportWorld {
+	public static uint Test(uint v) {
+	    return Host.Foo(new Import.Thing(v + 1)) + 4;
+	}
+    }
+}

--- a/tests/runtime/resource_borrow_in_record/wasm.cs
+++ b/tests/runtime/resource_borrow_in_record/wasm.cs
@@ -1,0 +1,38 @@
+using Import = ResourceBorrowInRecordWorld.wit.imports.test.resourceBorrowInRecord.ITest;
+using Host = ResourceBorrowInRecordWorld.wit.imports.test.resourceBorrowInRecord.TestInterop;
+
+namespace ResourceBorrowInRecordWorld.wit.exports.test.resourceBorrowInRecord
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public Import.Thing val;
+
+	    public Thing(string v) {
+		this.val = new Import.Thing(v + " Thing");
+	    }
+
+	    public Thing(Import.Thing thing) {
+		this.val = thing;
+	    }
+
+	    public string Get() {
+		return val.Get() + " Thing.get";
+	    }
+	}
+
+	public static List<ITest.Thing> Test(List<ITest.Foo> v) {
+	    var list = new List<Import.Foo>();
+	    foreach (var foo in v)
+	    {
+		list.Add(new Import.Foo(((Thing) foo.thing).val));
+	    }
+	    var result = Host.Test(list);
+	    var myResult = new List<ITest.Thing>();
+	    foreach (var thing in result)
+	    {
+		myResult.Add(new Thing(thing));
+	    }
+	    return myResult;
+	}
+    }
+}

--- a/tests/runtime/resource_borrow_simple/wasm.cs
+++ b/tests/runtime/resource_borrow_simple/wasm.cs
@@ -1,0 +1,8 @@
+namespace ResourceBorrowSimpleWorld
+{
+    public class ResourceBorrowSimpleWorldImpl : IResourceBorrowSimpleWorld {
+	public static void TestImports() {
+	    exports.ResourceBorrowSimpleWorld.Test(new IResourceBorrowSimpleWorld.R());
+	}
+    }
+}

--- a/tests/runtime/resource_floats/wasm.cs
+++ b/tests/runtime/resource_floats/wasm.cs
@@ -1,0 +1,31 @@
+using Import1 = ResourceFloatsWorld.wit.imports.IImports;
+using Import2 = ResourceFloatsWorld.wit.imports.test.resourceFloats.ITest;
+
+namespace ResourceFloatsWorld.wit.exports
+{
+    public class ExportsImpl : IExports {
+	public class Float : IExports.Float, IExports.IFloat {
+	    public Import1.Float val;
+
+	    public Float(double v) {
+		this.val = new Import1.Float(v + 1.0);
+	    }
+
+	    public double Get() {
+		return this.val.Get() + 3.0;
+	    }
+
+	    public static IExports.Float Add(IExports.Float a, double b) {
+		return new Float(Import1.Float.Add(((Float) a).val, b).Get() + 5.0);
+	    }
+	}
+    }
+}
+
+namespace ResourceFloatsWorld {
+    public class ResourceFloatsWorldImpl : IResourceFloatsWorld {
+	public static Import2.Float Add(Import2.Float a, Import2.Float b) {
+	    return new Import2.Float(a.Get() + b.Get() + 5.0);
+	}
+    }
+}

--- a/tests/runtime/resource_import_and_export/wasm.cs
+++ b/tests/runtime/resource_import_and_export/wasm.cs
@@ -1,0 +1,35 @@
+using Import = ResourceImportAndExportWorld.wit.imports.test.resourceImportAndExport.ITest;
+using Host = ResourceImportAndExportWorld.wit.imports.test.resourceImportAndExport.TestInterop;
+
+namespace ResourceImportAndExportWorld.wit.exports.test.resourceImportAndExport
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public Import.Thing val;
+
+	    public Thing(uint v) {
+		this.val = new Import.Thing(v + 1);
+	    }
+
+	    public uint Foo() {
+		return this.val.Foo() + 2;
+	    }
+
+	    public void Bar(uint v) {
+		this.val.Bar(v + 3);
+	    }
+
+	    public static ITest.Thing Baz(ITest.Thing a, ITest.Thing b) {
+		return new Thing(Import.Thing.Baz(((Thing) a).val, ((Thing) b).val).Foo() + 4);
+	    }
+	}
+    }
+}
+
+namespace ResourceImportAndExportWorld {
+    public class ResourceImportAndExportWorldImpl : IResourceImportAndExportWorld {
+	public static Import.Thing ToplevelExport(Import.Thing things) {
+	    return exports.ResourceImportAndExportWorld.ToplevelImport(things);
+	}
+    }
+}

--- a/tests/runtime/resource_into_inner/wasm.cs
+++ b/tests/runtime/resource_into_inner/wasm.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+
+namespace ResourceIntoInnerWorld.wit.exports.test.resourceIntoInner
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public string val;
+
+	    public Thing(string v) {
+		this.val = v;
+	    }
+	}
+
+	public static void Test() {
+	    // Unlike wasm.rs, this doesn't test anything interesting
+	    // due there being no ownership semantics in C# (and also
+	    // due to way the C# code generator lazily calls
+	    // `[resource-new]thing` only as needed), but we go
+	    // through the motions here anyway:
+	    var text = "Jabberwocky";
+	    Debug.Assert(new Thing(text).val == text);
+	}
+    }
+}

--- a/tests/runtime/resource_with_lists/wasm.cs
+++ b/tests/runtime/resource_with_lists/wasm.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using Import = ResourceWithListsWorld.wit.imports.test.resourceWithLists.ITest;
+using Host = ResourceWithListsWorld.wit.imports.test.resourceWithLists.TestInterop;
+
+namespace ResourceWithListsWorld.wit.exports.test.resourceWithLists
+{
+    public class TestImpl : ITest {
+	public class Thing : ITest.Thing, ITest.IThing {
+	    public Import.Thing val;
+
+	    public Thing(byte[] v) {
+		var bytes = Encoding.ASCII.GetBytes(" Thing");
+		var result = new byte[v.Count() + bytes.Count()];
+		Array.Copy(v, result, v.Count());
+		Array.Copy(bytes, 0, result, v.Count(), bytes.Count());
+		this.val = new Import.Thing(result);
+	    }
+
+	    public byte[] Foo() {
+		var v = this.val.Foo();
+		var bytes = Encoding.ASCII.GetBytes(" Thing.foo");
+		var result = new byte[v.Count() + bytes.Count()];
+		Array.Copy(v, result, v.Count());
+		Array.Copy(bytes, 0, result, v.Count(), bytes.Count());
+		return result;
+	    }
+
+	    public void Bar(byte[] v) {
+		var bytes = Encoding.ASCII.GetBytes(" Thing.bar");
+		var result = new byte[v.Count() + bytes.Count()];
+		Array.Copy(v, result, v.Count());
+		Array.Copy(bytes, 0, result, v.Count(), bytes.Count());
+		this.val.Bar(result);
+	    }
+
+	    public static byte[] Baz(byte[] v) {
+		var bytes = Encoding.ASCII.GetBytes(" Thing.baz");
+		var result = new byte[v.Count() + bytes.Count()];
+		Array.Copy(v, result, v.Count());
+		Array.Copy(bytes, 0, result, v.Count(), bytes.Count());
+
+		var v2 = Import.Thing.Baz(result);
+		var bytes2 = Encoding.ASCII.GetBytes(" Thing.baz again");
+		var result2 = new byte[v2.Count() + bytes2.Count()];
+		Array.Copy(v2, result2, v2.Count());
+		Array.Copy(bytes2, 0, result2, v2.Count(), bytes2.Count());
+
+		return result2;
+	    }
+	}
+    }
+}

--- a/tests/runtime/resources/wasm.cs
+++ b/tests/runtime/resources/wasm.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+using ResourcesWorld;
+using ResourcesWorld.wit.imports;
+
+namespace ResourcesWorld.wit.exports
+{
+    public class ExportsImpl : IExports
+    {
+        public static IExports.Z Add(IExports.Z a, IExports.Z b)
+        {
+            return new Z(((Z) a).val + ((Z) b).val);
+        }
+        
+        public static Result<None, string> TestImports()
+        {
+            var y1 = new IImports.Y(10);
+            Debug.Assert(y1.GetA() == 10);
+	    y1.SetA(20);
+            Debug.Assert(y1.GetA() == 20);	    
+	    var y2 = IImports.Y.Add(y1, 20);
+            Debug.Assert(y2.GetA() == 40);
+
+	    var y3 = new IImports.Y(1);
+	    var y4 = new IImports.Y(2);
+            Debug.Assert(y3.GetA() == 1);
+            Debug.Assert(y4.GetA() == 2);
+	    y3.SetA(10);
+	    y4.SetA(20);	    
+            Debug.Assert(y3.GetA() == 10);
+            Debug.Assert(y4.GetA() == 20);	    	    
+	    var y5 = IImports.Y.Add(y3, 20);
+	    var y6 = IImports.Y.Add(y4, 30);	    
+            Debug.Assert(y5.GetA() == 30);
+            Debug.Assert(y6.GetA() == 50);	    
+	    
+            return Result<None, string>.ok(new None());
+        }
+
+        public class X : IExports.X, IExports.IX {
+            public int val;
+
+            public X(int val) {
+                this.val = val;
+            }
+
+            public void SetA(int val) {
+                this.val = val;
+            }
+
+            public int GetA() {
+                return val;
+            }
+
+            public static IExports.X Add(IExports.X a, int b) {
+                var myA = (X) a;
+                myA.SetA(myA.GetA() + b);
+                return myA;
+            }
+        }
+    
+        public class Z : IExports.Z, IExports.IZ {
+            private static uint numDropped = 0;
+            
+            public int val;
+
+            public Z(int val) {
+                this.val = val;
+            }
+
+            public int GetA() {
+                return val;
+            }
+
+            public static uint NumDropped() {
+                return numDropped + 1;
+            }
+
+            override protected void Dispose(bool disposing) {
+		numDropped += 1;
+                
+                base.Dispose(disposing);
+            }
+        }
+
+        public class KebabCase : IExports.KebabCase, IExports.IKebabCase {
+            public uint val;
+            
+            public KebabCase(uint val) {
+                this.val = val;
+            }
+            
+            public uint GetA() {
+                return val;
+            }
+
+            public static uint TakeOwned(IExports.KebabCase a) {
+                return ((KebabCase) a).val;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds resource support to the C# generator and also fixes a few miscellaneous issues that were preventing tests from passing.

I believe the code generated for imported resources is reasonably ergonomic, although I'm pretty new to C#, so I'm open to suggestions to make it more idiomatic.

As with other languages, the code for exported resources is a bit less ergonomic, I'm using an `interface` to represent the API, but I also want implementations to inherit code which manages the resource handle, for which I'm currently using a `class`.  The upshot is that implementing an exported resource involves both extending a `class` and implementing an `interface`.  Again, I'm open to suggestions about improving this.  Note that exporting resources tends to be a lot less common in end-user code than importing them, so we probably don't need to obsess over ergonomics in that case.