### PR TITLE
fix C# resource dtor recursion issue

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1390,6 +1390,9 @@ impl InterfaceGenerator<'_> {
                     [UnmanagedCallersOnly(EntryPoint = "{prefix}[dtor]{name}")]
                     public static unsafe void wasmExportResourceDtor{upper_camel}(int rep) {{
                         var val = ({qualified}) {qualified}.repTable.Remove(rep);
+                        val.Handle = 0;
+                        // Note we call `Dispose` here even though the handle has already been disposed in case
+                        // the implementation has overridden `Dispose(bool)`.
                         val.Dispose();
                     }}
                     "#
@@ -1441,7 +1444,6 @@ impl InterfaceGenerator<'_> {
                             if (Handle != 0) {{
                                 var handle = Handle;
                                 Handle = 0;
-                                repTable.Remove(WasmInterop.wasmImportResourceRep(handle));
                                 WasmInterop.wasmImportResourceDrop(handle);
                             }}
                         }}

--- a/tests/runtime/resources/wasm.cs
+++ b/tests/runtime/resources/wasm.cs
@@ -13,8 +13,7 @@ namespace ResourcesWorld.wit.exports
 
         public static void Consume(IExports.X x)
         {
-          // FIXME: c-sharp generator seems wrong here
-          // x.Dispose();
+            x.Dispose();
         }
         
         public static Result<None, string> TestImports()


### PR DESCRIPTION
Given than the destructor function we export for a given exported resource will take care of removing the rep from the `RepTable`, we should not try to do that in the `Dispose(bool)` method; just call `WasmInterop.wasmImportResourceDrop`, which will call the host, which will call back into the guest, which will remove the entry.