### PR TITLE
fix(go): correct field name for C struct

### DIFF
--- a/crates/go/src/bindgen.rs
+++ b/crates/go/src/bindgen.rs
@@ -690,7 +690,8 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
     }
 
     pub(crate) fn get_c_field_name(&mut self, field: &Field) -> String {
-        avoid_keyword(field.name.to_snake_case().as_str())
+        let name = wit_bindgen_c::to_c_ident(field.name.to_snake_case().as_str());
+        avoid_keyword(&name)
     }
 
     pub(crate) fn get_go_field_name(&mut self, field: &Field) -> String {


### PR DESCRIPTION
Given the following wit file

```
package helloworld:example;

/// An example world for the component to target.
world example {
    record hello {
        namespace: list<u8>,
    }
}
```

the tiny-go based bindings are generated as 2 parts
- C bindings has `example_hello_t` struct corresponding to `hello` record, where `namespace` field is appended with a `_` suffix to avoid using the C++ keyword `namespace`
    ```C
    typedef struct example_hello_t {
      example_list_u8_t   namespace_;
    } example_hello_t;
    ```
- Go bindings wrongly reference `example_hello_t` struct through Cgo using field name `namespace` (without the `_` suffix)

This PR correct the C field name generation in go files.