### PR TITLE
Bump the wasi-sdk to 22.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,9 +20,9 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
 
-RUN cd /opt && curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz \
+RUN cd /opt && curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-linux.tar.gz \
     | tar -xz
-ENV WASI_SDK_PATH=/opt/wasi-sdk-20.0
+ENV WASI_SDK_PATH=/opt/wasi-sdk-22.0
 
-RUN echo 'alias clang=/opt/wasi-sdk-20.0/bin/clang' >> /etc/bash.bashrc
-RUN echo 'alias clang++=/opt/wasi-sdk-20.0/bin/clang++' >> /etc/bash.bashrc
+RUN echo 'alias clang=/opt/wasi-sdk-22.0/bin/clang' >> /etc/bash.bashrc
+RUN echo 'alias clang++=/opt/wasi-sdk-22.0/bin/clang++' >> /etc/bash.bashrc

--- a/.github/actions/install-wasi-sdk/action.yml
+++ b/.github/actions/install-wasi-sdk/action.yml
@@ -5,18 +5,18 @@ runs:
   using: composite
   steps:
     - run: |
-        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz -L | tar xzvf -
-        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-20.0" >> $GITHUB_ENV
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-linux.tar.gz -L | tar xzvf -
+        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-22.0" >> $GITHUB_ENV
       if: runner.os == 'Linux'
       shell: bash
     - run: |
-        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-macos.tar.gz -L | tar xzvf -
-        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-20.0" >> $GITHUB_ENV
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-macos.tar.gz -L | tar xzvf -
+        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-22.0" >> $GITHUB_ENV
       if: runner.os == 'macOS'
       shell: bash
     - run: |
-        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz -L | tar xzvf -
-        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-20.0+m" >> $GITHUB_ENV
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw.tar.gz -L | tar xzvf -
+        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-22.0+m" >> $GITHUB_ENV
       if: runner.os == 'Windows'
       shell: bash
     - name: Setup `wasm-tools`

--- a/crates/csharp/README.txt
+++ b/crates/csharp/README.txt
@@ -11,5 +11,5 @@ cd .\emsdk-main\main\emsdk-main
 .\emsdk_env.ps1 activate 3.1.23 --permanant
 
 // install wasi-sdk and set env
-curl.exe -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz | tar xzvf -
-$env:WASI_SDK_PATH="c:\users\jstur\wasi-sdk-20.0+m\"
+curl.exe -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw.tar.gz | tar xzvf -
+$env:WASI_SDK_PATH="c:\users\jstur\wasi-sdk-22.0+m\"

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ There are a few pre-requisites to testing the project. You only need the languag
 
 - WASI SDK
   - Download from wasi-sdk releases page. If you're using Windows, you need the one with mingw in its name.
-  - `curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz`
+  - `curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-linux.tar.gz`
   - Create an environment variable called `WASI_SDK_PATH`` giving the path where you extracted the WASI SDK download, i.e., the directory containing `bin`/`lib`/`share`` folders.
 - Compilers for the target language:
   - Go + TinyGo - https://tinygo.org/ (v0.27.0+)


### PR DESCRIPTION
This updates to the latest version and also works towards removing EMSDK for the c# generator (https://github.com/dotnet/runtimelab/pull/2592)