### PR TITLE
C#: use exceptions for functions returning `result`

### DIFF
--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -33,6 +33,7 @@ mod resource_import_and_export;
 mod resource_into_inner;
 mod resource_with_lists;
 mod resources;
+mod results;
 mod rust_xcrate;
 mod smoke;
 mod strings;

--- a/tests/runtime/resources/wasm.cs
+++ b/tests/runtime/resources/wasm.cs
@@ -16,7 +16,7 @@ namespace ResourcesWorld.wit.exports
             x.Dispose();
         }
         
-        public static Result<None, string> TestImports()
+        public static void TestImports()
         {
             var y1 = new IImports.Y(10);
             Debug.Assert(y1.GetA() == 10);
@@ -36,9 +36,7 @@ namespace ResourcesWorld.wit.exports
 	    var y5 = IImports.Y.Add(y3, 20);
 	    var y6 = IImports.Y.Add(y4, 30);	    
             Debug.Assert(y5.GetA() == 30);
-            Debug.Assert(y6.GetA() == 50);	    
-	    
-            return Result<None, string>.ok(new None());
+            Debug.Assert(y6.GetA() == 50);
         }
 
         public class X : IExports.X, IExports.IX {

--- a/tests/runtime/results.rs
+++ b/tests/runtime/results.rs
@@ -1,0 +1,166 @@
+use anyhow::Result;
+use wasmtime::Store;
+
+wasmtime::component::bindgen!({
+    path: "tests/runtime/results",
+});
+
+use test::results::test as imports;
+
+#[derive(Default)]
+pub struct MyImports;
+
+impl test::results::test::Host for MyImports {
+    fn string_error(&mut self, a: f32) -> Result<Result<f32, String>> {
+        Ok(if a == 0.0 {
+            Err("zero".to_owned())
+        } else {
+            Ok(a)
+        })
+    }
+
+    fn enum_error(&mut self, a: f64) -> Result<Result<f64, imports::E>> {
+        Ok(if a == 0.0 { Err(imports::E::A) } else { Ok(a) })
+    }
+
+    fn record_error(&mut self, a: f64) -> Result<Result<f64, imports::E2>> {
+        Ok(if a == 0.0 {
+            Err(imports::E2 {
+                line: 420,
+                column: 0,
+            })
+        } else if a == 1.0 {
+            Err(imports::E2 {
+                line: 77,
+                column: 2,
+            })
+        } else {
+            Ok(a)
+        })
+    }
+
+    fn variant_error(&mut self, a: f64) -> Result<Result<f64, imports::E3>> {
+        Ok(if a == 0.0 {
+            Err(imports::E3::E2(imports::E2 {
+                line: 420,
+                column: 0,
+            }))
+        } else if a == 1.0 {
+            Err(imports::E3::E1(imports::E::B))
+        } else if a == 2.0 {
+            Err(imports::E3::E1(imports::E::C))
+        } else {
+            Ok(a)
+        })
+    }
+
+    fn empty_error(&mut self, a: u32) -> Result<Result<u32, ()>> {
+        Ok(if a == 0 {
+            Err(())
+        } else if a == 1 {
+            Ok(42)
+        } else {
+            Ok(a)
+        })
+    }
+
+    fn double_error(&mut self, a: u32) -> Result<Result<Result<(), String>, String>> {
+        Ok(if a == 0 {
+            Ok(Ok(()))
+        } else if a == 1 {
+            Ok(Err("one".into()))
+        } else {
+            Err("two".into())
+        })
+    }
+}
+
+#[test]
+fn run() -> Result<()> {
+    crate::run_test(
+        "results",
+        |linker| Results::add_to_linker(linker, |x| &mut x.0),
+        |store, component, linker| Results::instantiate(store, component, linker),
+        run_test,
+    )
+}
+
+fn run_test(results: Results, store: &mut Store<crate::Wasi<MyImports>>) -> Result<()> {
+    use exports::test::results::test::{E, E2, E3};
+
+    assert_eq!(
+        results.interface0.call_string_error(&mut *store, 0.0)?,
+        Err("zero".to_owned())
+    );
+    assert_eq!(
+        results.interface0.call_string_error(&mut *store, 1.0)?,
+        Ok(1.0)
+    );
+
+    assert_eq!(
+        results.interface0.call_enum_error(&mut *store, 0.0)?,
+        Err(E::A)
+    );
+    assert_eq!(
+        results.interface0.call_enum_error(&mut *store, 0.0)?,
+        Err(E::A)
+    );
+
+    assert!(matches!(
+        results.interface0.call_record_error(&mut *store, 0.0)?,
+        Err(E2 {
+            line: 420,
+            column: 0
+        })
+    ));
+    assert!(matches!(
+        results.interface0.call_record_error(&mut *store, 1.0)?,
+        Err(E2 {
+            line: 77,
+            column: 2
+        })
+    ));
+
+    assert!(results
+        .interface0
+        .call_record_error(&mut *store, 2.0)?
+        .is_ok());
+
+    assert!(matches!(
+        results.interface0.call_variant_error(&mut *store, 0.0)?,
+        Err(E3::E2(E2 {
+            line: 420,
+            column: 0
+        }))
+    ));
+    assert!(matches!(
+        results.interface0.call_variant_error(&mut *store, 1.0)?,
+        Err(E3::E1(E::B))
+    ));
+    assert!(matches!(
+        results.interface0.call_variant_error(&mut *store, 2.0)?,
+        Err(E3::E1(E::C))
+    ));
+
+    assert_eq!(
+        results.interface0.call_empty_error(&mut *store, 0)?,
+        Err(())
+    );
+    assert_eq!(results.interface0.call_empty_error(&mut *store, 1)?, Ok(42));
+    assert_eq!(results.interface0.call_empty_error(&mut *store, 2)?, Ok(2));
+
+    assert_eq!(
+        results.interface0.call_double_error(&mut *store, 0)?,
+        Ok(Ok(()))
+    );
+    assert_eq!(
+        results.interface0.call_double_error(&mut *store, 1)?,
+        Ok(Err("one".into()))
+    );
+    assert_eq!(
+        results.interface0.call_double_error(&mut *store, 2)?,
+        Err("two".into())
+    );
+
+    Ok(())
+}

--- a/tests/runtime/results.rs
+++ b/tests/runtime/results.rs
@@ -19,11 +19,11 @@ impl test::results::test::Host for MyImports {
         })
     }
 
-    fn enum_error(&mut self, a: f64) -> Result<Result<f64, imports::E>> {
+    fn enum_error(&mut self, a: f32) -> Result<Result<f32, imports::E>> {
         Ok(if a == 0.0 { Err(imports::E::A) } else { Ok(a) })
     }
 
-    fn record_error(&mut self, a: f64) -> Result<Result<f64, imports::E2>> {
+    fn record_error(&mut self, a: f32) -> Result<Result<f32, imports::E2>> {
         Ok(if a == 0.0 {
             Err(imports::E2 {
                 line: 420,
@@ -39,7 +39,7 @@ impl test::results::test::Host for MyImports {
         })
     }
 
-    fn variant_error(&mut self, a: f64) -> Result<Result<f64, imports::E3>> {
+    fn variant_error(&mut self, a: f32) -> Result<Result<f32, imports::E3>> {
         Ok(if a == 0.0 {
             Err(imports::E3::E2(imports::E2 {
                 line: 420,

--- a/tests/runtime/results/wasm.cs
+++ b/tests/runtime/results/wasm.cs
@@ -1,0 +1,77 @@
+using ResultsWorld.wit.imports.test.results;
+
+namespace ResultsWorld.wit.exports.test.results
+{
+    public class TestImpl : ITest
+    {
+        public static float StringError(float a)
+        {
+            return ResultsWorld.wit.imports.test.results.TestInterop.StringError(a);
+        }
+
+        public static double EnumError(double a)
+        {
+            try {
+                return ResultsWorld.wit.imports.test.results.TestInterop.EnumError(a);
+            } catch (WitException e) {
+                switch ((ResultsWorld.wit.imports.test.results.ITest.E) e.Value) {
+                    case ResultsWorld.wit.imports.test.results.ITest.E.A:
+                        throw new WitException(ITest.E.A, 0);
+                    case ResultsWorld.wit.imports.test.results.ITest.E.B:
+                        throw new WitException(ITest.E.B, 0);
+                    case ResultsWorld.wit.imports.test.results.ITest.E.C:
+                        throw new WitException(ITest.E.C, 0);
+                    default:
+                        throw new Exception("unreachable");
+                }
+            }
+        }
+
+        public static double RecordError(double a)
+        {
+            try {
+                return ResultsWorld.wit.imports.test.results.TestInterop.RecordError(a);
+            } catch (WitException e) {
+                var value = (ResultsWorld.wit.imports.test.results.ITest.E2) e.Value;
+                throw new WitException(new ITest.E2(value.line, value.column), 0);
+            }
+        }
+
+        public static double VariantError(double a)
+        {
+            try {
+                return ResultsWorld.wit.imports.test.results.TestInterop.VariantError(a);
+            } catch (WitException e) {
+                var value = (ResultsWorld.wit.imports.test.results.ITest.E3) e.Value;
+                switch (value.Tag) {
+                    case ResultsWorld.wit.imports.test.results.ITest.E3.E1:
+                        switch (value.AsE1) {
+                            case ResultsWorld.wit.imports.test.results.ITest.E.A:
+                                throw new WitException(ITest.E3.e1(ITest.E.A), 0);
+                            case ResultsWorld.wit.imports.test.results.ITest.E.B:
+                                throw new WitException(ITest.E3.e1(ITest.E.B), 0);
+                            case ResultsWorld.wit.imports.test.results.ITest.E.C:
+                                throw new WitException(ITest.E3.e1(ITest.E.C), 0);
+                            default:
+                                throw new Exception("unreachable");
+                        }
+                    case ResultsWorld.wit.imports.test.results.ITest.E3.E2: {
+                        throw new WitException(ITest.E3.e2(new ITest.E2(value.AsE2.line, value.AsE2.column)), 0);
+                    }
+                    default:
+                        throw new Exception("unreachable");
+                }
+            }
+        }
+
+        public static uint EmptyError(uint a)
+        {
+            return ResultsWorld.wit.imports.test.results.TestInterop.EmptyError(a);
+        }
+
+        public static void DoubleError(uint a)
+        {
+            ResultsWorld.wit.imports.test.results.TestInterop.DoubleError(a);
+        }
+    }
+}

--- a/tests/runtime/results/wasm.cs
+++ b/tests/runtime/results/wasm.cs
@@ -9,7 +9,7 @@ namespace ResultsWorld.wit.exports.test.results
             return ResultsWorld.wit.imports.test.results.TestInterop.StringError(a);
         }
 
-        public static double EnumError(double a)
+        public static float EnumError(float a)
         {
             try {
                 return ResultsWorld.wit.imports.test.results.TestInterop.EnumError(a);
@@ -27,7 +27,7 @@ namespace ResultsWorld.wit.exports.test.results
             }
         }
 
-        public static double RecordError(double a)
+        public static float RecordError(float a)
         {
             try {
                 return ResultsWorld.wit.imports.test.results.TestInterop.RecordError(a);
@@ -37,7 +37,7 @@ namespace ResultsWorld.wit.exports.test.results
             }
         }
 
-        public static double VariantError(double a)
+        public static float VariantError(float a)
         {
             try {
                 return ResultsWorld.wit.imports.test.results.TestInterop.VariantError(a);
@@ -69,9 +69,9 @@ namespace ResultsWorld.wit.exports.test.results
             return ResultsWorld.wit.imports.test.results.TestInterop.EmptyError(a);
         }
 
-        public static void DoubleError(uint a)
+        public static void FloatError(uint a)
         {
-            ResultsWorld.wit.imports.test.results.TestInterop.DoubleError(a);
+            ResultsWorld.wit.imports.test.results.TestInterop.FloatError(a);
         }
     }
 }

--- a/tests/runtime/results/wasm.cs
+++ b/tests/runtime/results/wasm.cs
@@ -69,9 +69,9 @@ namespace ResultsWorld.wit.exports.test.results
             return ResultsWorld.wit.imports.test.results.TestInterop.EmptyError(a);
         }
 
-        public static void FloatError(uint a)
+        public static void DoubleError(uint a)
         {
-            ResultsWorld.wit.imports.test.results.TestInterop.FloatError(a);
-        }
+            ResultsWorld.wit.imports.test.results.TestInterop.DoubleError(a);
+        }    
     }
 }

--- a/tests/runtime/results/wasm.rs
+++ b/tests/runtime/results/wasm.rs
@@ -13,6 +13,7 @@ impl test_exports::Guest for Exports {
     fn string_error(a: f32) -> Result<f32, String> {
         test_imports::string_error(a)
     }
+
     fn enum_error(a: f64) -> Result<f64, test_exports::E> {
         match test_imports::enum_error(a) {
             Ok(b) => Ok(b),
@@ -21,6 +22,7 @@ impl test_exports::Guest for Exports {
             Err(test_imports::E::C) => Err(test_exports::E::C),
         }
     }
+
     fn record_error(a: f64) -> Result<f64, test_exports::E2> {
         match test_imports::record_error(a) {
             Ok(b) => Ok(b),
@@ -45,7 +47,12 @@ impl test_exports::Guest for Exports {
             }
         }
     }
+
     fn empty_error(a: u32) -> Result<u32, ()> {
         test_imports::empty_error(a)
+    }
+
+    fn double_error(a: u32) -> Result<Result<(), String>, String> {
+        test_imports::double_error(a)
     }
 }

--- a/tests/runtime/results/wasm.rs
+++ b/tests/runtime/results/wasm.rs
@@ -14,7 +14,7 @@ impl test_exports::Guest for Exports {
         test_imports::string_error(a)
     }
 
-    fn enum_error(a: f64) -> Result<f64, test_exports::E> {
+    fn enum_error(a: f32) -> Result<f32, test_exports::E> {
         match test_imports::enum_error(a) {
             Ok(b) => Ok(b),
             Err(test_imports::E::A) => Err(test_exports::E::A),
@@ -23,14 +23,14 @@ impl test_exports::Guest for Exports {
         }
     }
 
-    fn record_error(a: f64) -> Result<f64, test_exports::E2> {
+    fn record_error(a: f32) -> Result<f32, test_exports::E2> {
         match test_imports::record_error(a) {
             Ok(b) => Ok(b),
             Err(test_imports::E2 { line, column }) => Err(test_exports::E2 { line, column }),
         }
     }
 
-    fn variant_error(a: f64) -> Result<f64, test_exports::E3> {
+    fn variant_error(a: f32) -> Result<f32, test_exports::E3> {
         match test_imports::variant_error(a) {
             Ok(b) => Ok(b),
             Err(test_imports::E3::E1(test_imports::E::A)) => {

--- a/tests/runtime/results/world.wit
+++ b/tests/runtime/results/world.wit
@@ -14,6 +14,8 @@ interface test {
   variant-error: func(a: f64) -> result<f64, e3>;
 
   empty-error: func(a: u32) -> result<u32>;
+
+  double-error: func(a: u32) -> result<result<_, string>, string>;
 }
 
 world results {

--- a/tests/runtime/results/world.wit
+++ b/tests/runtime/results/world.wit
@@ -4,14 +4,14 @@ interface test {
   string-error: func(a: f32) -> result<f32, string>;
 
   enum e { a, b, c }
-  enum-error: func(a: f64) -> result<f64, e>;
+  enum-error: func(a: f32) -> result<f32, e>;
 
   record e2 { line: u32, column: u32 }
-  record-error: func(a: f64) -> result<f64, e2>;
+  record-error: func(a: f32) -> result<f32, e2>;
 
 
   variant e3 { e1(e), e2(e2) }
-  variant-error: func(a: f64) -> result<f64, e3>;
+  variant-error: func(a: f32) -> result<f32, e3>;
 
   empty-error: func(a: u32) -> result<u32>;
 


### PR DESCRIPTION
This addresses part of #964.

For WIT functions returning `result<T, E>`, we now generate methods which return `T` and throw `WitException` such that the `E` value may be retrieved using `WitException.Value`.

I considered making `WitException` generic, but I couldn't find a precedent for generic exception classes when searching online, so I'm not sure how idiomatic that would be.  So, for now at least, you need to cast the value obtained using `WitException.Value` to the expected type.  Happy to revisit this if desired.

For WIT functions returning nested results, e.g. `result<result<T, E1>, E2>`, we generate methods which return `T` and throw `WitException`, using `WitException.NestingLevel` to disambiguate when `E1` and `E2` are the same.