### PR TITLE
C#: Remove the emscripten compiler and rely on wasi-sdk

### DIFF
--- a/.github/actions/install-wasi-sdk/action.yml
+++ b/.github/actions/install-wasi-sdk/action.yml
@@ -15,7 +15,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
     - run: |
-        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw.tar.gz -L | tar xzvf -
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw64.tar.gz -L | tar xzvf -
         echo "WASI_SDK_PATH=`pwd`/wasi-sdk-22.0+m" >> $GITHUB_ENV
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,12 +80,6 @@ jobs:
         echo $LOCALAPPDATA'\Microsoft\dotnet' >> $GITHUB_PATH
         echo $LOCALAPPDATA'\Microsoft\dotnet\tools' >> $GITHUB_PATH
         $LOCALAPPDATA/Microsoft/dotnet/dotnet --info
-        echo nativeaot-llvm requires emscripten for its version of clang as wasi-sdk 20 does not work see https://github.com/WebAssembly/wasi-sdk/issues/326
-        curl.exe -OL https://github.com/emscripten-core/emsdk/archive/refs/heads/main.zip
-        unzip main.zip
-        cd emsdk-main
-        ./emsdk.bat install 3.1.47
-        ./emsdk.bat activate 3.1.47
       if : matrix.os == 'windows-latest'
 
     - run: ci/download-teavm.sh
@@ -103,14 +97,8 @@ jobs:
     - uses: acifani/setup-tinygo@v2
       with:
         tinygo-version: 0.31.0
-    - name: All but Windows, cargo test --workspace
-      if : matrix.os != 'windows-latest'
+    - name: cargo test --workspace
       run: cargo test --workspace
-    - name: Windows, set EMSDK and run cargo test
-      if : matrix.os == 'windows-latest'
-      run: |
-        source ./emsdk-main/emsdk_env.sh
-        cargo test --workspace
 
   check:
     name: Check

--- a/crates/csharp/README.txt
+++ b/crates/csharp/README.txt
@@ -1,15 +1,16 @@
-// generate the c# and the component meta module
+## generate the c# and the component module
 
-cargo run c-sharp  --string-encoding utf8 --out-dir testing-csharp tests/codegen/floats.wit
+The following will generate the c# code given a wit file:
 
-// to run the runtime tests with Native AOT, you need some additional set up
+```bash
+cargo run c-sharp --string-encoding utf8 --out-dir testing-csharp tests/codegen/floats.wit
+```
 
-// install emscripten
-curl.exe -OL https://github.com/emscripten-core/emsdk/archive/refs/heads/main.zip
-unzip main.zip
-cd .\emsdk-main\main\emsdk-main
-.\emsdk_env.ps1 activate 3.1.23 --permanant
+## Setup
+To run the runtime tests with Native AOT, you need some additional set up
 
+```bash
 // install wasi-sdk and set env
-curl.exe -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw.tar.gz | tar xzvf -
+curl.exe -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0.m-mingw64.tar.gz | tar xzvf -
 $env:WASI_SDK_PATH="c:\users\jstur\wasi-sdk-22.0+m\"
+```

--- a/crates/csharp/src/csproj.rs
+++ b/crates/csharp/src/csproj.rs
@@ -104,8 +104,10 @@ impl CSProjectLLVMBuilder {
                 </ItemGroup>
 
                 <Target Name="CheckWasmSdks">
-                    <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing upstream/emscripten/emcc.bat"
-                        Condition="'$(EMSDK)' == ''" />
+                    <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
+                        Condition="'$(WASI_SDK_PATH)' == ''" />
+                    <Warning Text="The WASI SDK version is too low. Please use WASI SDK 22 or newer with a 64 bit Clang."
+                        Condition="!Exists('$(WASI_SDK_PATH)/VERSION')" />
                 </Target>
                 "#,
             );
@@ -115,7 +117,7 @@ impl CSProjectLLVMBuilder {
                 Inputs=\"$(MSBuildProjectDirectory)/{camel}_cabi_realloc.c\"
                 Outputs=\"$(MSBuildProjectDirectory)/{camel}_cabi_realloc.o\"
                 >
-                <Exec Command=\"emcc.bat &quot;$(MSBuildProjectDirectory)/{camel}_cabi_realloc.c&quot; -c -o &quot;$(MSBuildProjectDirectory)/{camel}_cabi_realloc.o&quot;\"/>
+                <Exec Command=\"&quot;$(WASI_SDK_PATH)/bin/clang&quot; --target=wasm32-wasi &quot;$(MSBuildProjectDirectory)/{camel}_cabi_realloc.c&quot; -c -o &quot;$(MSBuildProjectDirectory)/{camel}_cabi_realloc.o&quot;\"/>
               </Target>
             "
             ));


### PR DESCRIPTION
Now that https://github.com/dotnet/runtimelab/pull/2592 has merged and released we no longer need emscripten which reduces requirements for installing.

Also update to use correct wasi-sdk url for windows: https://github.com/bytecodealliance/wit-bindgen/pull/967#issuecomment-2153269262

Used @dicej patch for the `csproj` update: https://github.com/bytecodealliance/wit-bindgen/pull/967#issuecomment-2153449662