### PR TITLE
[Rust] flip the generation default for non-local interfaces

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -176,7 +176,7 @@ impl WorldGenerator for C {
         name: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         let wasm_import_module = resolve.name_world_key(name);
         let mut gen = self.interface(resolve, true, Some(&wasm_import_module));
         gen.interface = Some((id, name));
@@ -192,6 +192,8 @@ impl WorldGenerator for C {
         }
 
         gen.gen.src.append(&gen.src);
+
+        Ok(())
     }
 
     fn import_funcs(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -37,7 +37,9 @@ pub trait WorldGenerator {
         for (name, import) in world.imports.iter() {
             match import {
                 WorldItem::Function(f) => funcs.push((unwrap_name(name), f)),
-                WorldItem::Interface { id, .. } => self.import_interface(resolve, name, *id, files),
+                WorldItem::Interface { id, .. } => {
+                    self.import_interface(resolve, name, *id, files)?
+                }
                 WorldItem::Type(id) => types.push((unwrap_name(name), *id)),
             }
         }
@@ -91,7 +93,7 @@ pub trait WorldGenerator {
         name: &WorldKey,
         iface: InterfaceId,
         files: &mut Files,
-    );
+    ) -> Result<()>;
 
     /// Called before any exported interfaces are generated.
     fn pre_export_interface(&mut self, resolve: &Resolve, files: &mut Files) -> Result<()> {

--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -196,7 +196,7 @@ impl WorldGenerator for CSharp {
         key: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         let name = interface_name(self, resolve, key, Direction::Import);
         self.interface_names.insert(id, name.clone());
         let mut gen = self.interface(resolve, &name, Direction::Import);
@@ -232,6 +232,8 @@ impl WorldGenerator for CSharp {
         gen.define_interface_types(id);
 
         gen.add_interface_fragment(false);
+
+        Ok(())
     }
 
     fn import_funcs(

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -169,7 +169,7 @@ impl WorldGenerator for TinyGo {
         name: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         let name_raw = &resolve.name_world_key(name);
         self.src
             .push_str(&format!("// Import functions from {name_raw}\n"));
@@ -187,6 +187,8 @@ impl WorldGenerator for TinyGo {
         let preamble = mem::take(&mut gen.preamble);
         self.src.push_str(&src);
         self.preamble.append_src(&preamble);
+
+        Ok(())
     }
 
     fn import_funcs(

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -99,6 +99,9 @@ impl Parse for Config {
                             .collect()
                     }
                     Opt::With(with) => opts.with.extend(with),
+                    Opt::GenerateAll => {
+                        opts.with.generate_by_default = true;
+                    }
                     Opt::TypeSectionSuffix(suffix) => {
                         opts.type_section_suffix = Some(suffix.value());
                     }
@@ -237,6 +240,7 @@ mod kw {
     syn::custom_keyword!(export_prefix);
     syn::custom_keyword!(additional_derives);
     syn::custom_keyword!(with);
+    syn::custom_keyword!(generate_all);
     syn::custom_keyword!(type_section_suffix);
     syn::custom_keyword!(disable_run_ctors_once_workaround);
     syn::custom_keyword!(default_bindings_module);
@@ -288,6 +292,7 @@ enum Opt {
     // Parse as paths so we can take the concrete types/macro names rather than raw strings
     AdditionalDerives(Vec<syn::Path>),
     With(HashMap<String, WithOption>),
+    GenerateAll,
     TypeSectionSuffix(syn::LitStr),
     DisableRunCtorsOnceWorkaround(syn::LitBool),
     DefaultBindingsModule(syn::LitStr),
@@ -393,6 +398,9 @@ impl Parse for Opt {
             let fields: Punctuated<_, Token![,]> =
                 contents.parse_terminated(with_field_parse, Token![,])?;
             Ok(Opt::With(HashMap::from_iter(fields.into_iter())))
+        } else if l.peek(kw::generate_all) {
+            input.parse::<kw::generate_all>()?;
+            Ok(Opt::GenerateAll)
         } else if l.peek(kw::type_section_suffix) {
             input.parse::<kw::type_section_suffix>()?;
             input.parse::<Token![:]>()?;

--- a/crates/guest-rust/src/examples/_1_interface_imports.rs
+++ b/crates/guest-rust/src/examples/_1_interface_imports.rs
@@ -24,4 +24,9 @@ crate::generate!({
     "#,
 
     path: "wasi-cli@0.2.0.wasm",
+
+    // specify that this interface dependency should be generated as well.
+    with: {
+        "wasi:cli/environment@0.2.0": generate,
+    }
 });

--- a/crates/guest-rust/src/examples/_3_world_exports.rs
+++ b/crates/guest-rust/src/examples/_3_world_exports.rs
@@ -37,4 +37,11 @@ crate::generate!({
 
     // provided to specify the path to `wasi:*` dependencies referenced above.
     path: "wasi-cli@0.2.0.wasm",
+
+    // specify that these interface dependencies should be generated as well.
+    with: {
+        "wasi:random/insecure@0.2.0": generate,
+        "wasi:clocks/monotonic-clock@0.2.0": generate,
+        "wasi:io/poll@0.2.0": generate
+    }
 });

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -668,25 +668,30 @@
 ///     // By default this set is empty.
 ///     additional_derives: [PartialEq, Eq, Hash, Clone],
 ///
-///     // When generating bindings for imports it might be the case that
-///     // bindings were already generated in a different crate. For example
-///     // if your world refers to WASI types then the `wasi` crate already
-///     // has generated bindings for all WASI types and structures. In this
+///     // When generating bindings for interfaces that are not defined in the
+///     // same package as `world`, this option can be used to either generate
+///     // those bindings or point to already generated bindings.
+///     // For example, if your world refers to WASI types then the `wasi` crate
+///     // already has generated bindings for all WASI types and structures. In this
 ///     // situation the key `with` here can be used to use those types
 ///     // elsewhere rather than regenerating types.
 ///     //
-///     // The `with` key here only works for interfaces referred to by imported
-///     // functions. Additionally it only supports replacing types at the
-///     // interface level at this time.
+///     // If, however, your world refers to interfaces for which you don't have
+///     // already generated bindings then you can use the special `generate` value
+///     // to have those bindings generated.
 ///     //
-///     // When an interface is specified here no bindings will be generated at
-///     // all. It's assumed bindings are fully generated upstream. This is an
+///     // The `with` key only supports replacing types at the interface level
+///     // at this time.
+///     //
+///     // When an interface is specified no bindings will be generated at
+///     // all. It's assumed bindings are fully generated somewhere else. This is an
 ///     // indicator that any further references to types defined in these
 ///     // interfaces should use the upstream paths specified here instead.
 ///     //
 ///     // Any unused keys in this map are considered an error.
 ///     with: {
 ///         "wasi:io/poll": wasi::io::poll,
+///         "some:package/my-interface": generate,
 ///     },
 ///
 ///     // An optional list of function names to skip generating bindings for.

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -117,7 +117,7 @@ impl WorldGenerator for Markdown {
         name: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         let name = resolve.name_world_key(name);
         uwriteln!(
             self.src,
@@ -131,6 +131,8 @@ impl WorldGenerator for Markdown {
         gen.push_str("\n");
         gen.types(id);
         gen.funcs(id);
+
+        Ok(())
     }
 
     fn import_funcs(

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -46,7 +46,16 @@ struct RustWasm {
 
     rt_module: IndexSet<RuntimeItem>,
     export_macros: Vec<(String, String)>,
-    with: HashMap<String, String>,
+    /// Interface names to how they should be generated
+    with: HashMap<String, InterfaceGeneration>,
+}
+
+/// How an interface should be generated.
+enum InterfaceGeneration {
+    // Remapped to some other type
+    Remap(String),
+    // Generate as normal
+    Generate,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
@@ -158,7 +167,7 @@ pub struct Opts {
     /// multiple times or one option can be comma separated, for example
     /// `k1=v1,k2=v2`.
     #[cfg_attr(feature = "clap", arg(long, value_parser = parse_with, value_delimiter = ','))]
-    pub with: Vec<(String, String)>,
+    pub with: Vec<(String, WithOption)>,
 
     /// Add the specified suffix to the name of the custome section containing
     /// the component type.
@@ -282,30 +291,39 @@ impl RustWasm {
         id: InterfaceId,
         name: &WorldKey,
         is_export: bool,
-    ) -> bool {
+    ) -> Result<bool> {
         let with_name = resolve.name_world_key(name);
-        let entry = if let Some(remapped_path) = self.with.get(&with_name) {
-            let name = format!("__with_name{}", self.with_name_counter);
-            self.used_with_opts.insert(with_name);
-            self.with_name_counter += 1;
-            uwriteln!(self.src, "use {remapped_path} as {name};");
-            InterfaceName {
-                remapped: true,
-                path: name,
+        let Some(remapping) = self.with.get(&with_name) else {
+            bail!("no remapping found for {with_name:?} - use the `generate!` macro's `with` option to force the interface to be generated or specify where it is already defined:
+```
+with: {{\n\t{with_name:?}: generate\n}}
+```")
+        };
+        let entry = match remapping {
+            InterfaceGeneration::Remap(remapped_path) => {
+                let name = format!("__with_name{}", self.with_name_counter);
+                self.used_with_opts.insert(with_name);
+                self.with_name_counter += 1;
+                uwriteln!(self.src, "use {remapped_path} as {name};");
+                InterfaceName {
+                    remapped: true,
+                    path: name,
+                }
             }
-        } else {
-            let path = compute_module_path(name, resolve, is_export).join("::");
+            InterfaceGeneration::Generate => {
+                let path = compute_module_path(name, resolve, is_export).join("::");
 
-            InterfaceName {
-                remapped: false,
-                path,
+                InterfaceName {
+                    remapped: false,
+                    path,
+                }
             }
         };
 
         let remapped = entry.remapped;
         self.interface_names.insert(id, entry);
 
-        remapped
+        Ok(remapped)
     }
 
     fn finish_runtime_module(&mut self) {
@@ -808,7 +826,7 @@ impl WorldGenerator for RustWasm {
             );
         }
         for (k, v) in self.opts.with.iter() {
-            uwriteln!(self.src, "//   * with {k:?} = {v:?}");
+            uwriteln!(self.src, "//   * with {k:?} = {v}");
         }
         if let Some(default) = &self.opts.default_bindings_module {
             uwriteln!(self.src, "//   * default-bindings-module: {default:?}");
@@ -825,8 +843,19 @@ impl WorldGenerator for RustWasm {
         self.types.analyze(resolve);
         self.world = Some(world);
 
+        let world = &resolve.worlds[world];
+        // Specify that all imports local to the world's package should be generated
+        for (key, item) in world.imports.iter().chain(world.exports.iter()) {
+            if let WorldItem::Interface { id, .. } = item {
+                if resolve.interfaces[*id].package == world.package {
+                    let name = resolve.name_world_key(key);
+                    self.with.insert(name, InterfaceGeneration::Generate);
+                }
+            }
+        }
+
         for (k, v) in self.opts.with.iter() {
-            self.with.insert(k.clone(), v.clone());
+            self.with.insert(k.clone(), v.clone().into());
         }
     }
 
@@ -836,7 +865,7 @@ impl WorldGenerator for RustWasm {
         name: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         self.interface_last_seen_as_import.insert(id, true);
         let wasm_import_module = resolve.name_world_key(name);
         let mut gen = self.interface(
@@ -846,14 +875,16 @@ impl WorldGenerator for RustWasm {
             true,
         );
         let (snake, module_path) = gen.start_append_submodule(name);
-        if gen.gen.name_interface(resolve, id, name, false) {
-            return;
+        if gen.gen.name_interface(resolve, id, name, false)? {
+            return Ok(());
         }
         gen.types(id);
 
         gen.generate_imports(resolve.interfaces[id].functions.values());
 
         gen.finish_append_submodule(&snake, module_path);
+
+        Ok(())
     }
 
     fn import_funcs(
@@ -883,7 +914,7 @@ impl WorldGenerator for RustWasm {
         self.interface_last_seen_as_import.insert(id, false);
         let mut gen = self.interface(Identifier::Interface(id, name), None, resolve, false);
         let (snake, module_path) = gen.start_append_submodule(name);
-        if gen.gen.name_interface(resolve, id, name, true) {
+        if gen.gen.name_interface(resolve, id, name, true)? {
             return Ok(());
         }
         gen.types(id);
@@ -1049,9 +1080,15 @@ impl WorldGenerator for RustWasm {
         let module_name = name.to_snake_case();
         files.push(&format!("{module_name}.rs"), src.as_bytes());
 
-        let remapping_keys = self.with.keys().cloned().collect::<HashSet<String>>();
+        let remapped_keys = self
+            .with
+            .iter()
+            .filter(|(_, r)| matches!(r, InterfaceGeneration::Remap(_)))
+            .map(|(k, _)| k)
+            .cloned()
+            .collect::<HashSet<String>>();
 
-        let mut unused_keys = remapping_keys
+        let mut unused_keys = remapped_keys
             .difference(&self.used_with_opts)
             .collect::<Vec<&String>>();
 
@@ -1156,6 +1193,31 @@ impl fmt::Display for Ownership {
                 duplicate_if_necessary: true,
             } => "borrowing-duplicate-if-necessary",
         })
+    }
+}
+
+/// Options for with "with" remappings.
+#[derive(Debug, Clone)]
+pub enum WithOption {
+    Path(String),
+    Generate,
+}
+
+impl std::fmt::Display for WithOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WithOption::Path(p) => f.write_fmt(format_args!("\"{p}\"")),
+            WithOption::Generate => f.write_str("generate"),
+        }
+    }
+}
+
+impl From<WithOption> for InterfaceGeneration {
+    fn from(opt: WithOption) -> Self {
+        match opt {
+            WithOption::Path(p) => InterfaceGeneration::Remap(p),
+            WithOption::Generate => InterfaceGeneration::Generate,
+        }
     }
 }
 

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -5,6 +5,10 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
+        (wasi_clocks $name:tt $test:tt) => {};
+        (wasi_filesystem $name:tt $test:tt) => {};
+        (issue569 $name:tt $test:tt) => {};
+        (multiversion $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -5,15 +5,12 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
-        (wasi_clocks $name:tt $test:tt) => {};
-        (wasi_filesystem $name:tt $test:tt) => {};
-        (issue569 $name:tt $test:tt) => {};
-        (multiversion $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({
                     path: $test,
-                    stubs
+                    stubs,
+                    generate_all
                 });
 
                 // This empty module named 'core' is here to catch module path
@@ -33,6 +30,7 @@ mod codegen_tests {
                         },
                         stubs,
                         export_prefix: "[borrowed]",
+                        generate_all
                     });
 
                     #[test]
@@ -47,6 +45,7 @@ mod codegen_tests {
                         },
                         stubs,
                         export_prefix: "[duplicate]",
+                        generate_all
                     });
 
                     #[test]

--- a/crates/rust/tests/codegen_no_std.rs
+++ b/crates/rust/tests/codegen_no_std.rs
@@ -16,16 +16,13 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
-        (wasi_clocks $name:tt $test:tt) => {};
-        (wasi_filesystem $name:tt $test:tt) => {};
-        (issue569 $name:tt $test:tt) => {};
-        (multiversion $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({
                     path: $test,
                     std_feature,
-                    stubs
+                    stubs,
+                    generate_all
                 });
 
                 #[test]

--- a/crates/rust/tests/codegen_no_std.rs
+++ b/crates/rust/tests/codegen_no_std.rs
@@ -16,6 +16,10 @@ mod codegen_tests {
     macro_rules! codegen_test {
         (wasi_cli $name:tt $test:tt) => {};
         (wasi_http $name:tt $test:tt) => {};
+        (wasi_clocks $name:tt $test:tt) => {};
+        (wasi_filesystem $name:tt $test:tt) => {};
+        (issue569 $name:tt $test:tt) => {};
+        (multiversion $name:tt $test:tt) => {};
         ($id:ident $name:tt $test:tt) => {
             mod $id {
                 wit_bindgen::generate!({

--- a/crates/teavm-java/src/lib.rs
+++ b/crates/teavm-java/src/lib.rs
@@ -92,7 +92,7 @@ impl WorldGenerator for TeaVmJava {
         key: &WorldKey,
         id: InterfaceId,
         _files: &mut Files,
-    ) {
+    ) -> Result<()> {
         let name = interface_name(resolve, key, Direction::Import);
         self.interface_names.insert(id, name.clone());
         let mut gen = self.interface(resolve, &name);
@@ -103,6 +103,8 @@ impl WorldGenerator for TeaVmJava {
         }
 
         gen.add_interface_fragment();
+
+        Ok(())
     }
 
     fn import_funcs(

--- a/tests/runtime/other-dependencies/wasm.rs
+++ b/tests/runtime/other-dependencies/wasm.rs
@@ -7,4 +7,7 @@ wit_bindgen::generate!({
     }
     "#,
     path: "../../tests/runtime/other-dependencies/other",
+    with: {
+        "other:test/test": generate,
+    }
 });

--- a/tests/runtime/resource_alias/wasm.rs
+++ b/tests/runtime/resource_alias/wasm.rs
@@ -6,6 +6,7 @@ pub struct Test {}
 
 export!(Test);
 
+#[allow(dead_code)]
 pub struct E1X(u32);
 
 impl exports::test::resource_alias::e1::Guest for Test {

--- a/tests/runtime/versions/wasm.rs
+++ b/tests/runtime/versions/wasm.rs
@@ -1,5 +1,9 @@
 wit_bindgen::generate!({
     path: "../../tests/runtime/versions",
+    with: {
+        "test:dep/test@0.1.0": generate,
+        "test:dep/test@0.2.0": generate,
+    }
 });
 
 use exports::test::dep0_1_0::test::Guest as v1;


### PR DESCRIPTION
Fixes #904 

Instead of non-local interfaces being generated automatically (and only not being generated when a `with` option is specified) - this PR changes the default to require a `with` option for all non-local interfaces.

If a foreign type is not present in the with `with` mapping an error is produced saying that the user must specify an entry in with map for all foreign types. The user can add an entry to with like they do today, or they can specify `generate` to have the type generated for them.

The error message when the `with` option is not specified is:

```
error: no remapping found for "my:package/my-interface" - use the `with` option to `generate!` to force the interface to be generated or specify where it is already defined:
       ```
       with: {
           "my:package/my-interface": generate
       } 
       ```
```