### PR TITLE
C#: use nullable types for non-nested options

### DIFF
--- a/tests/runtime/options.rs
+++ b/tests/runtime/options.rs
@@ -28,6 +28,10 @@ impl test::options::test::Host for MyImports {
     fn option_roundtrip(&mut self, a: Option<String>) -> Result<Option<String>> {
         Ok(a)
     }
+
+    fn double_option_roundtrip(&mut self, a: Option<Option<u32>>) -> Result<Option<Option<u32>>> {
+        Ok(a)
+    }
 }
 
 #[test]
@@ -53,6 +57,18 @@ fn run_test(exports: Options, store: &mut Store<crate::Wasi<MyImports>>) -> Resu
     assert_eq!(
         exports.call_option_roundtrip(&mut *store, Some("foo"))?,
         Some("foo".to_string())
+    );
+    assert_eq!(
+        exports.call_double_option_roundtrip(&mut *store, Some(Some(42)))?,
+        Some(Some(42))
+    );
+    assert_eq!(
+        exports.call_double_option_roundtrip(&mut *store, Some(None))?,
+        Some(None)
+    );
+    assert_eq!(
+        exports.call_double_option_roundtrip(&mut *store, None)?,
+        None
     );
     Ok(())
 }

--- a/tests/runtime/options/wasm.cs
+++ b/tests/runtime/options/wasm.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using OptionsWorld.wit.imports.test.options;
+
+namespace OptionsWorld.wit.exports.test.options
+{
+    public class TestImpl : ITest
+    {
+        public static void OptionNoneParam(string? a)
+        {
+            Debug.Assert(a == null);
+        }
+        
+        public static string? OptionNoneResult()
+        {
+            return null;
+        }
+        
+        public static void OptionSomeParam(string? a)
+        {
+            Debug.Assert(a == "foo");
+        }
+        
+        public static string? OptionSomeResult()
+        {
+            return "foo";
+        }
+
+        public static string? OptionRoundtrip(string? a)
+        {
+            return a;
+        }        
+
+        public static Option<uint?> DoubleOptionRoundtrip(Option<uint?> a)
+        {
+            return a;
+        }        
+    }
+}
+
+namespace OptionsWorld
+{
+    public class OptionsWorldImpl : IOptionsWorld
+    {
+        public static void TestImports()
+        {
+            TestInterop.OptionNoneParam(null);
+            TestInterop.OptionSomeParam("foo");
+            Debug.Assert(TestInterop.OptionNoneResult() == null);
+            Debug.Assert(TestInterop.OptionSomeResult() == "foo");
+            Debug.Assert(TestInterop.OptionRoundtrip("foo") == "foo");
+            Debug.Assert(TestInterop.DoubleOptionRoundtrip(new Option<uint?>(42)).Value == 42);
+            Debug.Assert(TestInterop.DoubleOptionRoundtrip(new Option<uint?>(null)).Value == null);
+            Debug.Assert(!TestInterop.DoubleOptionRoundtrip(Option<uint?>.None).HasValue);
+        }
+    }
+}

--- a/tests/runtime/options/wasm.rs
+++ b/tests/runtime/options/wasm.rs
@@ -15,6 +15,9 @@ impl Guest for Component {
         assert!(option_none_result().is_none());
         assert_eq!(option_some_result(), Some("foo".to_string()));
         assert_eq!(option_roundtrip(Some("foo")), Some("foo".to_string()));
+        assert_eq!(double_option_roundtrip(Some(Some(42))), Some(Some(42)));
+        assert_eq!(double_option_roundtrip(Some(None)), Some(None));
+        assert_eq!(double_option_roundtrip(None), None);
     }
 }
 
@@ -36,6 +39,10 @@ impl exports::test::options::test::Guest for Component {
     }
 
     fn option_roundtrip(a: Option<String>) -> Option<String> {
+        a
+    }
+
+    fn double_option_roundtrip(a: Option<Option<u32>>) -> Option<Option<u32>> {
         a
     }
 }

--- a/tests/runtime/options/world.wit
+++ b/tests/runtime/options/world.wit
@@ -7,6 +7,8 @@ interface test {
   option-some-result: func() -> option<string>;
 
   option-roundtrip: func(a: option<string>) -> option<string>;
+
+  double-option-roundtrip: func(a: option<option<u32>>) -> option<option<u32>>;
 }
 
 world options {

--- a/tests/runtime/resource_aggregates/wasm.cs
+++ b/tests/runtime/resource_aggregates/wasm.cs
@@ -22,8 +22,8 @@ namespace ResourceAggregatesWorld.wit.exports.test.resourceAggregates
 	    ITest.V2 v2,
 	    List<ITest.Thing> l1,
 	    List<ITest.Thing> l2,
-	    Option<ITest.Thing> o1,
-	    Option<ITest.Thing> o2,
+	    ITest.Thing? o1,
+	    ITest.Thing? o2,
 	    Result<ITest.Thing, None> result1,
 	    Result<ITest.Thing, None> result2
 	)
@@ -45,12 +45,12 @@ namespace ResourceAggregatesWorld.wit.exports.test.resourceAggregates
 	    {
 		il2.Add(((Thing) thing).val);
 	    }
-	    var io1 = o1.HasValue
-		? new Option<Import.Thing>(((Thing) o1.Value).val)
-		: Option<Import.Thing>.None;
-	    var io2 = o2.HasValue
-		? new Option<Import.Thing>(((Thing) o2.Value).val)
-		: Option<Import.Thing>.None;
+	    var io1 = o1 != null
+		? ((Thing) o1).val
+		: null;
+	    var io2 = o2 != null
+		? ((Thing) o2).val
+		: null;
 	    var iresult1 = result1.IsOk
 		? Result<Import.Thing, None>.ok(((Thing) result1.AsOk).val)
 		: Result<Import.Thing, None>.err(new None());


### PR DESCRIPTION
We now generate bindings which use nullable types (e.g. `uint?`) to represent non-nested `option` types.  Nested `option`s, such as `option<option<T>>` still use the `Option` class except for the innermost `option` in order to avoid ambiguity.

Fixes #964