### PR TITLE
Upgrade to wasm-tools 211 and wasmtime 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,15 +143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "codegen-macro"
 version = "0.0.0"
 dependencies = [
@@ -363,18 +360,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b27922a6879b5b5361d0a084cb0b1941bf109a98540addcb932da13b68bed4"
+checksum = "29daf137addc15da6bab6eae2c4a11e274b1d270bf2759508e62f6145e863ef6"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304c455b28bf56372729acb356afbb55d622f2b0f2f7837aa5e57c138acaac4d"
+checksum = "de619867d5de4c644b7fd9904d6e3295269c93d8a71013df796ab338681222d4"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -387,39 +384,40 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "regalloc2",
+ "rustc-hash",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1653c56b99591d07f67c5ca7f9f25888948af3f4b97186bff838d687d666f613"
+checksum = "29f5cf277490037d8dae9513d35e0ee8134670ae4a964a5ed5b198d4249d7c10"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b6a9cf6b6eb820ee3f973a0db313c05dc12d370f37b4fe9630286e1672573f"
+checksum = "8c3e22ecad1123343a3c09ac6ecc532bb5c184b6fcb7888df0ea953727f79924"
 
 [[package]]
 name = "cranelift-control"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d06e6bf30075fb6bed9e034ec046475093392eea1aff90eb5c44c4a033d19a"
+checksum = "53ca3ec6d30bce84ccf59c81fead4d16381a3ef0ef75e8403bc1e7385980da09"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29be04f931b73cdb9694874a295027471817f26f26d2f0ebe5454153176b6e3a"
+checksum = "7eabb8d36b0ca8906bec93c78ea516741cac2d7e6b266fa7b0ffddcc09004990"
 dependencies = [
  "serde",
  "serde_derive",
@@ -427,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07fd7393041d7faa2f37426f5dc7fc04003b70988810e8c063beefeff1cd8f9"
+checksum = "44b42630229e49a8cfcae90bdc43c8c4c08f7a7aa4618b67f79265cd2f996dd2"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -439,15 +437,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f341d7938caa6dff8149dac05bb2b53fc680323826b83b4cf175ab9f5139a3c9"
+checksum = "918d1e36361805dfe0b6cdfd5a5ffdb5d03fa796170c5717d2727cbe623b93a0"
 
 [[package]]
 name = "cranelift-native"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82af6066e6448d26eeabb7aa26a43f7ff79f8217b06bade4ee6ef230aecc8880"
+checksum = "75aea85a0d7e1800b14ce9d3f53adf8ad4d1ee8a9e23b0269bdc50285e93b9b3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -456,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.107.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2766fab7284a914a7f17f90ebe865c86453225fb8637ac31f123f5028fee69cd"
+checksum = "dac491fd3473944781f0cf9528c90cc899d18ad438da21961a839a3a44d57dfb"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -466,7 +464,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
  "wasmtime-types",
 ]
 
@@ -579,6 +577,12 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "encoding_rs"
@@ -932,6 +936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1089,17 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "serde",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1334,6 +1355,9 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1683,9 +1707,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.202.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
+checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
 dependencies = [
  "leb128",
 ]
@@ -1718,11 +1742,13 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.202.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
 dependencies = [
+ "ahash",
  "bitflags 2.5.0",
+ "hashbrown 0.14.3",
  "indexmap",
  "semver",
 ]
@@ -1743,45 +1769,55 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.202.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1cc9508685eef9502e787f4d4123745f5651a1e29aec047645d3cac1e2da7a"
+checksum = "9c2d8a7b4dabb460208e6b4334d9db5766e84505038b2529e69c3d07ac619115"
 dependencies = [
  "anyhow",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5990663c28d81015ddbb02a068ac1bf396a4ea296eba7125b2dfc7c00cb52e"
+checksum = "f92a1370c66a0022e6d92dcc277e2c84f5dece19569670b8ce7db8162560d8b6"
 dependencies = [
  "addr2line",
  "anyhow",
  "async-trait",
- "bincode",
  "bumpalo",
+ "cc",
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
  "gimli",
+ "hashbrown 0.14.3",
  "indexmap",
  "ittapi",
  "libc",
+ "libm",
  "log",
+ "mach2",
+ "memfd",
+ "memoffset",
  "object 0.33.0",
  "once_cell",
  "paste",
+ "postcard",
+ "psm",
  "rayon",
  "rustix",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
+ "smallvec",
+ "sptr",
  "target-lexicon",
- "wasm-encoder 0.202.0",
- "wasmparser 0.202.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
+ "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1790,8 +1826,8 @@ dependencies = [
  "wasmtime-fiber",
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
- "wasmtime-runtime",
  "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
  "wasmtime-winch",
  "wat",
  "windows-sys 0.52.0",
@@ -1799,24 +1835,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625ee94c72004f3ea0228989c9506596e469517d7d0ed66f7300d1067bdf1ca9"
+checksum = "6dee8679c974a7f258c03d60d3c747c426ed219945b6d08cbc77fd2eab15b2d1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98534bf28de232299e83eab33984a7a6c40c69534d6bd0ea216150b63d41a83a"
+checksum = "b00103ffaf7ee980f4e750fe272b6ada79d9901659892e457c7ca316b16df9ec"
 dependencies = [
  "anyhow",
  "base64",
- "bincode",
  "directories-next",
  "log",
+ "postcard",
  "rustix",
  "serde",
  "serde_derive",
@@ -1828,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f84414a25ee3a624c8b77550f3fe7b5d8145bd3405ca58886ee6900abb6dc2"
+checksum = "32cae30035f1cf97dcc6657c979cf39f99ce6be93583675eddf4aeaa5548509c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1838,20 +1874,20 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.202.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78580bdb4e04c7da3bf98088559ca1d29382668536e4d5c7f2f966d79c390307"
+checksum = "f7ae611f08cea620c67330925be28a96115bf01f8f393a6cbdf4856a86087134"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60df0ee08c6a536c765f69e9e8205273435b66d02dd401e938769a2622a6c1a"
+checksum = "b2909406a6007e28be964067167890bca4574bd48a9ff18f1fa9f4856d89ea40"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1866,32 +1902,31 @@ dependencies = [
  "object 0.33.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ffc1613db69ee47c96738861534f9a405e422a5aa00224fbf5d410b03fb445"
+checksum = "40e227f9ed2f5421473723d6c0352b5986e6e6044fde5410a274a394d726108f"
 dependencies = [
  "anyhow",
- "bincode",
  "cpp_demangle",
  "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
  "object 0.33.0",
+ "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "target-lexicon",
- "thiserror",
- "wasm-encoder 0.202.0",
- "wasmparser 0.202.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1899,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f043514a23792761c5765f8ba61a4aa7d67f260c0c37494caabceb41d8ae81de"
+checksum = "42edb392586d07038c1638e854382db916b6ca7845a2e6a7f8dc49e08907acdd"
 dependencies = [
  "anyhow",
  "cc",
@@ -1914,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0ca2ad8f5d2b37f507ef1c935687a690e84e9f325f5a2af9639440b43c1f0e"
+checksum = "95b26ef7914af0c0e3ca811bdc32f5f66fbba0fd21e1f8563350e8a7951e3598"
 dependencies = [
  "object 0.33.0",
  "once_cell",
@@ -1926,69 +1961,40 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9f93a3289057b26dc75eb84d6e60d7694f7d169c7c09597495de6e016a13ff"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime-runtime"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6332a2b0af4224c3ea57c857ad39acd2780ccc2b0c99ba1baa01864d90d7c94"
+checksum = "afe088f9b56bb353adaf837bf7e10f1c2e1676719dd5be4cac8e37f2ba1ee5bc"
 dependencies = [
  "anyhow",
- "cc",
  "cfg-if",
- "encoding_rs",
- "indexmap",
  "libc",
- "log",
- "mach2",
- "memfd",
- "memoffset",
- "paste",
- "psm",
- "rustix",
- "sptr",
- "wasm-encoder 0.202.0",
- "wasmtime-asm-macros",
- "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3655075824a374c536a2b2cc9283bb765fcdf3d58b58587862c48571ad81ef"
+checksum = "4ff75cafffe47b04b036385ce3710f209153525b0ed19d57b0cf44a22d446460"
 
 [[package]]
 name = "wasmtime-types"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf64a242b0b9257604181ca28b28a5fcaa4c9ea1d396f76d1d2d1c5b40eef"
+checksum = "2f2fa462bfea3220711c84e2b549f147e4df89eeb49b8a2a3d89148f6cc4a8b1"
 dependencies = [
  "cranelift-entity",
  "serde",
  "serde_derive",
- "thiserror",
- "wasmparser 0.202.0",
+ "smallvec",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8561d9e2920db2a175213d557d71c2ac7695831ab472bbfafb9060cd1034684f"
+checksum = "d4cedc5bfef3db2a85522ee38564b47ef3b7fc7c92e94cacbce99808e63cdd47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1997,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e1f53a9d4688a138282580fa7a46cbf1a41524f0e50c7e402e1407246f0155"
+checksum = "bdbbe94245904d4c96c7c5f7b55bad896cc27908644efd9442063c0748b631fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2028,16 +2034,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06b573d14ac846a0fb8c541d8fca6a64acf9a1d176176982472274ab1d2fa5d"
+checksum = "97b27054fed6be4f3800aba5766f7ef435d4220ce290788f021a08d4fa573108"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
  "object 0.33.0",
  "target-lexicon",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -2045,14 +2051,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595bc7bb3b0ff4aa00fab718c323ea552c3034d77abc821a35112552f2ea487a"
+checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap",
- "wit-parser 0.202.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
@@ -2088,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6552dda951239e219c329e5a768393664e8d120c5e0818487ac2633f173b1f"
+checksum = "a89ea6f74ece6d1cfbd089783006b8eb69a0219ca83cad22068f0d9fa9df3f91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2103,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da64cb31e0bfe8b1d2d13956ef9fd5c77545756a1a6ef0e6cfd44e8f1f207aed"
+checksum = "36beda94813296ecaf0d91b7ada9da073fd41865ba339bdd3b7764e2e785b8e9"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -2118,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "20.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900b2416ef2ff2903ded6cf55d4a941fed601bf56a8c4874856d7a77c1891994"
+checksum = "0b47d2b4442ce93106dba5d1a9c59d5f85b5732878bb3d0598d3c93c0d01b16b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2152,9 +2158,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb23450977f9d4a23c02439cf6899340b2d68887b19465c5682740d9cc37d52e"
+checksum = "1dc69899ccb2da7daa4df31426dcfd284b104d1a85e1dae35806df0c46187f87"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2162,7 +2168,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -2496,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.202.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744237b488352f4f27bca05a10acb79474415951c450e52ebd0da784c1df2bcc"
+checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2509,7 +2515,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.202.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,10 +1414,10 @@ name = "test-helpers"
 version = "0.0.0"
 dependencies = [
  "codegen-macro",
- "wasm-encoder 0.209.0",
+ "wasm-encoder 0.211.0",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.209.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -1692,18 +1692,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.209.0"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821112ccd35a6e25790ba5f4ed72ac5321707cf18a379bf071b76f8d0336603d"
+checksum = "4edac552f5404c9083b446afddf3f1b9e2eb35950e8f5155fa3d7b460b4835be"
 dependencies = [
  "leb128",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.209.0"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6902f36840b21a4fb907f700125da1965a08478f8f1338d737f248edcf57c49b"
+checksum = "e64e56c3d0178b926f44e7b6cddeaeb0f6269b505c5c6ac36cb107a8fe68cf0a"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1711,8 +1712,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.209.0",
- "wasmparser 0.209.0",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
@@ -1728,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.209.0"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233c757e98c11d092b757fd3ada885a446fdc002432bf7bf12c93f81ba96c7c9"
+checksum = "6fdc36907b68eb391c201401b3e342e175610dae14566e61b6b317216d531355"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2065,24 +2066,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "209.0.0"
+version = "211.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796916a29f4a8454655b7af3aa2d0e40532d07b4d3b8abdb78e4cb6b84c00586"
+checksum = "01019afce6a03155ce7cda8f7eeb4b846a114d0978e16e1a32f7cd9932e282c3"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.209.0",
+ "wasm-encoder 0.211.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.209.0"
+version = "1.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecc135c1bdf98ef1c818b80996897ab23dff91391149e8c22d8278796b743e9"
+checksum = "779365ca4640d48cd714788626bb622b4f491d7cd3d3ecb1a48bad4082f420ac"
 dependencies = [
- "wast 209.0.0",
+ "wast 211.0.0",
 ]
 
 [[package]]
@@ -2342,11 +2343,11 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "test-helpers",
- "wasm-encoder 0.209.0",
+ "wasm-encoder 0.211.0",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.209.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -2357,8 +2358,8 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "test-artifacts",
- "wasm-encoder 0.209.0",
- "wasmparser 0.209.0",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-c",
@@ -2369,7 +2370,7 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-bindgen-teavm-java",
  "wit-component",
- "wit-parser 0.209.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -2378,7 +2379,7 @@ version = "0.26.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.209.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -2390,9 +2391,9 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "test-helpers",
- "wasm-encoder 0.209.0",
+ "wasm-encoder 0.211.0",
  "wasm-metadata",
- "wasmparser 0.209.0",
+ "wasmparser 0.211.0",
  "wit-bindgen-core",
  "wit-component",
 ]
@@ -2475,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.209.0"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b996f57f396e6bd6bbb7b7322d35e9bf146a508885c910a800820a75febd2a05"
+checksum = "527854bf3c712340abdb71f2e44aea9c8a98c13fdd32e67efff3c27ee6775fe6"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -2486,11 +2487,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.209.0",
+ "wasm-encoder 0.211.0",
  "wasm-metadata",
- "wasmparser 0.209.0",
+ "wasmparser 0.211.0",
  "wat",
- "wit-parser 0.209.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -2513,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.209.0"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9455f94dfa4817ec1cdd7f53bba662dcbaf10cd41152d03bd39c6cabe90491fa"
+checksum = "cafc0ef6c5b790a3df1ec53dee41c37ebe560bc465e509e8a5ed9fe620ef1865"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2526,7 +2527,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.209.0",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ indexmap = "2.0.0"
 prettyplease = "0.2.20"
 syn = { version = "2.0", features = ["printing"] }
 
-wasmparser = "0.209.0"
-wasm-encoder = "0.209.0"
-wasm-metadata = "0.209.0"
-wit-parser = "0.209.0"
-wit-component = "0.209.0"
+wasmparser = "0.211.0"
+wasm-encoder = "0.211.0"
+wasm-metadata = "0.211.0"
+wit-parser = "0.211.0"
+wit-component = "0.211.0"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.26.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.26.0' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ csharp-mono = ['csharp']
 
 [dev-dependencies]
 heck = { workspace = true }
-wasmtime = { version = "20.0.0", features = ['component-model'] }
-wasmtime-wasi =  { version = "20.0.0" }
+wasmtime = { version = "21.0.0", features = ['component-model'] }
+wasmtime-wasi =  { version = "21.0.0" }
 test-artifacts = { path = 'crates/test-rust-wasm/artifacts' }
 wit-parser = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/c/tests/codegen.rs
+++ b/crates/c/tests/codegen.rs
@@ -3,7 +3,7 @@ use heck::*;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use wit_parser::{Resolve, UnresolvedPackage};
+use wit_parser::{Resolve, UnresolvedPackageGroup};
 
 macro_rules! codegen_test {
     ($id:ident $name:tt $test:tt) => {
@@ -94,8 +94,8 @@ fn rename_option() -> Result<()> {
     opts.rename.push(("c".to_string(), "rename3".to_string()));
 
     let mut resolve = Resolve::default();
-    let pkg = resolve.push(UnresolvedPackage::parse(
-        "input.wit".as_ref(),
+    let pkgs = resolve.push_group(UnresolvedPackageGroup::parse(
+        "input.wit",
         r#"
             package foo:bar;
 
@@ -118,7 +118,7 @@ fn rename_option() -> Result<()> {
             }
         "#,
     )?)?;
-    let world = resolve.select_world(pkg, None)?;
+    let world = resolve.select_world(&pkgs, None)?;
     let mut files = Default::default();
     opts.build().generate(&resolve, world, &mut files)?;
     for (file, contents) in files.iter() {

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{braced, token, Token};
-use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackage, WorldId};
+use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackageGroup, WorldId};
 use wit_bindgen_rust::{Opts, Ownership, WithOption};
 
 #[proc_macro]
@@ -131,10 +131,10 @@ impl Parse for Config {
                 source = Some(Source::Path(input.parse::<syn::LitStr>()?.value()));
             }
         }
-        let (resolve, pkg, files) =
+        let (resolve, pkgs, files) =
             parse_source(&source, &features).map_err(|err| anyhow_to_syn(call_site, err))?;
         let world = resolve
-            .select_world(pkg, world.as_deref())
+            .select_world(&pkgs, world.as_deref())
             .map_err(|e| anyhow_to_syn(call_site, e))?;
         Ok(Config {
             opts,
@@ -149,7 +149,7 @@ impl Parse for Config {
 fn parse_source(
     source: &Option<Source>,
     features: &[String],
-) -> anyhow::Result<(Resolve, PackageId, Vec<PathBuf>)> {
+) -> anyhow::Result<(Resolve, Vec<PackageId>, Vec<PathBuf>)> {
     let mut resolve = Resolve::default();
     resolve.features.extend(features.iter().cloned());
     let mut files = Vec::new();
@@ -164,7 +164,7 @@ fn parse_source(
             if let Some(p) = path {
                 parse(&root.join(p))?;
             }
-            resolve.push(UnresolvedPackage::parse("macro-input".as_ref(), s)?)?
+            resolve.push_group(UnresolvedPackageGroup::parse("macro-input", s)?)?
         }
         Some(Source::Path(s)) => parse(&root.join(s))?,
         None => parse(&root.join("wit"))?,

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -143,10 +143,10 @@ pub fn run_component_codegen_test(
 
 fn parse_wit(path: &Path) -> (Resolve, WorldId) {
     let mut resolve = Resolve::default();
-    let (pkg, _files) = resolve.push_path(path).unwrap();
-    let world = resolve.select_world(pkg, None).unwrap_or_else(|_| {
+    let (pkgs, _files) = resolve.push_path(path).unwrap();
+    let world = resolve.select_world(&pkgs, None).unwrap_or_else(|_| {
         // note: if there are multiples worlds in the wit package, we assume the "imports" world
-        resolve.select_world(pkg, Some("imports")).unwrap()
+        resolve.select_world(&pkgs, Some("imports")).unwrap()
     });
     (resolve, world)
 }

--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -181,8 +181,8 @@ fn gen_world(
             resolve.features.insert(feature.to_string());
         }
     }
-    let (pkg, _files) = resolve.push_path(&opts.wit)?;
-    let world = resolve.select_world(pkg, opts.world.as_deref())?;
+    let (pkgs, _files) = resolve.push_path(&opts.wit)?;
+    let world = resolve.select_world(&pkgs, opts.world.as_deref())?;
     generator.generate(&resolve, world, files)?;
 
     Ok(())

--- a/tests/runtime/flavorful.rs
+++ b/tests/runtime/flavorful.rs
@@ -12,77 +12,69 @@ pub struct MyImports {
 }
 
 impl test_imports::Host for MyImports {
-    fn f_list_in_record1(&mut self, ty: test_imports::ListInRecord1) -> Result<()> {
+    fn f_list_in_record1(&mut self, ty: test_imports::ListInRecord1) {
         assert_eq!(ty.a, "list_in_record1");
-        Ok(())
     }
 
-    fn f_list_in_record2(&mut self) -> Result<test_imports::ListInRecord2> {
-        Ok(test_imports::ListInRecord2 {
+    fn f_list_in_record2(&mut self) -> test_imports::ListInRecord2 {
+        test_imports::ListInRecord2 {
             a: "list_in_record2".to_string(),
-        })
+        }
     }
 
-    fn f_list_in_record3(
-        &mut self,
-        a: test_imports::ListInRecord3,
-    ) -> Result<test_imports::ListInRecord3> {
+    fn f_list_in_record3(&mut self, a: test_imports::ListInRecord3) -> test_imports::ListInRecord3 {
         assert_eq!(a.a, "list_in_record3 input");
-        Ok(test_imports::ListInRecord3 {
+        test_imports::ListInRecord3 {
             a: "list_in_record3 output".to_string(),
-        })
+        }
     }
 
-    fn f_list_in_record4(
-        &mut self,
-        a: test_imports::ListInAlias,
-    ) -> Result<test_imports::ListInAlias> {
+    fn f_list_in_record4(&mut self, a: test_imports::ListInAlias) -> test_imports::ListInAlias {
         assert_eq!(a.a, "input4");
-        Ok(test_imports::ListInRecord4 {
+        test_imports::ListInRecord4 {
             a: "result4".to_string(),
-        })
+        }
     }
 
     fn f_list_in_variant1(
         &mut self,
         a: test_imports::ListInVariant1V1,
         b: test_imports::ListInVariant1V2,
-    ) -> Result<()> {
+    ) {
         assert_eq!(a.unwrap(), "foo");
         assert_eq!(b.unwrap_err(), "bar");
-        Ok(())
     }
 
-    fn f_list_in_variant2(&mut self) -> Result<Option<String>> {
-        Ok(Some("list_in_variant2".to_string()))
+    fn f_list_in_variant2(&mut self) -> Option<String> {
+        Some("list_in_variant2".to_string())
     }
 
-    fn f_list_in_variant3(&mut self, a: test_imports::ListInVariant3) -> Result<Option<String>> {
+    fn f_list_in_variant3(&mut self, a: test_imports::ListInVariant3) -> Option<String> {
         assert_eq!(a.unwrap(), "input3");
-        Ok(Some("output3".to_string()))
+        Some("output3".to_string())
     }
 
-    fn errno_result(&mut self) -> Result<Result<(), test_imports::MyErrno>> {
+    fn errno_result(&mut self) -> Result<(), test_imports::MyErrno> {
         if self.errored {
-            return Ok(Ok(()));
+            return Ok(());
         }
         test_imports::MyErrno::A.to_string();
         format!("{:?}", test_imports::MyErrno::A);
         fn assert_error<T: std::error::Error>() {}
         assert_error::<test_imports::MyErrno>();
         self.errored = true;
-        Ok(Err(test_imports::MyErrno::B))
+        Err(test_imports::MyErrno::B)
     }
 
     fn list_typedefs(
         &mut self,
         a: test_imports::ListTypedef,
         b: test_imports::ListTypedef3,
-    ) -> Result<(test_imports::ListTypedef2, test_imports::ListTypedef3)> {
+    ) -> (test_imports::ListTypedef2, test_imports::ListTypedef3) {
         assert_eq!(a, "typedef1");
         assert_eq!(b.len(), 1);
         assert_eq!(b[0], "typedef2");
-        Ok((b"typedef3".to_vec(), vec!["typedef4".to_string()]))
+        (b"typedef3".to_vec(), vec!["typedef4".to_string()])
     }
 
     fn list_of_variants(
@@ -90,18 +82,18 @@ impl test_imports::Host for MyImports {
         bools: Vec<bool>,
         results: Vec<Result<(), ()>>,
         enums: Vec<test_imports::MyErrno>,
-    ) -> Result<(Vec<bool>, Vec<Result<(), ()>>, Vec<test_imports::MyErrno>)> {
+    ) -> (Vec<bool>, Vec<Result<(), ()>>, Vec<test_imports::MyErrno>) {
         assert_eq!(bools, [true, false]);
         assert_eq!(results, [Ok(()), Err(())]);
         assert_eq!(
             enums,
             [test_imports::MyErrno::Success, test_imports::MyErrno::A]
         );
-        Ok((
+        (
             vec![false, true],
             vec![Err(()), Ok(())],
             vec![test_imports::MyErrno::A, test_imports::MyErrno::B],
-        ))
+        )
     }
 }
 

--- a/tests/runtime/lists.rs
+++ b/tests/runtime/lists.rs
@@ -9,98 +9,92 @@ wasmtime::component::bindgen!({
 pub struct MyImports;
 
 impl test::lists::test::Host for MyImports {
-    fn empty_list_param(&mut self, a: Vec<u8>) -> Result<()> {
+    fn empty_list_param(&mut self, a: Vec<u8>) {
         assert!(a.is_empty());
-        Ok(())
     }
 
-    fn empty_string_param(&mut self, a: String) -> Result<()> {
+    fn empty_string_param(&mut self, a: String) {
         assert_eq!(a, "");
-        Ok(())
     }
 
-    fn empty_list_result(&mut self) -> Result<Vec<u8>> {
-        Ok(Vec::new())
+    fn empty_list_result(&mut self) -> Vec<u8> {
+        Vec::new()
     }
 
-    fn empty_string_result(&mut self) -> Result<String> {
-        Ok(String::new())
+    fn empty_string_result(&mut self) -> String {
+        String::new()
     }
 
-    fn list_param(&mut self, list: Vec<u8>) -> Result<()> {
+    fn list_param(&mut self, list: Vec<u8>) {
         assert_eq!(list, [1, 2, 3, 4]);
-        Ok(())
     }
 
-    fn list_param2(&mut self, ptr: String) -> Result<()> {
+    fn list_param2(&mut self, ptr: String) {
         assert_eq!(ptr, "foo");
-        Ok(())
     }
 
-    fn list_param3(&mut self, ptr: Vec<String>) -> Result<()> {
+    fn list_param3(&mut self, ptr: Vec<String>) {
         assert_eq!(ptr.len(), 3);
         assert_eq!(ptr[0], "foo");
         assert_eq!(ptr[1], "bar");
         assert_eq!(ptr[2], "baz");
-        Ok(())
     }
 
-    fn list_param4(&mut self, ptr: Vec<Vec<String>>) -> Result<()> {
+    fn list_param4(&mut self, ptr: Vec<Vec<String>>) {
         assert_eq!(ptr.len(), 2);
         assert_eq!(ptr[0][0], "foo");
         assert_eq!(ptr[0][1], "bar");
         assert_eq!(ptr[1][0], "baz");
-        Ok(())
     }
 
-    fn list_result(&mut self) -> Result<Vec<u8>> {
-        Ok(vec![1, 2, 3, 4, 5])
+    fn list_result(&mut self) -> Vec<u8> {
+        vec![1, 2, 3, 4, 5]
     }
 
-    fn list_result2(&mut self) -> Result<String> {
-        Ok("hello!".to_string())
+    fn list_result2(&mut self) -> String {
+        "hello!".to_string()
     }
 
-    fn list_result3(&mut self) -> Result<Vec<String>> {
-        Ok(vec!["hello,".to_string(), "world!".to_string()])
+    fn list_result3(&mut self) -> Vec<String> {
+        vec!["hello,".to_string(), "world!".to_string()]
     }
 
-    fn list_roundtrip(&mut self, list: Vec<u8>) -> Result<Vec<u8>> {
-        Ok(list.to_vec())
+    fn list_roundtrip(&mut self, list: Vec<u8>) -> Vec<u8> {
+        list.to_vec()
     }
 
-    fn string_roundtrip(&mut self, s: String) -> Result<String> {
-        Ok(s.to_string())
+    fn string_roundtrip(&mut self, s: String) -> String {
+        s.to_string()
     }
 
-    fn list_minmax8(&mut self, u: Vec<u8>, s: Vec<i8>) -> Result<(Vec<u8>, Vec<i8>)> {
+    fn list_minmax8(&mut self, u: Vec<u8>, s: Vec<i8>) -> (Vec<u8>, Vec<i8>) {
         assert_eq!(u, [u8::MIN, u8::MAX]);
         assert_eq!(s, [i8::MIN, i8::MAX]);
-        Ok((u, s))
+        (u, s)
     }
 
-    fn list_minmax16(&mut self, u: Vec<u16>, s: Vec<i16>) -> Result<(Vec<u16>, Vec<i16>)> {
+    fn list_minmax16(&mut self, u: Vec<u16>, s: Vec<i16>) -> (Vec<u16>, Vec<i16>) {
         assert_eq!(u, [u16::MIN, u16::MAX]);
         assert_eq!(s, [i16::MIN, i16::MAX]);
-        Ok((u, s))
+        (u, s)
     }
 
-    fn list_minmax32(&mut self, u: Vec<u32>, s: Vec<i32>) -> Result<(Vec<u32>, Vec<i32>)> {
+    fn list_minmax32(&mut self, u: Vec<u32>, s: Vec<i32>) -> (Vec<u32>, Vec<i32>) {
         assert_eq!(u, [u32::MIN, u32::MAX]);
         assert_eq!(s, [i32::MIN, i32::MAX]);
-        Ok((u, s))
+        (u, s)
     }
 
-    fn list_minmax64(&mut self, u: Vec<u64>, s: Vec<i64>) -> Result<(Vec<u64>, Vec<i64>)> {
+    fn list_minmax64(&mut self, u: Vec<u64>, s: Vec<i64>) -> (Vec<u64>, Vec<i64>) {
         assert_eq!(u, [u64::MIN, u64::MAX]);
         assert_eq!(s, [i64::MIN, i64::MAX]);
-        Ok((u, s))
+        (u, s)
     }
 
-    fn list_minmax_float(&mut self, u: Vec<f32>, s: Vec<f64>) -> Result<(Vec<f32>, Vec<f64>)> {
+    fn list_minmax_float(&mut self, u: Vec<f32>, s: Vec<f64>) -> (Vec<f32>, Vec<f64>) {
         assert_eq!(u, [f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY]);
         assert_eq!(s, [f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY]);
-        Ok((u, s))
+        (u, s)
     }
 }
 

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -777,7 +777,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
 #[allow(dead_code)] // not used by all generators
 fn resolve_wit_dir(dir: &PathBuf) -> (Resolve, WorldId) {
     let mut resolve = Resolve::new();
-    let (pkg, _files) = resolve.push_path(dir).unwrap();
-    let world = resolve.select_world(pkg, None).unwrap();
+    let (pkgs, _files) = resolve.push_path(dir).unwrap();
+    let world = resolve.select_world(&pkgs, None).unwrap();
     (resolve, world)
 }

--- a/tests/runtime/many_arguments.rs
+++ b/tests/runtime/many_arguments.rs
@@ -25,7 +25,7 @@ impl imports::Host for MyImports {
         a14: u64,
         a15: u64,
         a16: u64,
-    ) -> Result<()> {
+    ) {
         assert_eq!(a1, 1);
         assert_eq!(a2, 2);
         assert_eq!(a3, 3);
@@ -42,7 +42,6 @@ impl imports::Host for MyImports {
         assert_eq!(a14, 14);
         assert_eq!(a15, 15);
         assert_eq!(a16, 16);
-        Ok(())
     }
 }
 

--- a/tests/runtime/numbers.rs
+++ b/tests/runtime/numbers.rs
@@ -9,57 +9,56 @@ pub struct MyImports {
 }
 
 impl test::numbers::test::Host for MyImports {
-    fn roundtrip_u8(&mut self, val: u8) -> Result<u8> {
-        Ok(val)
+    fn roundtrip_u8(&mut self, val: u8) -> u8 {
+        val
     }
 
-    fn roundtrip_s8(&mut self, val: i8) -> Result<i8> {
-        Ok(val)
+    fn roundtrip_s8(&mut self, val: i8) -> i8 {
+        val
     }
 
-    fn roundtrip_u16(&mut self, val: u16) -> Result<u16> {
-        Ok(val)
+    fn roundtrip_u16(&mut self, val: u16) -> u16 {
+        val
     }
 
-    fn roundtrip_s16(&mut self, val: i16) -> Result<i16> {
-        Ok(val)
+    fn roundtrip_s16(&mut self, val: i16) -> i16 {
+        val
     }
 
-    fn roundtrip_u32(&mut self, val: u32) -> Result<u32> {
-        Ok(val)
+    fn roundtrip_u32(&mut self, val: u32) -> u32 {
+        val
     }
 
-    fn roundtrip_s32(&mut self, val: i32) -> Result<i32> {
-        Ok(val)
+    fn roundtrip_s32(&mut self, val: i32) -> i32 {
+        val
     }
 
-    fn roundtrip_u64(&mut self, val: u64) -> Result<u64> {
-        Ok(val)
+    fn roundtrip_u64(&mut self, val: u64) -> u64 {
+        val
     }
 
-    fn roundtrip_s64(&mut self, val: i64) -> Result<i64> {
-        Ok(val)
+    fn roundtrip_s64(&mut self, val: i64) -> i64 {
+        val
     }
 
-    fn roundtrip_f32(&mut self, val: f32) -> Result<f32> {
-        Ok(val)
+    fn roundtrip_f32(&mut self, val: f32) -> f32 {
+        val
     }
 
-    fn roundtrip_f64(&mut self, val: f64) -> Result<f64> {
-        Ok(val)
+    fn roundtrip_f64(&mut self, val: f64) -> f64 {
+        val
     }
 
-    fn roundtrip_char(&mut self, val: char) -> Result<char> {
-        Ok(val)
+    fn roundtrip_char(&mut self, val: char) -> char {
+        val
     }
 
-    fn set_scalar(&mut self, val: u32) -> Result<()> {
+    fn set_scalar(&mut self, val: u32) {
         self.scalar = val;
-        Ok(())
     }
 
-    fn get_scalar(&mut self) -> Result<u32> {
-        Ok(self.scalar)
+    fn get_scalar(&mut self) -> u32 {
+        self.scalar
     }
 }
 

--- a/tests/runtime/options.rs
+++ b/tests/runtime/options.rs
@@ -7,26 +7,24 @@ wasmtime::component::bindgen!(in "tests/runtime/options");
 pub struct MyImports;
 
 impl test::options::test::Host for MyImports {
-    fn option_none_param(&mut self, a: Option<String>) -> Result<()> {
+    fn option_none_param(&mut self, a: Option<String>) {
         assert!(a.is_none());
-        Ok(())
     }
 
-    fn option_none_result(&mut self) -> Result<Option<String>> {
-        Ok(None)
+    fn option_none_result(&mut self) -> Option<String> {
+        None
     }
 
-    fn option_some_param(&mut self, a: Option<String>) -> Result<()> {
+    fn option_some_param(&mut self, a: Option<String>) {
         assert_eq!(a, Some("foo".to_string()));
-        Ok(())
     }
 
-    fn option_some_result(&mut self) -> Result<Option<String>> {
-        Ok(Some("foo".to_string()))
+    fn option_some_result(&mut self) -> Option<String> {
+        Some("foo".to_string())
     }
 
-    fn option_roundtrip(&mut self, a: Option<String>) -> Result<Option<String>> {
-        Ok(a)
+    fn option_roundtrip(&mut self, a: Option<String>) -> Option<String> {
+        a
     }
 }
 

--- a/tests/runtime/options.rs
+++ b/tests/runtime/options.rs
@@ -27,8 +27,8 @@ impl test::options::test::Host for MyImports {
         a
     }
 
-    fn double_option_roundtrip(&mut self, a: Option<Option<u32>>) -> Result<Option<Option<u32>>> {
-        Ok(a)
+    fn double_option_roundtrip(&mut self, a: Option<Option<u32>>) -> Option<Option<u32>> {
+        a
     }
 }
 

--- a/tests/runtime/ownership.rs
+++ b/tests/runtime/ownership.rs
@@ -20,44 +20,39 @@ pub struct MyImports {
 pub struct MyResource;
 
 impl lists::Host for MyImports {
-    fn foo(&mut self, list: Vec<Vec<String>>) -> Result<Vec<Vec<String>>> {
+    fn foo(&mut self, list: Vec<Vec<String>>) -> Vec<Vec<String>> {
         self.called_foo = true;
-        Ok(list)
+        list
     }
 }
 
 impl thing_in::Host for MyImports {
-    fn bar(&mut self, _value: thing_in::Thing) -> Result<()> {
+    fn bar(&mut self, _value: thing_in::Thing) {
         self.called_bar = true;
-        Ok(())
     }
 }
 
 impl thing_in_and_out::Host for MyImports {
-    fn baz(&mut self, value: thing_in_and_out::Thing) -> Result<thing_in_and_out::Thing> {
+    fn baz(&mut self, value: thing_in_and_out::Thing) -> thing_in_and_out::Thing {
         self.called_baz = true;
-        Ok(value)
+        value
     }
 }
 
 impl test::ownership::both_list_and_resource::Host for MyImports {
-    fn list_and_resource(
-        &mut self,
-        value: test::ownership::both_list_and_resource::Thing,
-    ) -> Result<()> {
+    fn list_and_resource(&mut self, value: test::ownership::both_list_and_resource::Thing) {
         assert_eq!(value.b.rep(), 100);
         assert!(value.b.owned());
         let expected = self.last_resource_list.as_ref().unwrap();
         assert_eq!(value.a, *expected);
-        Ok(())
     }
 }
 
 impl test::ownership::both_list_and_resource::HostTheResource for MyImports {
-    fn new(&mut self, list: Vec<String>) -> Result<Resource<MyResource>> {
+    fn new(&mut self, list: Vec<String>) -> Resource<MyResource> {
         assert!(self.last_resource_list.is_none());
         self.last_resource_list = Some(list);
-        Ok(Resource::new_own(100))
+        Resource::new_own(100)
     }
 
     fn drop(&mut self, _val: Resource<MyResource>) -> Result<()> {

--- a/tests/runtime/records.rs
+++ b/tests/runtime/records.rs
@@ -9,22 +9,22 @@ use test::records::test as test_imports;
 pub struct MyImports;
 
 impl test_imports::Host for MyImports {
-    fn multiple_results(&mut self) -> Result<(u8, u16)> {
-        Ok((4, 5))
+    fn multiple_results(&mut self) -> (u8, u16) {
+        (4, 5)
     }
 
-    fn swap_tuple(&mut self, a: (u8, u32)) -> Result<(u32, u8)> {
-        Ok((a.1, a.0))
+    fn swap_tuple(&mut self, a: (u8, u32)) -> (u32, u8) {
+        (a.1, a.0)
     }
 
-    fn roundtrip_flags1(&mut self, a: test_imports::F1) -> Result<test_imports::F1> {
+    fn roundtrip_flags1(&mut self, a: test_imports::F1) -> test_imports::F1 {
         drop(format!("{:?}", a));
         let _ = a & test_imports::F1::all();
-        Ok(a)
+        a
     }
 
-    fn roundtrip_flags2(&mut self, a: test_imports::F2) -> Result<test_imports::F2> {
-        Ok(a)
+    fn roundtrip_flags2(&mut self, a: test_imports::F2) -> test_imports::F2 {
+        a
     }
 
     fn roundtrip_flags3(
@@ -33,22 +33,22 @@ impl test_imports::Host for MyImports {
         b: test_imports::Flag16,
         c: test_imports::Flag32,
         d: test_imports::Flag64,
-    ) -> Result<(
+    ) -> (
         test_imports::Flag8,
         test_imports::Flag16,
         test_imports::Flag32,
         test_imports::Flag64,
-    )> {
-        Ok((a, b, c, d))
+    ) {
+        (a, b, c, d)
     }
 
-    fn roundtrip_record1(&mut self, a: test_imports::R1) -> Result<test_imports::R1> {
+    fn roundtrip_record1(&mut self, a: test_imports::R1) -> test_imports::R1 {
         drop(format!("{:?}", a));
-        Ok(a)
+        a
     }
 
-    fn tuple1(&mut self, a: (u8,)) -> Result<(u8,)> {
-        Ok((a.0,))
+    fn tuple1(&mut self, a: (u8,)) -> (u8,) {
+        (a.0,)
     }
 }
 

--- a/tests/runtime/resource_aggregates.rs
+++ b/tests/runtime/resource_aggregates.rs
@@ -17,11 +17,11 @@ pub struct MyHostThing {
 }
 
 impl HostThing for MyHostThing {
-    fn new(&mut self, v: u32) -> wasmtime::Result<wasmtime::component::Resource<Thing>> {
+    fn new(&mut self, v: u32) -> wasmtime::component::Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_a.insert(id, v + 2);
-        Ok(wasmtime::component::Resource::new_own(id))
+        wasmtime::component::Resource::new_own(id)
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Thing>) -> wasmtime::Result<()> {
@@ -54,7 +54,7 @@ impl Host for MyHostThing {
         o2: Option<wasmtime::component::Resource<Thing>>,
         result1: Result<wasmtime::component::Resource<Thing>, ()>,
         result2: Result<wasmtime::component::Resource<Thing>, ()>,
-    ) -> wasmtime::Result<u32> {
+    ) -> u32 {
         let res = self.get_value(r1.thing)
             + self.get_value(r2.thing)
             + self.get_value(r3.thing1)
@@ -75,7 +75,7 @@ impl Host for MyHostThing {
             + result1.map(|o| self.get_value(o)).unwrap_or_default()
             + result2.map(|o| self.get_value(o)).unwrap_or_default()
             + 3;
-        Ok(res)
+        res
     }
 }
 

--- a/tests/runtime/resource_alias_redux.rs
+++ b/tests/runtime/resource_alias_redux.rs
@@ -23,16 +23,16 @@ impl MyHost {
 }
 
 impl HostThing for MyHost {
-    fn new(&mut self, s: String) -> wasmtime::Result<wasmtime::component::Resource<Thing>> {
+    fn new(&mut self, s: String) -> wasmtime::component::Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, s + " HostThing");
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn get(&mut self, self_: wasmtime::component::Resource<Thing>) -> wasmtime::Result<String> {
+    fn get(&mut self, self_: wasmtime::component::Resource<Thing>) -> String {
         let id = self_.rep();
-        Ok(self.map_l[&id].clone() + " HostThing.get")
+        self.map_l[&id].clone() + " HostThing.get"
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Thing>) -> wasmtime::Result<()> {
@@ -43,18 +43,14 @@ impl HostThing for MyHost {
 }
 
 impl Host1 for MyHost {
-    fn a(&mut self, f: Foo1) -> wasmtime::Result<Vec<wasmtime::component::Resource<Thing>>> {
-        Ok(vec![f.thing])
+    fn a(&mut self, f: Foo1) -> Vec<wasmtime::component::Resource<Thing>> {
+        vec![f.thing]
     }
 }
 
 impl Host2 for MyHost {
-    fn b(
-        &mut self,
-        f: Foo2,
-        g: Bar,
-    ) -> wasmtime::Result<Vec<wasmtime::component::Resource<Thing>>> {
-        Ok(vec![f.thing, g.thing])
+    fn b(&mut self, f: Foo2, g: Bar) -> Vec<wasmtime::component::Resource<Thing>> {
+        vec![f.thing, g.thing]
     }
 }
 
@@ -76,7 +72,7 @@ fn run_test(
     store: &mut Store<crate::Wasi<MyHost>>,
 ) -> anyhow::Result<()> {
     let mut thing = MyHost::default();
-    let thing1 = HostThing::new(&mut thing, "Ni Hao".to_string())?;
+    let thing1 = HostThing::new(&mut thing, "Ni Hao".to_string());
     let res: Vec<String> = instance
         .call_test(&mut *store, &[thing1])?
         .into_iter()

--- a/tests/runtime/resource_borrow_import.rs
+++ b/tests/runtime/resource_borrow_import.rs
@@ -13,11 +13,11 @@ pub struct MyHostThing {
 }
 
 impl HostThing for MyHostThing {
-    fn new(&mut self, v: u32) -> wasmtime::Result<wasmtime::component::Resource<Thing>> {
+    fn new(&mut self, v: u32) -> wasmtime::component::Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, v + 2);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Thing>) -> wasmtime::Result<()> {
@@ -28,9 +28,9 @@ impl HostThing for MyHostThing {
 }
 
 impl Host for MyHostThing {
-    fn foo(&mut self, v: wasmtime::component::Resource<Thing>) -> wasmtime::Result<u32> {
+    fn foo(&mut self, v: wasmtime::component::Resource<Thing>) -> u32 {
         let id = v.rep();
-        Ok(self.map_l[&id] + 3)
+        self.map_l[&id] + 3
     }
 }
 

--- a/tests/runtime/resource_borrow_in_record.rs
+++ b/tests/runtime/resource_borrow_in_record.rs
@@ -22,32 +22,28 @@ impl MyHostThing {
 }
 
 impl TestHost for MyHostThing {
-    fn test(
-        &mut self,
-        a: Vec<HostFoo>,
-    ) -> wasmtime::Result<Vec<wasmtime::component::Resource<Thing>>> {
+    fn test(&mut self, a: Vec<HostFoo>) -> Vec<wasmtime::component::Resource<Thing>> {
         a.into_iter()
             .map(|a| {
                 let val = self.get_value(a.thing.rep());
                 // val + " test"
-                let thing = HostThing::new(self, val.to_string() + " test")?;
-                Ok(thing)
+                HostThing::new(self, val.to_string() + " test")
             })
             .collect()
     }
 }
 
 impl HostThing for MyHostThing {
-    fn new(&mut self, s: String) -> wasmtime::Result<wasmtime::component::Resource<Thing>> {
+    fn new(&mut self, s: String) -> wasmtime::component::Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, s + " HostThing");
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn get(&mut self, self_: wasmtime::component::Resource<Thing>) -> wasmtime::Result<String> {
+    fn get(&mut self, self_: wasmtime::component::Resource<Thing>) -> String {
         let id = self_.rep();
-        Ok(self.map_l[&id].clone() + " HostThing.get")
+        self.map_l[&id].clone() + " HostThing.get"
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Thing>) -> wasmtime::Result<()> {

--- a/tests/runtime/resource_borrow_simple.rs
+++ b/tests/runtime/resource_borrow_simple.rs
@@ -7,8 +7,8 @@ wasmtime::component::bindgen!(in "tests/runtime/resource_borrow_simple");
 pub struct MyHostRImpl {}
 
 impl HostR for MyHostRImpl {
-    fn new(&mut self) -> std::result::Result<wasmtime::component::Resource<R>, anyhow::Error> {
-        Ok(Resource::new_own(0))
+    fn new(&mut self) -> wasmtime::component::Resource<R> {
+        Resource::new_own(0)
     }
 
     fn drop(
@@ -20,9 +20,7 @@ impl HostR for MyHostRImpl {
 }
 
 impl ResourceBorrowSimpleImports for MyHostRImpl {
-    fn test(&mut self, _: wasmtime::component::Resource<R>) -> wasmtime::Result<()> {
-        Ok(())
-    }
+    fn test(&mut self, _: wasmtime::component::Resource<R>) {}
 }
 
 #[test]

--- a/tests/runtime/resource_floats.rs
+++ b/tests/runtime/resource_floats.rs
@@ -16,23 +16,23 @@ pub struct MyHostFloats {
 
 impl Host for MyHostFloats {}
 impl HostFloat for MyHostFloats {
-    fn new(&mut self, v: f64) -> wasmtime::Result<wasmtime::component::Resource<ImportFloat1>> {
+    fn new(&mut self, v: f64) -> wasmtime::component::Resource<ImportFloat1> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, v + 2.0);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn get(&mut self, self_: wasmtime::component::Resource<ImportFloat1>) -> wasmtime::Result<f64> {
+    fn get(&mut self, self_: wasmtime::component::Resource<ImportFloat1>) -> f64 {
         let id = self_.rep();
-        Ok(self.map_l[&id] + 4.0)
+        self.map_l[&id] + 4.0
     }
 
     fn add(
         &mut self,
         a: wasmtime::component::Resource<ImportFloat1>,
         b: f64,
-    ) -> wasmtime::Result<wasmtime::component::Resource<ImportFloat1>> {
+    ) -> wasmtime::component::Resource<ImportFloat1> {
         let id = a.rep();
         let a_value = self.map_l[&id];
         (self as &mut dyn HostFloat).new(a_value + b + 6.0)
@@ -47,16 +47,16 @@ impl HostFloat for MyHostFloats {
 impl Host2 for MyHostFloats {}
 
 impl HostFloat2 for MyHostFloats {
-    fn new(&mut self, v: f64) -> wasmtime::Result<wasmtime::component::Resource<Float>> {
+    fn new(&mut self, v: f64) -> wasmtime::component::Resource<Float> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, v + 1.0);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn get(&mut self, self_: wasmtime::component::Resource<Float>) -> wasmtime::Result<f64> {
+    fn get(&mut self, self_: wasmtime::component::Resource<Float>) -> f64 {
         let id = self_.rep();
-        Ok(self.map_l[&id] + 3.0)
+        self.map_l[&id] + 3.0
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Float>) -> wasmtime::Result<()> {

--- a/tests/runtime/resource_import_and_export.rs
+++ b/tests/runtime/resource_import_and_export.rs
@@ -13,35 +13,34 @@ pub struct MyHostThing {
 }
 
 impl ResourceImportAndExportImports for MyHostThing {
-    fn toplevel_import(&mut self, a: Resource<Thing>) -> Result<Resource<Thing>> {
-        Ok(a)
+    fn toplevel_import(&mut self, a: Resource<Thing>) -> Resource<Thing> {
+        a
     }
 }
 
 impl Host for MyHostThing {}
 
 impl HostThing for MyHostThing {
-    fn new(&mut self, v: u32) -> Result<Resource<Thing>> {
+    fn new(&mut self, v: u32) -> Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_l.insert(id, v + 1);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn foo(&mut self, self_: Resource<Thing>) -> Result<u32> {
+    fn foo(&mut self, self_: Resource<Thing>) -> u32 {
         let id = self_.rep();
-        Ok(self.map_l[&id] + 2)
+        self.map_l[&id] + 2
     }
 
-    fn bar(&mut self, self_: Resource<Thing>, v: u32) -> Result<()> {
+    fn bar(&mut self, self_: Resource<Thing>, v: u32) {
         let id = self_.rep();
         self.map_l.insert(id, v + 3);
-        Ok(())
     }
 
-    fn baz(&mut self, a: Resource<Thing>, b: Resource<Thing>) -> Result<Resource<Thing>> {
-        let a = self.foo(a)?;
-        let b = self.foo(b)?;
+    fn baz(&mut self, a: Resource<Thing>, b: Resource<Thing>) -> Resource<Thing> {
+        let a = self.foo(a);
+        let b = self.foo(b);
         self.new(a + b + 4)
     }
 

--- a/tests/runtime/resource_with_lists.rs
+++ b/tests/runtime/resource_with_lists.rs
@@ -15,34 +15,33 @@ pub struct MyHostThing {
 impl Host for MyHostThing {}
 
 impl HostThing for MyHostThing {
-    fn new(&mut self, l: Vec<u8>) -> wasmtime::Result<Resource<Thing>> {
+    fn new(&mut self, l: Vec<u8>) -> Resource<Thing> {
         let id = self.next_id;
         self.next_id += 1;
         let mut result = l.clone();
         result.extend_from_slice(" HostThing".as_bytes());
         self.map_l.insert(id, result);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn foo(&mut self, self_: Resource<Thing>) -> wasmtime::Result<Vec<u8>> {
+    fn foo(&mut self, self_: Resource<Thing>) -> Vec<u8> {
         let id = self_.rep();
         let mut list = self.map_l[&id].clone();
         list.extend_from_slice(" HostThing.foo".as_bytes());
-        Ok(list)
+        list
     }
 
-    fn bar(&mut self, self_: Resource<Thing>, l: Vec<u8>) -> wasmtime::Result<()> {
+    fn bar(&mut self, self_: Resource<Thing>, l: Vec<u8>) {
         let id = self_.rep();
         let mut result = l.clone();
         result.extend_from_slice(" HostThing.bar".as_bytes());
         self.map_l.insert(id, result);
-        Ok(())
     }
 
-    fn baz(&mut self, l: Vec<u8>) -> wasmtime::Result<Vec<u8>> {
+    fn baz(&mut self, l: Vec<u8>) -> Vec<u8> {
         let mut result = l.clone();
         result.extend_from_slice(" HostThing.baz".as_bytes());
-        Ok(result)
+        result
     }
 
     fn drop(&mut self, rep: Resource<Thing>) -> wasmtime::Result<()> {

--- a/tests/runtime/resources.rs
+++ b/tests/runtime/resources.rs
@@ -19,34 +19,33 @@ pub struct MyImports {
 }
 
 impl HostY for MyImports {
-    fn new(&mut self, a: i32) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+    fn new(&mut self, a: i32) -> wasmtime::component::Resource<Y> {
         let id = self.next_id;
         self.next_id += 1;
         self.map_a.insert(id, a);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
-    fn get_a(&mut self, self_: wasmtime::component::Resource<Y>) -> wasmtime::Result<i32> {
+    fn get_a(&mut self, self_: wasmtime::component::Resource<Y>) -> i32 {
         let id = self_.rep();
-        Ok(self.map_a[&id])
+        self.map_a[&id]
     }
 
-    fn set_a(&mut self, self_: wasmtime::component::Resource<Y>, a: i32) -> wasmtime::Result<()> {
+    fn set_a(&mut self, self_: wasmtime::component::Resource<Y>, a: i32) {
         let id = self_.rep();
         self.map_a.insert(id, a);
-        Ok(())
     }
 
     fn add(
         &mut self,
         y: wasmtime::component::Resource<Y>,
         a: i32,
-    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+    ) -> wasmtime::component::Resource<Y> {
         let id = self.next_id;
         self.next_id += 1;
         let y = y.rep();
         self.map_a.insert(id, self.map_a[&y] + a);
-        Ok(Resource::new_own(id))
+        Resource::new_own(id)
     }
 
     fn drop(&mut self, rep: wasmtime::component::Resource<Y>) -> wasmtime::Result<()> {

--- a/tests/runtime/results.rs
+++ b/tests/runtime/results.rs
@@ -11,20 +11,24 @@ use test::results::test as imports;
 pub struct MyImports;
 
 impl test::results::test::Host for MyImports {
-    fn string_error(&mut self, a: f32) -> Result<Result<f32, String>> {
-        Ok(if a == 0.0 {
+    fn string_error(&mut self, a: f32) -> Result<f32, String> {
+        if a == 0.0 {
             Err("zero".to_owned())
         } else {
             Ok(a)
-        })
+        }
     }
 
-    fn enum_error(&mut self, a: f32) -> Result<Result<f32, imports::E>> {
-        Ok(if a == 0.0 { Err(imports::E::A) } else { Ok(a) })
+    fn enum_error(&mut self, a: f32) -> Result<f32, imports::E> {
+        if a == 0.0 {
+            Err(imports::E::A)
+        } else {
+            Ok(a)
+        }
     }
 
-    fn record_error(&mut self, a: f32) -> Result<Result<f32, imports::E2>> {
-        Ok(if a == 0.0 {
+    fn record_error(&mut self, a: f32) -> Result<f32, imports::E2> {
+        if a == 0.0 {
             Err(imports::E2 {
                 line: 420,
                 column: 0,
@@ -36,11 +40,11 @@ impl test::results::test::Host for MyImports {
             })
         } else {
             Ok(a)
-        })
+        }
     }
 
-    fn variant_error(&mut self, a: f32) -> Result<Result<f32, imports::E3>> {
-        Ok(if a == 0.0 {
+    fn variant_error(&mut self, a: f32) -> Result<f32, imports::E3> {
+        if a == 0.0 {
             Err(imports::E3::E2(imports::E2 {
                 line: 420,
                 column: 0,
@@ -51,27 +55,27 @@ impl test::results::test::Host for MyImports {
             Err(imports::E3::E1(imports::E::C))
         } else {
             Ok(a)
-        })
+        }
     }
 
-    fn empty_error(&mut self, a: u32) -> Result<Result<u32, ()>> {
-        Ok(if a == 0 {
+    fn empty_error(&mut self, a: u32) -> Result<u32, ()> {
+        if a == 0 {
             Err(())
         } else if a == 1 {
             Ok(42)
         } else {
             Ok(a)
-        })
+        }
     }
 
-    fn double_error(&mut self, a: u32) -> Result<Result<Result<(), String>, String>> {
-        Ok(if a == 0 {
+    fn double_error(&mut self, a: u32) -> Result<Result<(), String>, String> {
+        if a == 0 {
             Ok(Ok(()))
         } else if a == 1 {
             Ok(Err("one".into()))
         } else {
             Err("two".into())
-        })
+        }
     }
 }
 

--- a/tests/runtime/rust_xcrate.rs
+++ b/tests/runtime/rust_xcrate.rs
@@ -11,19 +11,15 @@ use test::xcrate::b_imports::X as B_X;
 pub struct MyImports;
 
 impl test::xcrate::a_imports::Host for MyImports {
-    fn a(&mut self) -> Result<()> {
-        Ok(())
-    }
+    fn a(&mut self) {}
 }
 
 impl test::xcrate::a_imports::HostX for MyImports {
-    fn new(&mut self) -> Result<Resource<A_X>> {
-        Ok(Resource::new_own(2))
+    fn new(&mut self) -> Resource<A_X> {
+        Resource::new_own(2)
     }
 
-    fn foo(&mut self, _resource: Resource<A_X>) -> Result<()> {
-        Ok(())
-    }
+    fn foo(&mut self, _resource: Resource<A_X>) {}
 
     fn drop(&mut self, _resource: Resource<A_X>) -> Result<()> {
         Ok(())
@@ -31,19 +27,15 @@ impl test::xcrate::a_imports::HostX for MyImports {
 }
 
 impl test::xcrate::b_imports::Host for MyImports {
-    fn b(&mut self) -> Result<()> {
-        Ok(())
-    }
+    fn b(&mut self) {}
 }
 
 impl test::xcrate::b_imports::HostX for MyImports {
-    fn new(&mut self) -> Result<Resource<B_X>> {
-        Ok(Resource::new_own(2))
+    fn new(&mut self) -> Resource<B_X> {
+        Resource::new_own(2)
     }
 
-    fn foo(&mut self, _resource: Resource<B_X>) -> Result<()> {
-        Ok(())
-    }
+    fn foo(&mut self, _resource: Resource<B_X>) {}
 
     fn drop(&mut self, _resource: Resource<B_X>) -> Result<()> {
         Ok(())

--- a/tests/runtime/smoke.rs
+++ b/tests/runtime/smoke.rs
@@ -9,10 +9,9 @@ pub struct MyImports {
 }
 
 impl test::smoke::imports::Host for MyImports {
-    fn thunk(&mut self) -> Result<()> {
+    fn thunk(&mut self) {
         self.hit = true;
         println!("in the host");
-        Ok(())
     }
 }
 

--- a/tests/runtime/strings.rs
+++ b/tests/runtime/strings.rs
@@ -7,13 +7,12 @@ wasmtime::component::bindgen!(in "tests/runtime/strings");
 pub struct MyImports;
 
 impl test::strings::imports::Host for MyImports {
-    fn take_basic(&mut self, s: String) -> Result<()> {
+    fn take_basic(&mut self, s: String) {
         assert_eq!(s, "latin utf16");
-        Ok(())
     }
 
-    fn return_unicode(&mut self) -> Result<String> {
-        Ok("🚀🚀🚀 𠈄𓀀".to_string())
+    fn return_unicode(&mut self) -> String {
+        "🚀🚀🚀 𠈄𓀀".to_string()
     }
 }
 

--- a/tests/runtime/type_section_suffix.rs
+++ b/tests/runtime/type_section_suffix.rs
@@ -8,9 +8,7 @@ use self::test::suffix::imports::Host;
 pub struct MyFoo;
 
 impl Host for MyFoo {
-    fn foo(&mut self) -> wasmtime::Result<()> {
-        Ok(())
-    }
+    fn foo(&mut self) {}
 }
 
 #[test]

--- a/tests/runtime/variants.rs
+++ b/tests/runtime/variants.rs
@@ -9,53 +9,46 @@ use test::variants::test as test_imports;
 pub struct MyImports;
 
 impl test_imports::Host for MyImports {
-    fn roundtrip_option(&mut self, a: Option<f32>) -> anyhow::Result<Option<u8>> {
-        Ok(a.map(|x| x as u8))
+    fn roundtrip_option(&mut self, a: Option<f32>) -> Option<u8> {
+        a.map(|x| x as u8)
     }
 
-    fn roundtrip_result(&mut self, a: Result<u32, f32>) -> anyhow::Result<Result<f64, u8>> {
-        Ok(match a {
+    fn roundtrip_result(&mut self, a: Result<u32, f32>) -> Result<f64, u8> {
+        match a {
             Ok(a) => Ok(a.into()),
             Err(b) => Err(b as u8),
-        })
+        }
     }
 
-    fn roundtrip_enum(&mut self, a: test_imports::E1) -> anyhow::Result<test_imports::E1> {
+    fn roundtrip_enum(&mut self, a: test_imports::E1) -> test_imports::E1 {
         assert_eq!(a, a);
-        Ok(a)
+        a
     }
 
-    fn invert_bool(&mut self, a: bool) -> anyhow::Result<bool> {
-        Ok(!a)
+    fn invert_bool(&mut self, a: bool) -> bool {
+        !a
     }
 
-    fn variant_casts(&mut self, a: test_imports::Casts) -> anyhow::Result<test_imports::Casts> {
-        Ok(a)
+    fn variant_casts(&mut self, a: test_imports::Casts) -> test_imports::Casts {
+        a
     }
 
-    fn variant_zeros(&mut self, a: test_imports::Zeros) -> anyhow::Result<test_imports::Zeros> {
-        Ok(a)
+    fn variant_zeros(&mut self, a: test_imports::Zeros) -> test_imports::Zeros {
+        a
     }
 
-    fn variant_typedefs(
-        &mut self,
-        _: Option<u32>,
-        _: bool,
-        _: Result<u32, ()>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
+    fn variant_typedefs(&mut self, _: Option<u32>, _: bool, _: Result<u32, ()>) {}
 
     fn variant_enums(
         &mut self,
         a: bool,
         b: Result<(), ()>,
         c: test_imports::MyErrno,
-    ) -> anyhow::Result<(bool, Result<(), ()>, test_imports::MyErrno)> {
+    ) -> (bool, Result<(), ()>, test_imports::MyErrno) {
         assert_eq!(a, true);
         assert_eq!(b, Ok(()));
         assert_eq!(c, test_imports::MyErrno::Success);
-        Ok((false, Err(()), test_imports::MyErrno::A))
+        (false, Err(()), test_imports::MyErrno::A)
     }
 }
 

--- a/tests/runtime/versions.rs
+++ b/tests/runtime/versions.rs
@@ -9,22 +9,22 @@ use crate::versions::test::dep0_2_0::test::Host as v2;
 pub struct MyFoo;
 
 impl v1 for MyFoo {
-    fn x(&mut self) -> wasmtime::Result<f32> {
-        Ok(1.0)
+    fn x(&mut self) -> f32 {
+        1.0
     }
 
-    fn y(&mut self, a: f32) -> wasmtime::Result<f32> {
-        Ok(1.0 + a)
+    fn y(&mut self, a: f32) -> f32 {
+        1.0 + a
     }
 }
 
 impl v2 for MyFoo {
-    fn x(&mut self) -> wasmtime::Result<f32> {
-        Ok(2.0)
+    fn x(&mut self) -> f32 {
+        2.0
     }
 
-    fn z(&mut self, a: f32, b: f32) -> wasmtime::Result<f32> {
-        Ok(2.0 + a + b)
+    fn z(&mut self, a: f32, b: f32) -> f32 {
+        2.0 + a + b
     }
 }
 


### PR DESCRIPTION
The wasm-tools upgrade is pretty benign: wit-bindgen's parse deals in groups of packages now, rather than a single package.

The wasmtime upgrade has lots of text diff but ultimately the principle is simple: by default, wasmtime::component::bindgen no longer makes import funcs trappable.