### PR TITLE
fix(go): correct bool&string type for lower_value and duplicated static function name

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -416,6 +416,7 @@ impl WorldGenerator for C {
 
         uwriteln!(h_str, "#include <stdint.h>");
         uwriteln!(h_str, "#include <stdbool.h>");
+        uwriteln!(h_str, "#include <stddef.h>");
         for include in self.h_includes.iter() {
             uwriteln!(h_str, "#include {include}");
         }

--- a/crates/go/src/bindgen.rs
+++ b/crates/go/src/bindgen.rs
@@ -172,7 +172,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
     pub(crate) fn lower_value(&mut self, param: &str, ty: &Type, lower_name: &str) {
         match ty {
             Type::Bool => {
-                uwriteln!(self.lower_src, "{lower_name} := {param}",);
+                uwriteln!(self.lower_src, "{lower_name} := (C._Bool)({param})",);
             }
             Type::String => {
                 self.interface.gen.with_import_unsafe(true);
@@ -185,7 +185,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
                     self.lower_src,
                     "
                     // use unsafe.Pointer to avoid copy
-                    {lower_name}.ptr = (*uint8)(unsafe.Pointer(C.CString({param})))
+                    {lower_name}.ptr = (*C.uint8_t)(unsafe.Pointer(C.CString({param})))
                     {lower_name}.len = C.size_t(len({param}))"
                 );
             }
@@ -416,7 +416,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
     pub(crate) fn lift_value(&mut self, param: &str, ty: &Type, lift_name: &str) {
         match ty {
             Type::Bool => {
-                uwriteln!(self.lift_src, "{lift_name} := {param}");
+                uwriteln!(self.lift_src, "{lift_name} := (bool)({param})");
             }
             Type::String => {
                 self.interface.gen.with_import_unsafe(true);

--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -158,7 +158,11 @@ impl InterfaceGenerator<'_> {
     pub(crate) fn func_name(&self, func: &Function) -> String {
         match func.kind {
             FunctionKind::Freestanding => func.name.to_upper_camel_case(),
-            FunctionKind::Static(_) => func.name.replace('.', " ").to_upper_camel_case(),
+            FunctionKind::Static(_) => func.name.to_upper_camel_case().replacen(
+                "Static",
+                &("Static".to_string() + &self.namespace()),
+                1,
+            ),
             FunctionKind::Method(_) => match self.direction {
                 Direction::Import => func.name.split('.').last().unwrap().to_upper_camel_case(),
                 Direction::Export => func.name.replace('.', " ").to_upper_camel_case(),

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -129,9 +129,6 @@ impl TinyGo {
                 }
             }
         };
-        if res == "bool" {
-            return res;
-        }
         format!("C.{res}")
     }
 


### PR DESCRIPTION
# type errors
Given the following fit file `world.wit`
```wit
package helloworld:expamle;
/// An example world for the component to target.
world expamle{
    import in;
    import in2;
}
```
and file `helloworld.wit`
```wit
interface in {
    resource res {
        boolean: static func(b: bool);
        str: static func(s:string);
    }
}
```

the tiny-go based bindings generated codes below:

```go
func StaticResBoolean(b bool) {
  lower_b := b
  C.helloworld_expamle_in_static_res_boolean(lower_b )
}

func StaticResStr(s string) {
  var lower_s C.expamle_string_t

  // use unsafe.Pointer to avoid copy
  lower_s.ptr = (*uint8)(unsafe.Pointer(C.CString(s)))
  lower_s.len = C.size_t(len(s))
  C.helloworld_expamle_in_static_res_str(&lower_s )
}
```

- boolean type bug
    
    the first function caused a compiler error
   
      cannot use lower_b (variable of type bool) as _Ctype__Bool value in argument to C.helloworld_expamle_in_static_res_fn

    for `lower_b` is type `bool` but param type is `_Ctype_Bool`

- string type bug

  the second function caused a compiler error
  
      cannot use (*uint8)(unsafe.Pointer(C.CString(s))) (value of type *uint8) as *_Ctype_uchar value in assignment
  
  for `lower_s.ptr` is type `*_Ctype_uchar` but given `*uint8`.

[01fc12](https://github.com/YinY1/wit-bindgen/commit/01fc12c13e85d9e303d7404e2e856e8c894d95d0) fixed these two problems.

also, when using `string`, the generated `c header file` used `size_t` without including `stddef.h`, causing compiler errors. [befcde](https://github.com/YinY1/wit-bindgen/commit/befcde92973aa04e0a527ed48fe810786703334e) fixed this problem

# function name error

Given the following fit file `another.wit`
```wit
interface in2 {
    resource res {
        boolean: static func(b: bool);
        str: static func(s:string);
    }
}
```
with same static function names.

generated codes would have duplicated name as blow:
``` go
// Import functions from helloworld:expamle/in
// ...

func StaticResBoolean(b bool) {
  lower_b := b
  C.helloworld_expamle_in_static_res_boolean(lower_b )
}

// ...

// Import functions from helloworld:expamle/in2
// ...

func StaticResBoolean(b bool) {
  lower_b := b
  C.helloworld_expamle_in2_static_res_boolean(lower_b )
}

// ...
```

[29b73d](https://github.com/bytecodealliance/wit-bindgen/commit/29b73dbd09b736f4d936003709ee3e8b2c7e0d26) add namespace between `Static` and `ResBoolean` to fix the problem