### PR TITLE
Split up test jobs on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       if: matrix.lang == 'rust'
 
     - uses: ./.github/actions/install-wasi-sdk
-      if: matrix.lang == 'c' || (matrix.lang == 'csharp' && matrix.os == 'windows-latest')
+      if: matrix.lang == 'c'
 
     - run: |
         curl.exe -LO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        lang: [c, rust, teavm-java, go, csharp]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -65,12 +66,13 @@ jobs:
         submodules: true
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Install wasm32-unknown-unknown target
-      run: rustup target add wasm32-unknown-unknown
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-wasi
+
+    - run: rustup target add wasm32-unknown-unknown
+      if: matrix.lang == 'rust'
 
     - uses: ./.github/actions/install-wasi-sdk
+      if: matrix.lang == 'c'
 
     - run: |
         curl.exe -LO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1
@@ -80,25 +82,44 @@ jobs:
         echo $LOCALAPPDATA'\Microsoft\dotnet' >> $GITHUB_PATH
         echo $LOCALAPPDATA'\Microsoft\dotnet\tools' >> $GITHUB_PATH
         $LOCALAPPDATA/Microsoft/dotnet/dotnet --info
-      if : matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && matrix.lang == 'csharp'
 
     - run: ci/download-teavm.sh
-
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '16'
+      if: matrix.lang == 'teavm-java'
     - uses: actions/setup-java@v4
+      if: matrix.lang == 'teavm-java'
       with:
         java-version: '18'
         distribution: 'adopt'
+
     - uses: actions/setup-go@v4
+      if: matrix.lang == 'go'
       with:
         go-version: '1.20'
     - uses: acifani/setup-tinygo@v2
+      if: matrix.lang == 'go'
       with:
         tinygo-version: 0.31.0
-    - name: cargo test --workspace
-      run: cargo test --workspace
+
+    - run: |
+        cargo test \
+          -p wit-bindgen-cli \
+          -p wit-bindgen-${{ matrix.lang }} \
+          --no-default-features \
+          --features ${{ matrix.lang }}
+
+  test_unit:
+    name: Crate Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - run: cargo test -p wit-bindgen-core
+    - run: cargo test -p wit-bindgen
+    - run: cargo test --workspace --exclude 'wit-bindgen*'
 
   check:
     name: Check
@@ -169,6 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test_unit
       - rustfmt
       - build
       - verify-publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       if: matrix.lang == 'rust'
 
     - uses: ./.github/actions/install-wasi-sdk
-      if: matrix.lang == 'c'
+      if: matrix.lang == 'c' || (matrix.lang == 'csharp' && matrix.os == 'windows-latest')
 
     - run: |
         curl.exe -LO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,7 @@ jobs:
         submodules: true
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
+    - run: rustup target add wasm32-wasi
     - run: cargo test -p wit-bindgen-core
     - run: cargo test -p wit-bindgen
     - run: cargo test --workspace --exclude 'wit-bindgen*'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ default = [
   'markdown',
   'teavm-java',
   'go',
-  'csharp-naot',
+  'csharp',
 ]
 c = ['dep:wit-bindgen-c']
 rust = ['dep:wit-bindgen-rust']
@@ -76,8 +76,6 @@ markdown = ['dep:wit-bindgen-markdown']
 teavm-java = ['dep:wit-bindgen-teavm-java']
 go = ['dep:wit-bindgen-go']
 csharp = ['dep:wit-bindgen-csharp']
-csharp-naot = ['csharp']
-csharp-mono = ['csharp']
 
 [dev-dependencies]
 heck = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ markdown = ['dep:wit-bindgen-markdown']
 teavm-java = ['dep:wit-bindgen-teavm-java']
 go = ['dep:wit-bindgen-go']
 csharp = ['dep:wit-bindgen-csharp']
+csharp-mono = ['csharp']
 
 [dev-dependencies]
 heck = { workspace = true }

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -497,7 +497,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
         result.push(component_path);
     }
 
-    #[cfg(feature = "csharp-mono")]
+    #[cfg(feature = "csharp")]
     if cfg!(windows) && !c_sharp.is_empty() {
         let (resolve, world) = resolve_wit_dir(&dir);
         for path in c_sharp.iter() {
@@ -658,7 +658,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
         }
     }
 
-    #[cfg(feature = "csharp-naot")]
+    #[cfg(feature = "csharp")]
     if cfg!(windows) && !c_sharp.is_empty() {
         let (resolve, world) = resolve_wit_dir(&dir);
         for path in c_sharp.iter() {

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -497,7 +497,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
         result.push(component_path);
     }
 
-    #[cfg(feature = "csharp")]
+    #[cfg(feature = "csharp-mono")]
     if cfg!(windows) && !c_sharp.is_empty() {
         let (resolve, world) = resolve_wit_dir(&dir);
         for path in c_sharp.iter() {


### PR DESCRIPTION
Currently CI takes a pretty significant chunk of time for this repository so try to speed it up by sharding jobs. Each language is now tested in isolation to avoid the need to have one giant builder with all the deps for all the languages. That helps split out install steps and test less on each builder while maintaining the same set of test coverage.

This also merges the `csharp-{naot,mono}` features as for CI they were both already always enabled so now there's just one `csharp` feature.