### PR TITLE
Rename `wasm32-wasi` usage to `wasm32-wasip1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         submodules: true
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
-    - run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-wasip1
 
     - run: rustup target add wasm32-unknown-unknown
       if: matrix.lang == 'rust'
@@ -117,7 +117,7 @@ jobs:
         submodules: true
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
-    - run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-wasip1
     - run: cargo test -p wit-bindgen-core
     - run: cargo test -p wit-bindgen
     - run: cargo test --workspace --exclude 'wit-bindgen*'
@@ -131,8 +131,8 @@ jobs:
       run: rustup update stable --no-self-update && rustup default stable
     - name: Install wasm32-unknown-unknown target
       run: rustup target add wasm32-unknown-unknown
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
+    - name: Install wasm32-wasip1 target
+      run: rustup target add wasm32-wasip1
 
     # Verify the output of the `./ci/rebuild-libcabi-realloc.sh` script is
     # up-to-date.
@@ -151,10 +151,10 @@ jobs:
     - run: cargo build --no-default-features --features markdown
 
     # Feature combos of the `wit-bindgen` crate
-    - run: cargo build --target wasm32-wasi -p wit-bindgen --no-default-features
-    - run: cargo build --target wasm32-wasi -p wit-bindgen --no-default-features --features realloc
-    - run: cargo build --target wasm32-wasi -p wit-bindgen --no-default-features --features macros
-    - run: cargo build --target wasm32-wasi -p wit-bindgen --no-default-features --features macros,realloc
+    - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features
+    - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features realloc
+    - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features macros
+    - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features macros,realloc
 
     # Verity that documentation can be generated for the rust bindings crate.
     - run: cargo doc -p wit-bindgen --no-deps

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ is:
 2. The native language toolchain is used to emit a core WebAssembly module. This
    core wasm module is the "meat" of a component and contains all user-defined
    code compiled to WebAssembly. The most common native target to use for
-   compilation today is the `wasm32-wasi` target.
+   compilation today is the `wasm32-wasip1` target.
 3. The output core wasm module is transformed into a component using the
    [`wasm-tools`] project, notably the `wasm-tools component new` subcommand.
    This will ingest the native core wasm output and wrap the output into the
@@ -185,11 +185,11 @@ world host {
 
 ### Guest: Rust
 
-The Rust compiler supports a native `wasm32-wasi` target and can be added to
+The Rust compiler supports a native `wasm32-wasip1` target and can be added to
 any `rustup`-based toolchain with:
 
 ```sh
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 In order to compile a wasi dynamic library, the following must be added to the
@@ -244,8 +244,8 @@ generated code (which is probably also a bug in `wit-bindgen`), you can use
 This project can then be built with:
 
 ```sh
-cargo build --target wasm32-wasi
-wasm-tools component new ./target/wasm32-wasi/debug/my-project.wasm \
+cargo build --target wasm32-wasip1
+wasm-tools component new ./target/wasm32-wasip1/debug/my-project.wasm \
     -o my-component.wasm --adapt ./wasi_snapshot_preview1.reactor.wasm
 ```
 
@@ -265,7 +265,7 @@ which in this case, as expected, is the same as the input world.
 
 ### Guest: C/C++
 
-C and C++ code can be compiled for the `wasm32-wasi` target using the [WASI
+C and C++ code can be compiled for the `wasm32-wasip1` target using the [WASI
 SDK] project. The releases on that repository have precompiled `clang` binaries
 which are pre-configured to compile for WebAssembly.
 

--- a/crates/test-rust-wasm/artifacts/build.rs
+++ b/crates/test-rust-wasm/artifacts/build.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let target_to_test = match std::env::var("WIT_BINDGEN_WASI_TEST_TARGET") {
         Ok(s) => s,
-        Err(_) => "wasm32-wasi".to_string(),
+        Err(_) => "wasm32-wasip1".to_string(),
     };
 
     let mut cmd = Command::new("cargo");

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ There are a few pre-requisites to testing the project. You only need the languag
   - Create an environment variable called `WASI_SDK_PATH`` giving the path where you extracted the WASI SDK download, i.e., the directory containing `bin`/`lib`/`share`` folders.
 - Compilers for the target language:
   - Go + TinyGo - https://tinygo.org/ (v0.27.0+)
-  - Rust - wasi target: `rustup target add wasm32-wasi`
+  - Rust - wasi target: `rustup target add wasm32-wasip1`
   - Java - TeaVM-WASI `ci/download-teamvm.sh`
   - C - [Clang](https://clang.llvm.org/)
   - C# - [Dotnet 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)


### PR DESCRIPTION
Handle the rename of the Rust target happening throughout the release channels now.