### PR TITLE
Normalize the path parameter in the generate macro

### DIFF
--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -155,7 +155,14 @@ fn parse_source(
     let mut files = Vec::new();
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let mut parse = |path: &Path| -> anyhow::Result<_> {
-        let (pkg, sources) = resolve.push_path(path)?;
+        // Try to normalize the path to make the error message more understandable when
+        // the path is not correct. Fallback to the original path if normalization fails
+        // (probably return an error somewhere else).
+        let normalized_path = match std::fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(_) => path.to_path_buf(),
+        };
+        let (pkg, sources) = resolve.push_path(normalized_path)?;
         files.extend(sources);
         Ok(pkg)
     };


### PR DESCRIPTION
ref https://github.com/bytecodealliance/wasmtime/pull/8871

cc @alexcrichton 