### PR TITLE
Load pointer and length of a list before creating the block for the deallocation loop.

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -1806,16 +1806,17 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 TypeDefKind::Type(t) => self.deallocate(t, addr, offset),
 
                 TypeDefKind::List(element) => {
+                    self.stack.push(addr.clone());
+                    self.emit(&Instruction::PointerLoad { offset });
+                    self.stack.push(addr);
+                    self.emit(&Instruction::LengthLoad { offset: offset + 4 });
+
                     self.push_block();
                     self.emit(&IterBasePointer);
                     let elemaddr = self.stack.pop().unwrap();
                     self.deallocate(element, elemaddr, 0);
                     self.finish_block(0);
 
-                    self.stack.push(addr.clone());
-                    self.emit(&Instruction::PointerLoad { offset });
-                    self.stack.push(addr);
-                    self.emit(&Instruction::LengthLoad { offset: offset + 4 });
                     self.emit(&Instruction::GuestDeallocateList { element });
                 }
 


### PR DESCRIPTION
Currently the block for the deallocation loop gets generated before the pointer and the length of the list.

In the [haskell generator](https://github.com/bytecodealliance/wit-bindgen/pull/979) this leads to the problem where the variables that store the pointer/length are pushed to the inner block rather than the outer one (since I always just push all code to the last block on the “block-stack”) making them inaccessible for the loop setup itself. Both Rust and C do not store the pointer/length in variables, just pushing the code to load them onto the results directly.

This solves that issue by simply getting them before the inner block is created. I don’t think this will break any other generators, tho I can’t test most of them on my machine.

Alternatively I could keep track of the current active block manually rather than assuming it’s the last one but I would prefer this solution instead if possible.
