### PR TITLE
Switch from CentOS to Alma Linux

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
+FROM almalinux:8
 
-RUN yum install -y git gcc
+RUN dnf install -y git gcc
 
 ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
Looks like the old CentOS mirrors are being decommissioned.