### PR TITLE
Fix parsing of `--with` on the CLI

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -694,6 +694,10 @@
 ///         "some:package/my-interface": generate,
 ///     },
 ///
+///     // Indicates that all interfaces not present in `with` should be assumed
+///     // to be marked with `generate`.
+///     generate_all,
+///
 ///     // An optional list of function names to skip generating bindings for.
 ///     // This is only applicable to imports and the name specified is the name
 ///     // of the function.

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -513,3 +513,46 @@ mod gated_features {
         z();
     }
 }
+
+#[allow(unused)]
+mod simple_with_option {
+    mod a {
+        wit_bindgen::generate!({
+            inline: r#"
+                package foo:bar {
+                    interface a {
+                        x: func();
+                    }
+                }
+
+                package foo:baz {
+                    world w {
+                        import foo:bar/a;
+                    }
+                }
+            "#,
+            world: "foo:baz/w",
+            generate_all,
+        });
+    }
+
+    mod b {
+        wit_bindgen::generate!({
+            inline: r#"
+                package foo:bar {
+                    interface a {
+                        x: func();
+                    }
+                }
+
+                package foo:baz {
+                    world w {
+                        import foo:bar/a;
+                    }
+                }
+            "#,
+            world: "foo:baz/w",
+            with: { "foo:bar/a": generate },
+        });
+    }
+}


### PR DESCRIPTION
This commit fixes the `--with` option in the Rust generate from changes in #972. Notably the fixes here are:

* The `--with` option is no longer required.
* Multiple `--with` options are now accepted again.
* A new `--generate-all` option was added.
* The `generate_all` macro option was documented.
* Error messages on the CLI and the macro now mention all the variants of how to fix the error.

Closes #995