### PR TITLE
add component type WIT file to C# output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,10 +1438,10 @@ name = "test-helpers"
 version = "0.0.0"
 dependencies = [
  "codegen-macro",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.213.0",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.212.0",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -1716,19 +1716,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
+checksum = "850e4e6a56413a8f33567741a2388c8f6dafd841a939d945c7248671a8739dd8"
 dependencies = [
  "leb128",
- "wasmparser 0.212.0",
+ "wasmparser 0.213.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1849fac257fd76c43268555e73d74848c8dff23975c238c2cbad61cffe5045"
+checksum = "c7435c10326606a75cba79447f9ece5c9459fec0316e21061d1397838133fedb"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1736,8 +1736,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder 0.213.0",
+ "wasmparser 0.213.0",
 ]
 
 [[package]]
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+checksum = "e48e5a90a9e0afc2990437f5600b8de682a32b18cbaaf6f2b5db185352868b6b"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2073,24 +2073,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "212.0.0"
+version = "213.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
+checksum = "cd051172bc72db3567b039f710f27d6d80f358b8333088eb4c4c12dac2a4d993"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.213.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.212.0"
+version = "1.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
+checksum = "5be77619385eca699d204399d2ffc9b1dfda1df3320266773d2d664ecb06cf3e"
 dependencies = [
- "wast 212.0.0",
+ "wast 213.0.0",
 ]
 
 [[package]]
@@ -2350,11 +2350,11 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "test-helpers",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.213.0",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.212.0",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -2365,8 +2365,8 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "test-artifacts",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder 0.213.0",
+ "wasmparser 0.213.0",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-c",
@@ -2377,7 +2377,7 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-bindgen-teavm-java",
  "wit-component",
- "wit-parser 0.212.0",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -2386,7 +2386,7 @@ version = "0.27.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.212.0",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -2398,11 +2398,12 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "test-helpers",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.213.0",
  "wasm-metadata",
- "wasmparser 0.212.0",
+ "wasmparser 0.213.0",
  "wit-bindgen-core",
  "wit-component",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -2483,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed5b0f9fc3d6424787d2a49e1142bf954ae4f26ee891992c144f0cfd68c4b7f"
+checksum = "b65c79d1eed332b05c5df1462561765605b6eccb65bc51b338aa70914cfc5fd1"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -2494,11 +2495,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.213.0",
  "wasm-metadata",
- "wasmparser 0.212.0",
+ "wasmparser 0.213.0",
  "wat",
- "wit-parser 0.212.0",
+ "wit-parser 0.213.0",
 ]
 
 [[package]]
@@ -2521,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceeb0424aa8679f3fcf2d6e3cfa381f3d6fa6179976a2c05a6249dd2bb426716"
+checksum = "b565a6b187ab01e48da8c5a83f495159bfaa72ea27e4623a0774f4b7d26bb348"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2534,7 +2535,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.212.0",
+ "wasmparser 0.213.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ indexmap = "2.0.0"
 prettyplease = "0.2.20"
 syn = { version = "2.0", features = ["printing"] }
 
-wasmparser = "0.212.0"
-wasm-encoder = "0.212.0"
-wasm-metadata = "0.212.0"
-wit-parser = "0.212.0"
-wit-component = "0.212.0"
+wasmparser = "0.213.0"
+wasm-encoder = "0.213.0"
+wasm-metadata = "0.213.0"
+wit-parser = "0.213.0"
+wit-component = "0.213.0"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.27.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.27.0' }

--- a/crates/csharp/Cargo.toml
+++ b/crates/csharp/Cargo.toml
@@ -19,6 +19,7 @@ test = false
 wasm-encoder = { workspace = true }
 wit-bindgen-core = { workspace = true }
 wit-component = { workspace = true }
+wit-parser = { workspace = true }
 wasm-metadata = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }


### PR DESCRIPTION
This is to avoid the need to add binary .o files (which are difficult to audit from a security perspective) to the .NET runtime repository.  I will open related PRs on the `wasm-tools` and `wasm-component-ld` repos to enable the latter to accept WIT files at link (and componentization) time.

Note that I've taken this opportunity to remove the cabi_realloc C file from the output, since we can rely on `wasi-libc` providing an implementation.