### PR TITLE
Support to parse WIT files from multiple paths

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -647,6 +647,12 @@
 ///
 ///     // Path to parse WIT and its dependencies from. Defaults to the `wit`
 ///     // folder adjacent to your `Cargo.toml`.
+///     //
+///     // This parameter also supports the form of a list, such as:
+///     // ["../path/to/wit1", "../path/to/wit2"]
+///     // Usually used in testing, our test suite may want to generate code
+///     // from wit files located in multiple paths within a single mod, and we
+///     // don't want to copy these files again.
 ///     path: "../path/to/wit",
 ///
 ///     // Enables passing "inline WIT". If specified this is the default

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -556,3 +556,19 @@ mod simple_with_option {
         });
     }
 }
+
+#[allow(unused)]
+mod multiple_paths {
+    wit_bindgen::generate!({
+        inline: r#"
+        package test:paths;
+
+        world test {
+            import paths:path1/test;
+            export paths:path2/test;
+        }
+        "#,
+        path: ["tests/wit/path1", "tests/wit/path2"],
+        generate_all,
+    });
+}

--- a/crates/rust/tests/wit/path1/world.wit
+++ b/crates/rust/tests/wit/path1/world.wit
@@ -1,0 +1,3 @@
+package paths:path1;
+
+interface test {}

--- a/crates/rust/tests/wit/path2/world.wit
+++ b/crates/rust/tests/wit/path2/world.wit
@@ -1,0 +1,3 @@
+package paths:path2;
+
+interface test {}


### PR DESCRIPTION
Background information reference: https://github.com/bytecodealliance/wasmtime/pull/8939#issuecomment-2225909824

This patch allows us to parse WIT files from multiple paths, which is often useful in testing. We can unify all the generated code into a single mod. For example, for Wasmtime's case, we can do it like this:

before:

```rust
wit_bindgen::generate!({
    world: "test-command",
    path: "../wasi/wit",
    generate_all,
});

pub mod config {
    wit_bindgen::generate!({
        path: "../wasi-runtime-config/wit",
        world: "wasi:config/imports",
    });
}

// use the generated code:

use test_programs::wasi::sockets;
use test_programs::config::wasi::config;
```

after:

```rust
wit_bindgen::generate!({
    inline: "
        package wasmtime:test;

        world test {
            include wasi:cli/imports@0.2.0;
            include wasi:config/imports@0.2.0-draft;
            import wasi:http/types@0.2.0;
            import wasi:http/outgoing-handler@0.2.0;
        }
    ",
    paths: ["../wasi/wit", "../wasi-runtime-config/wit"],
    generate_all,
});

// use the generated code:

use test_programs::wasi::sockets;
use test_programs::wasi::config;
```

I am not familiar with the whole process of wit parsing, so I am not sure if there will be any side effects of doing this. I have tested the wasmtime case locally and it does work.

cc @alexcrichton 