### PR TITLE
fix(markdown): update primary link to match behavior from #818

### DIFF
--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -43,7 +43,7 @@ impl WorldGenerator for Markdown {
         let world = &resolve.worlds[world];
         uwriteln!(
             self.src,
-            "# <a name=\"{}\">World {}</a>\n",
+            "# <a name=\"{}\"></a>World {}\n",
             world.name.to_snake_case(),
             world.name
         );


### PR DESCRIPTION
Just aligning the h1 output to match the rest of the "empty anchor before text" pattern for headings