### PR TITLE
make imported resource `THandle` struct and ctor public

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -1482,9 +1482,9 @@ impl InterfaceGenerator<'_> {
                     {access} class {upper_camel}: IDisposable {{
                         internal int Handle {{ get; set; }}
 
-                        internal readonly record struct THandle(int Handle);
+                        {access} readonly record struct THandle(int Handle);
 
-                        internal {upper_camel}(THandle handle) {{
+                        {access} {upper_camel}(THandle handle) {{
                             Handle = handle.Handle;
                         }}
 


### PR DESCRIPTION
Originally, I made these `internal` rather than `public` since they aren't meant to be used in application code.  However, that prevents an important use case: splitting the bindings across assemblies.

In particular, when targetting a world that includes exports, it's useful to put the generated types and imports in a reusable library, but we can't put the exports in that library since the application code should be providing the entry points.  This is analogous to how a CLI library might provide utilities for e.g. parsing command line options, but still leave it to the application to provide a `static int Main` function.

In the case of a world that includes one or more exports, we'll want to put the generated code for those exports in the application assembly and put everything else in the library.  However, the export code may need to be able to marshal raw resource handles into the appropriate object wrapper for that resource type, and that requires access to the `THandle` struct and corresponding constructor for that class.