### PR TITLE
crates/rust: remove unnecessary braces

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -727,7 +727,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str(&format!(
                     "if ptr.is_null()\n{{\n{alloc}::handle_alloc_error({layout});\n}}\nptr\n}}",
                 ));
-                self.push_str("else {{\n::core::ptr::null_mut()\n}};\n");
+                self.push_str("else {\n::core::ptr::null_mut()\n};\n");
                 self.push_str(&format!("for (i, e) in {vec}.into_iter().enumerate() {{\n",));
                 self.push_str(&format!("let base = {result}.add(i * {size});\n",));
                 self.push_str(&body);


### PR DESCRIPTION
I encountered the following warning during compilation:

```
warning: unnecessary braces around block return value
```

This patch removes the unnecessary braces:

```diff
} else {
-   { ::core::ptr::null_mut() }
+   ::core::ptr::null_mut()
};
```