### PR TITLE
update C# generator to match latest ILC package

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -692,31 +692,6 @@ impl WorldGenerator for CSharp {
         }
 
         if !self.opts.skip_support_files {
-            let cabi_relloc_src = r#"
-                #include <stdlib.h>
-
-                /* Done in C so we can avoid initializing the dotnet runtime and hence WASI libc */
-                /* It would be preferable to do this in C# but the constraints of cabi_realloc and the demands */
-                /* of WASI libc prevent us doing so. */
-                /* See https://github.com/bytecodealliance/wit-bindgen/issues/777  */
-                /* and https://github.com/WebAssembly/wasi-libc/issues/452 */
-                /* The component model `start` function might be an alternative to this depending on whether it */
-                /* has the same constraints as `cabi_realloc` */
-                __attribute__((__weak__, __export_name__("cabi_realloc")))
-                void *cabi_realloc(void *ptr, size_t old_size, size_t align, size_t new_size) {
-                    (void) old_size;
-                    if (new_size == 0) return (void*) align;
-                    void *ret = realloc(ptr, new_size);
-                    if (!ret) abort();
-                    return ret;
-                }
-            "#;
-
-            files.push(
-                &format!("{name}World_cabi_realloc.c"),
-                indent(cabi_relloc_src).as_bytes(),
-            );
-
             //TODO: This is currently needed for mono even if it's built as a library.
             if self.opts.runtime == CSharpRuntime::Mono {
                 files.push(

--- a/tests/runtime/main.rs
+++ b/tests/runtime/main.rs
@@ -749,25 +749,7 @@ fn tests(name: &str, dir_name: &str) -> Result<Vec<PathBuf>> {
                 panic!("failed to compile");
             }
 
-            // Translate the canonical ABI module into a component.
-
-            let module = fs::read(&wasm_filename).expect("failed to read wasm file");
-            let component = ComponentEncoder::default()
-                .module(module.as_slice())
-                .expect("pull custom sections from module")
-                .validate(true)
-                .adapter("wasi_snapshot_preview1", &wasi_adapter)
-                .expect("adapter failed to get loaded")
-                .realloc_via_memory_grow(true)
-                .encode()
-                .expect(&format!(
-                    "module {:?} can be translated to a component",
-                    out_wasm
-                ));
-            let component_path = out_wasm.with_extension("component.wasm");
-            fs::write(&component_path, component).expect("write component to disk");
-
-            result.push(component_path);
+            result.push(wasm_filename);
         }
     }
 


### PR DESCRIPTION
This also locks the ILC dependencies to a specific version to avoid future surprises.