### PR TITLE
Add world package name into custom section

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -744,7 +744,7 @@ macro_rules! __export_{world_name}_impl {{
     fn emit_custom_section(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        world_id: WorldId,
         section_suffix: &str,
         func_name: Option<&str>,
     ) {
@@ -755,11 +755,13 @@ macro_rules! __export_{world_name}_impl {{
         // concatenated to other custom sections by LLD by accident since LLD will
         // concatenate custom sections of the same name.
         let opts_suffix = self.opts.type_section_suffix.as_deref().unwrap_or("");
-        let world_name = &resolve.worlds[world].name;
+        let world = &resolve.worlds[world_id];
+        let world_name = &world.name;
+        let pkg = &resolve.packages[world.package.unwrap()].name;
         let version = env!("CARGO_PKG_VERSION");
         self.src.push_str(&format!(
             "#[link_section = \"component-type:wit-bindgen:{version}:\
-             {world_name}:{section_suffix}{opts_suffix}\"]\n"
+             {pkg}:{world_name}:{section_suffix}{opts_suffix}\"]\n"
         ));
 
         let mut producers = wasm_metadata::Producers::empty();
@@ -771,7 +773,7 @@ macro_rules! __export_{world_name}_impl {{
 
         let component_type = wit_component::metadata::encode(
             resolve,
-            world,
+            world_id,
             wit_component::StringEncoding::UTF8,
             Some(&producers),
         )

--- a/tests/runtime/type_section_suffix.rs
+++ b/tests/runtime/type_section_suffix.rs
@@ -7,6 +7,11 @@ use self::test::suffix::imports::Host;
 #[derive(Default)]
 pub struct MyFoo;
 
+impl RequiredExportsImports for MyFoo {
+    fn foo(&mut self) {}
+    fn bar(&mut self) {}
+}
+
 impl Host for MyFoo {
     fn foo(&mut self) {}
 }

--- a/tests/runtime/type_section_suffix/deps/a.wit
+++ b/tests/runtime/type_section_suffix/deps/a.wit
@@ -1,0 +1,5 @@
+package test:a ;
+
+world imports {
+  import foo: func();
+}

--- a/tests/runtime/type_section_suffix/deps/b.wit
+++ b/tests/runtime/type_section_suffix/deps/b.wit
@@ -1,0 +1,5 @@
+package test:b;
+
+world imports {
+  import bar: func();
+}

--- a/tests/runtime/type_section_suffix/wasm.rs
+++ b/tests/runtime/type_section_suffix/wasm.rs
@@ -22,11 +22,26 @@ mod b {
     });
 }
 
+mod c {
+    wit_bindgen::generate!({
+        world: "test:a/imports",
+        path: "../../tests/runtime/type_section_suffix",
+    });
+}
+mod d {
+    wit_bindgen::generate!({
+        world: "test:b/imports",
+        path: "../../tests/runtime/type_section_suffix",
+    });
+}
+
 struct Exports;
 
 impl Guest for Exports {
     fn run() {
         a::test::suffix::imports::foo();
         b::test::suffix::imports::foo();
+        c::foo();
+        d::bar();
     }
 }

--- a/tests/runtime/type_section_suffix/world.wit
+++ b/tests/runtime/type_section_suffix/world.wit
@@ -6,6 +6,8 @@ interface imports {
 
 world available-imports {
   import imports;
+  include test:a/imports;
+  include test:b/imports;
 }
 
 world required-exports {


### PR DESCRIPTION
This adds in the package name in addition to the world name in the custom section for Rust code that has the component type information within it. This helps prevent clashes between worlds of the same name.

Closes #975