### PR TITLE
Allow rust enumerations to be ordered

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1560,7 +1560,7 @@ macro_rules! {macro_name} {{
             .cloned()
             .collect();
         derives.extend(
-            ["Clone", "Copy", "PartialEq", "Eq"]
+            ["Clone", "Copy", "PartialEq", "Eq", "PartialOrd", "Ord"]
                 .into_iter()
                 .map(|s| s.to_string()),
         );


### PR DESCRIPTION
Currently enumerations in the generated rust bindings are not ordered, and can only be compared by equality.  This patch adds the `PartialOrd` and `Ord` derives to generated enums.

I'm aware that I can add these using additional_derives for my use case, but that adds it for all types, not just enumerations, and it's generally not appropriate for structs in many cases.