### PR TITLE
Add stddef.h include in C headers

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -416,6 +416,7 @@ impl WorldGenerator for C {
 
         uwriteln!(h_str, "#include <stdint.h>");
         uwriteln!(h_str, "#include <stdbool.h>");
+        uwriteln!(h_str, "#include <stddef.h>");
         for include in self.h_includes.iter() {
             uwriteln!(h_str, "#include {include}");
         }


### PR DESCRIPTION
`size_t` is used in the generated C headers, but is not guaranteed by the standard to be defined in either the `stdint.h` or `stdbool.h` headers that are unconditionally generated.

This patch adds an unconditional include to `stddef.h` to address compile issues on certain standard libraries.