### PR TITLE
Use stderr for diagnostics

### DIFF
--- a/src/bin/wit-bindgen.rs
+++ b/src/bin/wit-bindgen.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
             Some(path) => path.join(name),
             None => name.into(),
         };
-        println!("Generating {:?}", dst);
+        eprintln!("Generating {:?}", dst);
 
         if opt.check {
             let prev = std::fs::read(&dst).with_context(|| format!("failed to read {:?}", dst))?;


### PR DESCRIPTION
I would like to propose switching the diagnostics output (i.e. which file is being generated) to be sent to stderr instead of stdout.

This would have the benefit of making it any other programs that embed `wit-bindgen` not have to worry about redirecting the diagnostics output to stderr instead so as to prevent their own program output from including things from `wit-bindgen` unless they explicitly choose to do so by including them from stderr.