### PR TITLE
MoonBit feature updates

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -534,7 +534,10 @@ impl WorldGenerator for MoonBit {
         }
 
         // Export FFI Utils
-        files.push(&format!("{FFI_DIR}/top.mbt"), FFI.as_bytes());
+        let mut body = Source::default();
+        wit_bindgen_core::generated_preamble(&mut body, version);
+        body.push_str(FFI);
+        files.push(&format!("{FFI_DIR}/top.mbt"), indent(&body).as_bytes());
         files.push(&format!("{FFI_DIR}/moon.pkg.json"), "{}".as_bytes());
 
         // Export project files
@@ -547,6 +550,7 @@ impl WorldGenerator for MoonBit {
         let ffi_qualifier = gen.qualify_package(&FFI_DIR.to_string());
 
         let mut body = Source::default();
+        wit_bindgen_core::generated_preamble(&mut body, version);
         uwriteln!(
             &mut body,
             "

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -12,6 +12,7 @@ macro_rules! codegen_test {
                     wit_bindgen_moonbit::Opts {
                         derive_show: true,
                         derive_eq: true,
+                        derive_error: true,
                         ignore_stub: false,
                     }
                     .build()


### PR DESCRIPTION
This PR contains 
- feature: experimental export resource support
- feature: `--derive-error` option to treat resource/variants/enums whose names containing `Error` as error type to profit from the error handling mechanism of MoonBit
- fix: update the `to_int` and `to_uint` to `reinterpret_as_int` and `reinterpret_as_uint` as per core library changes (https://github.com/moonbitlang/core/pull/948 https://github.com/moonbitlang/core/pull/947)