### PR TITLE
Also add pull-requests permission to release CI

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release_process:


### PR DESCRIPTION
This wasn't needed in the Wasmtime repository but it's needed here because a custom token is not used.