### PR TITLE
fix(moonbit): eliminate warning and fix ownership

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -111,34 +111,34 @@ extern "wasm" fn copy_inline(dest : Int, src : Int, len : Int) =
   #|(func (param i32) (param i32) (param i32) local.get 0 local.get 1 local.get 2 memory.copy)
 
 pub extern "wasm" fn str2ptr(str : String) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn ptr2str(ptr : Int) -> String =
   #|(func (param i32) (result i32) local.get 0 i32.const 4 i32.sub i32.const 243 i32.store8 local.get 0 i32.const 8 i32.sub)
 
 pub extern "wasm" fn bytes2ptr(bytes : Bytes) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn ptr2bytes(ptr : Int) -> Bytes =
   #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.sub)
 
 pub extern "wasm" fn uint_array2ptr(array : FixedArray[UInt]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn uint64_array2ptr(array : FixedArray[UInt64]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn int_array2ptr(array : FixedArray[Int]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn int64_array2ptr(array : FixedArray[Int64]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn float_array2ptr(array : FixedArray[Float]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn double_array2ptr(array : FixedArray[Double]) -> Int =
-  #|(func (param i32) (result i32) local.get 0 call $moonbit.decref local.get 0 i32.const 8 i32.add)
+  #|(func (param i32) (result i32) local.get 0 i32.const 8 i32.add)
 
 pub extern "wasm" fn ptr2uint_array(ptr : Int) -> FixedArray[UInt] =
   #|(func (param i32) (result i32) local.get 0 i32.const 4 i32.sub i32.const 241 i32.store8 local.get 0 i32.const 8 i32.sub)

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -2764,7 +2764,7 @@ impl ToMoonBitIdent for str {
             "continue" | "for" | "match" | "if" | "pub" | "priv" | "readonly" | "break"
             | "raise" | "try" | "except" | "catch" | "else" | "enum" | "struct" | "type"
             | "trait" | "return" | "let" | "mut" | "while" | "loop" | "extern" | "with"
-            | "throw" | "init" | "main" | "test" | "in" => {
+            | "throw" | "init" | "main" | "test" | "in" | "guard" => {
                 format!("{self}_")
             }
             _ => self.to_snake_case(),

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -31,6 +31,7 @@ fn verify(dir: &Path, _name: &str) {
     cmd.arg("check")
         .arg("--target")
         .arg("wasm")
+        .arg("--deny-warn")
         .arg("--source-dir")
         .arg(dir);
 

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -36,4 +36,12 @@ fn verify(dir: &Path, _name: &str) {
         .arg(dir);
 
     test_helpers::run_command(&mut cmd);
+    let mut cmd = Command::new("moon");
+    cmd.arg("build")
+        .arg("--target")
+        .arg("wasm")
+        .arg("--source-dir")
+        .arg(dir);
+
+    test_helpers::run_command(&mut cmd);
 }


### PR DESCRIPTION
This PR eliminates all the warnings of the generated code and use `--deny-warn` option in test to enforce this.

This PR also adds build process to the test instead of just checking.

This PR fixes an issue with ownership, which may occur when exporting a data structure and being freed later.