### PR TITLE
temporarily remove moonbit from CI language matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        lang: [c, rust, teavm-java, go, csharp, moonbit]
+        # moonbit removed from language matrix for now - causing CI failures
+        lang: [c, rust, teavm-java, go, csharp]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The moonbit CI job seems to be broken (https://github.com/bytecodealliance/wit-bindgen/actions/runs/11407779008/job/31744559397) due to some change to the compiler. This PR disables the CI jobs temporarily. Maybe when we re-enable it, we should pin a compiler version?