### PR TITLE
fix: MoonBit update and refactor organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,19 +384,26 @@ wasm-tools validate main.component.wasm --features component-model
 MoonBit can be compiled to WebAssembly using [its toolchain](https://moonbitlang.com/download):
 
 ```sh
-moon build --target wasm # -g to keep symbols
+moon build --target wasm # --debug to keep symbols
 ```
 
-The generarted core wasm will be found under `target/wasm/release/build/gen/gen.wasm` by default. Then you can use `wasm-tools` to componentize the module:
+The generated core wasm will be found under `target/wasm/release/build/gen/gen.wasm` by default. Then you can use `wasm-tools` to componentize the module:
 
 ```
 wasm-tools component embed wit target/wasm/release/build/gen/gen.wasm -o target/gen.wasm
 wasm-tools component new target/gen.wasm -o target/gen.component.wasm
 ```
 
-When using `wit-bindgen moonbit`, you may use `--derive-show` or `--derive-eq` to derive `Show` or `Eq` for all types.
+You may use `--gen-dir` to specify which package should be responsible for the exportation. The default is `gen` as mentioned above.
+This can be useful having one project that exports multiple worlds.
+
+When using `wit-bindgen moonbit`, you may use `--derive-show` or `--derive-eq` to derive `Show` or `Eq` traits for all types.
+You may also use `--derive-error`, which will make types containing `Error` as error types in MoonBit.
 
 You will find the files to be modified with the name `**/stub.mbt`.
+To avoid touching the files during regeneration (including `moon.pkg.json` or `moon.mod.json`) you may use `--ignore-stub`.
+
+/!\ MoonBit is still evolving, so please check out the [Weekly Updates](https://www.moonbitlang.com/weekly-updates/) for any breaking changes or deprecations.
 
 ### Guest: Other Languages
 

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -2784,7 +2784,7 @@ impl ToMoonBitIdent for str {
             "continue" | "for" | "match" | "if" | "pub" | "priv" | "readonly" | "break"
             | "raise" | "try" | "except" | "catch" | "else" | "enum" | "struct" | "type"
             | "trait" | "return" | "let" | "mut" | "while" | "loop" | "extern" | "with"
-            | "throw" | "init" | "main" | "test" | "in" | "guard" => {
+            | "throw" | "init" | "main" | "test" | "in" | "guard" | "typealias" => {
                 format!("{self}_")
             }
             _ => self.to_snake_case(),
@@ -2802,7 +2802,7 @@ impl ToMoonBitTypeIdent for str {
         match self.to_upper_camel_case().as_str() {
             type_name @ ("Bool" | "Byte" | "Int" | "Int64" | "UInt" | "UInt64" | "Float"
             | "Double" | "Error" | "Buffer" | "Bytes" | "Array" | "FixedArray"
-            | "Map" | "String" | "Option" | "Result" | "Char") => {
+            | "Map" | "String" | "Option" | "Result" | "Char" | "Json") => {
                 format!("{type_name}_")
             }
             type_name => type_name.to_owned(),

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -537,8 +537,8 @@ impl WorldGenerator for MoonBit {
             files.push(&format!("{directory}/top.mbt"), indent(&src).as_bytes());
             if !self.opts.ignore_stub {
                 files.push(&format!("{directory}/stub.mbt"), indent(&stub).as_bytes());
+                generate_pkg_definition(&name, files);
             }
-            generate_pkg_definition(&name, files);
             generate_ffi(directory, fragments, files);
         }
 

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -14,6 +14,7 @@ macro_rules! codegen_test {
                         derive_eq: true,
                         derive_error: true,
                         ignore_stub: false,
+                        gen_dir: "gen".to_string(),
                     }
                     .build()
                     .generate(resolve, world, files)


### PR DESCRIPTION
This PR contains 

- (BREAKING CHANGE) a reorganize in the generated directory structure, make it more convenient to have a project that exports multiple worlds.
- some language updates according to the MoonBit standard library API changes.
- ci change according to #1068 
