### PR TITLE
Avoid emitting redundant `#[allow(dead_code)]` directives.

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -439,7 +439,6 @@ macro_rules! {macro_name} {{
         };
         let module = format!(
             "\
-                #[allow(dead_code, clippy::all)]
                 pub mod {snake} {{
                     {used_static}
                     {module}


### PR DESCRIPTION
Only emit `#[allow(dead_code)]` on top-level modules, and emit `#[rustfmt::skip]` on all top-level modules.