### PR TITLE
Rust: Add interface doc comments.

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -422,8 +422,13 @@ macro_rules! {macro_name} {{
         (snake, module_path)
     }
 
-    pub fn finish_append_submodule(mut self, snake: &str, module_path: Vec<String>) {
+    pub fn finish_append_submodule(mut self, snake: &str, module_path: Vec<String>, docs: &Docs) {
         let module = self.finish();
+
+        self.rustdoc(docs);
+        let docs = mem::take(&mut self.src).to_string();
+        let docs = docs.trim_end();
+
         let path_to_root = self.path_to_root();
         let used_static = if self.gen.opts.disable_custom_section_link_helpers {
             String::new()
@@ -439,6 +444,7 @@ macro_rules! {macro_name} {{
         };
         let module = format!(
             "\
+                {docs}
                 pub mod {snake} {{
                     {used_static}
                     {module}

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -984,7 +984,9 @@ impl WorldGenerator for RustWasm {
 
         gen.generate_imports(resolve.interfaces[id].functions.values());
 
-        gen.finish_append_submodule(&snake, module_path);
+        let docs = &resolve.interfaces[id].docs;
+
+        gen.finish_append_submodule(&snake, module_path, docs);
 
         Ok(())
     }
@@ -1022,7 +1024,10 @@ impl WorldGenerator for RustWasm {
         gen.types(id);
         let macro_name =
             gen.generate_exports(Some((id, name)), resolve.interfaces[id].functions.values())?;
-        gen.finish_append_submodule(&snake, module_path);
+
+        let docs = &resolve.interfaces[id].docs;
+
+        gen.finish_append_submodule(&snake, module_path, docs);
         self.export_macros
             .push((macro_name, self.interface_names[&id].path.clone()));
 


### PR DESCRIPTION
Add interface documentation as doc comments for the generated Rust modules.