### PR TITLE
[C#] Add another element of type f32 to the variant test

### DIFF
--- a/crates/csharp/src/lib.rs
+++ b/crates/csharp/src/lib.rs
@@ -3227,7 +3227,7 @@ fn dotnet_aligned_array(array_size: usize, required_alignment: usize) -> (usize,
 
 fn perform_cast(op: &String, cast: &Bitcast) -> String {
     match cast {
-        Bitcast::I32ToF32 => format!("BitConverter.Int32BitsToSingle({op})"),
+        Bitcast::I32ToF32 => format!("BitConverter.Int32BitsToSingle((int){op})"),
         Bitcast::I64ToF32 => format!("BitConverter.Int32BitsToSingle((int){op})"),
         Bitcast::F32ToI32 => format!("BitConverter.SingleToInt32Bits({op})"),
         Bitcast::F32ToI64 => format!("BitConverter.SingleToInt32Bits({op})"),

--- a/tests/codegen/variants.wit
+++ b/tests/codegen/variants.wit
@@ -21,6 +21,7 @@ interface variants {
       e(empty),
       f,
       g(u32),
+      h(f32),
   }
 
   v1-arg: func(x: v1);


### PR DESCRIPTION
This PR adds another case of a `f32` type to the variant to exercise more conversion code in the c# codegen.

Fixes #1092 