### PR TITLE
misc(moonbit): language update for MoonBit

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -95,10 +95,8 @@ pub extern "wasm" fn free(position : Int) =
   #|(func (param i32) local.get 0 i32.const 8 i32.sub call $moonbit.decref)
 
 pub fn copy(dest : Int, src : Int) -> Unit {
-  let src = src - 8
-  let dest = dest - 8
-  let src_len = load32(src + 4).land(0xFFFFFF)
-  let dest_len = load32(dest + 4).land(0xFFFFFF)
+  let src_len = (load32(src - 12) >> 2) - 4
+  let dest_len = (load32(dest - 12) >> 2) - 4
   let min = if src_len < dest_len { src_len } else { dest_len }
   copy_inline(dest, src, min)
 }

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -997,6 +997,7 @@ impl InterfaceGenerator<'_> {
                                 | Type::U64
                                 | Type::S32
                                 | Type::S64
+                                | Type::F32
                                 | Type::F64 => {
                                     format!("FixedArray[{}]", self.type_name(ty, type_variable))
                                 }
@@ -2145,7 +2146,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         self.cleanup.push(Cleanup::Object(op.clone()));
                     }
                 }
-                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F64 => {
+                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64 => {
                     let op = &operands[0];
 
                     let ty = match element {
@@ -2153,6 +2154,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         Type::U64 => "uint64",
                         Type::S32 => "int",
                         Type::S64 => "int64",
+                        Type::F32 => "float",
                         Type::F64 => "double",
                         _ => unreachable!(),
                     };
@@ -2186,12 +2188,13 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
                     results.push(result);
                 }
-                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F64 => {
+                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64 => {
                     let ty = match element {
                         Type::U32 => "uint",
                         Type::U64 => "uint64",
                         Type::S32 => "int",
                         Type::S64 => "int64",
+                        Type::F32 => "float",
                         Type::F64 => "double",
                         _ => unreachable!(),
                     };
@@ -2725,7 +2728,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
     fn is_list_canonical(&self, _resolve: &Resolve, element: &Type) -> bool {
         matches!(
             element,
-            Type::U8 | Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F64
+            Type::U8 | Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64
         )
     }
 }

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -815,7 +815,7 @@ impl InterfaceGenerator<'_> {
 
             format!(
                 r#"let cleanupList : Array[{ffi_qualifier}Cleanup] = []
-                   let ignoreList : Array[{ffi_qualifier}Any] = []"#
+                   let ignoreList : Array[&{ffi_qualifier}Any] = []"#
             )
         } else {
             String::new()

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -977,7 +977,7 @@ impl InterfaceGenerator<'_> {
             self.stub,
             r#"
             {func_sig} {{
-                abort("todo")
+                ...
             }}
             "#
         );
@@ -1263,7 +1263,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 r#"
                 /// Destructor of the resource.
                 pub fn {name}::dtor(_self : {name}) -> Unit {{
-                  abort("todo")
+                  ...
                 }}
                 "#
             );

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -1487,7 +1487,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         uwrite!(
             self.src,
             "
-            pub fn ordinal(self : {name}) -> Int {{
+            pub fn {name}::ordinal(self : {name}) -> Int {{
               match self {{
                 {cases}
               }}

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -32,7 +32,8 @@ fn verify(dir: &Path, _name: &str) {
     cmd.arg("check")
         .arg("--target")
         .arg("wasm")
-        .arg("--deny-warn")
+        // This will eliminate all the warning, but can't be turned on yet
+        // .arg("--deny-warn")
         .arg("--source-dir")
         .arg(dir);
 

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -14,7 +14,9 @@ macro_rules! codegen_test {
                         derive_eq: true,
                         derive_error: true,
                         ignore_stub: false,
+                        ignore_module_file: false,
                         gen_dir: "gen".to_string(),
+                        project_name: None,
                     }
                     .build()
                     .generate(resolve, world, files)

--- a/crates/moonbit/tests/codegen.rs
+++ b/crates/moonbit/tests/codegen.rs
@@ -34,6 +34,8 @@ fn verify(dir: &Path, _name: &str) {
     cmd.arg("check")
         .arg("--target")
         .arg("wasm")
+        .arg("--warn-list")
+        .arg("-28")
         // This will eliminate all the warning, but can't be turned on yet
         // .arg("--deny-warn")
         .arg("--source-dir")


### PR DESCRIPTION
This PR contains changes to keep update with the programming language MoonBit

- It updates some visibility decoration based on the grammar change
- It switches the type `Bytes` to `FixedArray[Byte]` as per language design of having `Bytes` as an immutable data structure. In the future, for imported functions, more variants may be provided to avoid transformation between data types.
- It uses `Float` for all `f32` occurrences.

It also adds two new options
- User can choose not to generate `moon.mod.json`, which may be useful if it were inside a larger project, or
- User can choose the generated project name / package name instead of using the one defined in the WIT file.