### PR TITLE
[Rust] Look through typedefs to pass borrowed strings as `&str`

### DIFF
--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -82,6 +82,58 @@ mod strings {
     }
 }
 
+/// Like `strings` but with a type alias.
+mod aliased_strings {
+    wit_bindgen::generate!({
+        inline: "
+            package my:strings;
+
+            world not-used-name {
+                import cat: interface {
+                    type my-string = string;
+                    foo: func(x: my-string);
+                    bar: func() -> my-string;
+                }
+            }
+        ",
+    });
+
+    #[allow(dead_code)]
+    fn test() {
+        // Test the argument is `&str`.
+        cat::foo("hello");
+
+        // Test the return type is `String`.
+        let _t: String = cat::bar();
+    }
+}
+
+/// Like `aliased_string` but with lists instead of strings.
+mod aliased_lists {
+    wit_bindgen::generate!({
+        inline: "
+            package my:strings;
+
+            world not-used-name {
+                import cat: interface {
+                    type my-list = list<u8>;
+                    foo: func(x: my-list);
+                    bar: func() -> my-list;
+                }
+            }
+        ",
+    });
+
+    #[allow(dead_code)]
+    fn test() {
+        // Test the argument is `&[u8]`.
+        cat::foo(b"hello");
+
+        // Test the return type is `Vec<u8>`.
+        let _t: Vec<u8> = cat::bar();
+    }
+}
+
 mod run_ctors_once_workaround {
     wit_bindgen::generate!({
         inline: "
@@ -96,7 +148,7 @@ mod run_ctors_once_workaround {
     });
 }
 
-/// Like `strings` but with raw_strings`.
+/// Like `strings` but with `raw_strings`.
 mod raw_strings {
     wit_bindgen::generate!({
         inline: "


### PR DESCRIPTION
wit-bindgen already knows to special-case passing strings by reference and pass them as `&str` instead of naively passing them as `&String` and requiring callers to have owned `Strings`. Implement this behavior for type aliases of strings as well, so that in code like this:
```wit
type my-string = string;
foo: func(x: my-string);
```
the argument is `&str` instead of `&MyString` which is effectively `&String`. And similar for lists.

This comes up in several functions in wasi-http; for example, in the bindings for the `Fields::append` function, it enables this change:

```diff
@@ -5075,8 +5075,8 @@ pub mod wasi {
                 /// `field-value` are syntactically invalid.
                 pub fn append(
                     &self,
-                    name: &FieldName,
-                    value: &FieldValue,
+                    name: &str,
+                    value: &[u8],
                 ) -> Result<(), HeaderError> {
                     unsafe {
                         #[repr(align(1))]
```

where `FieldName` and `FieldValue` are defined as:
```wit
            pub type FieldKey = _rt::String;
            pub type FieldName = FieldKey;
            pub type FieldValue = _rt::Vec<u8>;
```