### PR TITLE
[C] Prefex function export names with `exports_`.

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -893,7 +893,12 @@ pub fn c_func_name(
             !in_import,
             renamed_interfaces,
         )),
-        None => name.push_str(&world.to_snake_case()),
+        None => {
+            if !in_import {
+                name.push_str("exports_");
+            }
+            name.push_str(&world.to_snake_case());
+        }
     }
     name.push_str("_");
     name.push_str(&func.name.to_snake_case().replace('.', "_"));

--- a/tests/codegen/import-export-same-func.wit
+++ b/tests/codegen/import-export-same-func.wit
@@ -1,0 +1,6 @@
+package green:blue;
+
+world my-world {
+  import purple: func();
+  export purple: func();
+}

--- a/tests/runtime/flavorful/wasm.c
+++ b/tests/runtime/flavorful/wasm.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-void flavorful_test_imports() {
+void exports_flavorful_test_imports() {
   {
     test_flavorful_test_list_in_record1_t a;
     flavorful_string_set(&a.a, "list_in_record1");

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -7,11 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-uint32_t lists_allocated_bytes(void) {
+uint32_t exports_lists_allocated_bytes(void) {
   return 0;
 }
 
-void lists_test_imports() {
+void exports_lists_test_imports() {
   {
     uint8_t list[] = {};
     lists_list_u8_t a;

--- a/tests/runtime/many_arguments/wasm.c
+++ b/tests/runtime/many_arguments/wasm.c
@@ -3,7 +3,7 @@
 #include <limits.h>
 #include <math.h>
 
-void many_arguments_many_arguments(
+void exports_many_arguments_many_arguments(
     uint64_t a1,
     uint64_t a2,
     uint64_t a3,

--- a/tests/runtime/numbers/wasm.c
+++ b/tests/runtime/numbers/wasm.c
@@ -58,7 +58,7 @@ uint32_t exports_test_numbers_test_get_scalar(void) {
 }
 
 
-void numbers_test_imports() {
+void exports_numbers_test_imports() {
   assert(test_numbers_test_roundtrip_u8(1) == 1);
   assert(test_numbers_test_roundtrip_u8(0) == 0);
   assert(test_numbers_test_roundtrip_u8(UCHAR_MAX) == UCHAR_MAX);

--- a/tests/runtime/records/wasm.c
+++ b/tests/runtime/records/wasm.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <records.h>
 
-void records_test_imports() {
+void exports_records_test_imports() {
   {
     records_tuple2_u8_u16_t ret;
     test_records_test_multiple_results(&ret);

--- a/tests/runtime/resource_borrow_simple/wasm.c
+++ b/tests/runtime/resource_borrow_simple/wasm.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <resource_borrow_simple.h>
 
-void resource_borrow_simple_test_imports(void) {
+void exports_resource_borrow_simple_test_imports(void) {
     resource_borrow_simple_own_r_t r = resource_borrow_simple_constructor_r();
     resource_borrow_simple_borrow_r_t b = resource_borrow_simple_borrow_r(r);
     resource_borrow_simple_test(b);

--- a/tests/runtime/resource_import_and_export/wasm.c
+++ b/tests/runtime/resource_import_and_export/wasm.c
@@ -12,7 +12,7 @@ struct exports_test_resource_import_and_export_test_thing_t {
 };
 
 resource_import_and_export_own_thing_t
-resource_import_and_export_toplevel_export(resource_import_and_export_own_thing_t a) {
+exports_resource_import_and_export_toplevel_export(resource_import_and_export_own_thing_t a) {
   return resource_import_and_export_toplevel_import(a);
 }
 

--- a/tests/runtime/smoke/wasm.c
+++ b/tests/runtime/smoke/wasm.c
@@ -1,7 +1,7 @@
 #include <smoke.h>
 #include <stdio.h>
 
-void smoke_thunk() {
+void exports_smoke_thunk() {
   test_smoke_imports_thunk();
 
   printf("howdy\n");

--- a/tests/runtime/strings/wasm_utf16.c
+++ b/tests/runtime/strings/wasm_utf16.c
@@ -14,7 +14,7 @@ void assert_str(strings_string_t* str, const char16_t* expected) {
   assert(memcmp(str->ptr, expected, expected_len * 2) == 0);
 }
 
-void strings_test_imports() {
+void exports_strings_test_imports() {
   strings_string_t str1;
   strings_string_set(&str1, u"latin utf16");
   test_strings_imports_take_basic(&str1);
@@ -25,11 +25,11 @@ void strings_test_imports() {
   strings_string_free(&str2);
 }
 
-void strings_return_empty(strings_string_t *ret) {
+void exports_strings_return_empty(strings_string_t *ret) {
   strings_string_dup(ret, u""); // Exercise cabi_realloc new_size = 0
 }
 
-void strings_roundtrip(strings_string_t *str, strings_string_t *ret) {
+void exports_strings_roundtrip(strings_string_t *str, strings_string_t *ret) {
   assert(str->len > 0);
   ret->len = str->len;
   ret->ptr = (uint16_t *) malloc(ret->len * 2);

--- a/tests/runtime/variants/wasm.c
+++ b/tests/runtime/variants/wasm.c
@@ -2,7 +2,7 @@
 #include <variants.h>
 #include <stddef.h>
 
-void variants_test_imports() {
+void exports_variants_test_imports() {
   {
     float a = 1;
     uint8_t r;


### PR DESCRIPTION
In the C bindings, prefix exported function names with `exports_` so that a world that imports and exports the same function can do so without collisions.

For example, with this WIT:

```wit
package green:blue;

world my-world {
  import purple: func();
  export purple: func();
}
```wit

This fixes a wit-bindgen panic with:

```
duplicate symbols: "name `my_world_purple` already defined"
```