### PR TITLE
C#: make keywords static to avoid allocations

### DIFF
--- a/crates/csharp/src/csharp_ident.rs
+++ b/crates/csharp/src/csharp_ident.rs
@@ -1,15 +1,15 @@
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
 pub(crate) trait ToCSharpIdent: ToOwned {
-    fn csharp_keywords() -> Vec<&'static str>;
+    fn csharp_keywords() -> &'static [&'static str];
     fn to_csharp_ident(&self) -> Self::Owned;
     fn to_csharp_ident_upper(&self) -> Self::Owned;
 }
 
 impl ToCSharpIdent for str {
     // Source: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
-    fn csharp_keywords() -> Vec<&'static str> {
-        vec![
+    fn csharp_keywords() ->  &'static [&'static str] {
+        static CSHARP_KEY_WORDS: &[&str] = &[
             "abstract",
             "as",
             "base",
@@ -87,7 +87,8 @@ impl ToCSharpIdent for str {
             "void",
             "volatile",
             "while",
-        ]
+        ];
+        CSHARP_KEY_WORDS
     }
 
     fn to_csharp_ident(&self) -> String {

--- a/crates/csharp/src/csharp_ident.rs
+++ b/crates/csharp/src/csharp_ident.rs
@@ -8,7 +8,7 @@ pub(crate) trait ToCSharpIdent: ToOwned {
 
 impl ToCSharpIdent for str {
     // Source: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
-    fn csharp_keywords() ->  &'static [&'static str] {
+    fn csharp_keywords() -> &'static [&'static str] {
         static CSHARP_KEY_WORDS: &[&str] = &[
             "abstract",
             "as",

--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -929,7 +929,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         1 => {
                             let mut payload_is_void = false;
                             let mut previous = operands[0].clone();
-                            let mut vars: Vec::<(String, Option<String>)> = Vec::with_capacity(self.results.len());
+                            let mut vars: Vec<(String, Option<String>)> = Vec::with_capacity(self.results.len());
                             if let Direction::Import = self.interface_gen.direction {
                                 for ty in &self.results {
                                     let tmp = self.locals.tmp("tmp");
@@ -1132,7 +1132,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 );
                 self.fixed = self.fixed + 1;
 
-                return format!("{ptr}");
+                format!("{ptr}")
             }
             Direction::Export => {
                 self.interface_gen.csharp_gen.return_area_size =
@@ -1148,7 +1148,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 );
                 self.interface_gen.csharp_gen.needs_export_return_area = true;
 
-                return format!("{ptr}");
+                format!("{ptr}")
             }
         }
     }
@@ -1183,8 +1183,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
         self.blocks.push(Block {
             body: mem::replace(&mut self.src, body),
             results: mem::take(operands),
-            element: element,
-            base: base,
+            element,
+            base,
         });
     }
 

--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -32,7 +32,7 @@ pub(crate) struct InterfaceTypeAndFragments {
 impl InterfaceTypeAndFragments {
     pub(crate) fn new(is_export: bool) -> Self {
         InterfaceTypeAndFragments {
-            is_export: is_export,
+            is_export,
             interface_fragments: Vec::<InterfaceFragment>::new(),
         }
     }

--- a/crates/csharp/src/world_generator.rs
+++ b/crates/csharp/src/world_generator.rs
@@ -825,18 +825,10 @@ enum Stubs<'a> {
 // so for byte it would always use 1 regardless of the "Pack".
 pub fn dotnet_aligned_array(array_size: usize, required_alignment: usize) -> (usize, String) {
     match required_alignment {
-        1 => {
-            (array_size, "byte".to_owned())
-        }
-        2 => {
-            ((array_size + 1) / 2, "ushort".to_owned())
-        }
-        4 => {
-            ((array_size + 3) / 4, "uint".to_owned())
-        }
-        8 => {
-            ((array_size + 7) / 8, "ulong".to_owned())
-        }
+        1 => (array_size, "byte".to_owned()),
+        2 => ((array_size + 1) / 2, "ushort".to_owned()),
+        4 => ((array_size + 3) / 4, "uint".to_owned()),
+        8 => ((array_size + 7) / 8, "ulong".to_owned()),
         _ => todo!("unsupported return_area_align {}", required_alignment),
     }
 }

--- a/crates/csharp/src/world_generator.rs
+++ b/crates/csharp/src/world_generator.rs
@@ -660,7 +660,7 @@ impl WorldGenerator for CSharp {
             //TODO: This is currently needed for mono even if it's built as a library.
             if self.opts.runtime == CSharpRuntime::Mono {
                 files.push(
-                    &format!("MonoEntrypoint.cs",),
+                    &"MonoEntrypoint.cs".to_string(),
                     indent(&format!(
                         r#"
                         {access} class MonoEntrypoint() {{
@@ -826,16 +826,16 @@ enum Stubs<'a> {
 pub fn dotnet_aligned_array(array_size: usize, required_alignment: usize) -> (usize, String) {
     match required_alignment {
         1 => {
-            return (array_size, "byte".to_owned());
+            (array_size, "byte".to_owned())
         }
         2 => {
-            return ((array_size + 1) / 2, "ushort".to_owned());
+            ((array_size + 1) / 2, "ushort".to_owned())
         }
         4 => {
-            return ((array_size + 3) / 4, "uint".to_owned());
+            ((array_size + 3) / 4, "uint".to_owned())
         }
         8 => {
-            return ((array_size + 7) / 8, "ulong".to_owned());
+            ((array_size + 7) / 8, "ulong".to_owned())
         }
         _ => todo!("unsupported return_area_align {}", required_alignment),
     }


### PR DESCRIPTION
follow up to  https://github.com/bytecodealliance/wit-bindgen/pull/1110#discussion_r1893225142

Also a few other minor clean ups