### PR TITLE
Fix mismatched tuple ABIs in Rust

### DIFF
--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -30,6 +30,9 @@ pub struct TypeInfo {
     /// Whether this type (transitively) has a list (or string).
     pub has_list: bool,
 
+    /// Whether this type (transitively) has a tuple.
+    pub has_tuple: bool,
+
     /// Whether this type (transitively) has a resource (or handle).
     pub has_resource: bool,
 
@@ -46,6 +49,7 @@ impl std::ops::BitOrAssign for TypeInfo {
         self.owned |= rhs.owned;
         self.error |= rhs.error;
         self.has_list |= rhs.has_list;
+        self.has_tuple |= rhs.has_tuple;
         self.has_resource |= rhs.has_resource;
         self.has_borrow_handle |= rhs.has_borrow_handle;
         self.has_own_handle |= rhs.has_own_handle;
@@ -171,6 +175,7 @@ impl Types {
                 for ty in t.types.iter() {
                     info |= self.type_info(resolve, ty);
                 }
+                info.has_tuple = true;
             }
             TypeDefKind::Flags(_) => {}
             TypeDefKind::Enum(_) => {}

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -292,7 +292,12 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             return false;
         }
         match ty {
-            Type::Id(id) => !self.gen.gen.types.get(*id).has_resource,
+            // Note that tuples in Rust are not ABI-compatible with component
+            // model tuples, so those are exempted here from canonical lists.
+            Type::Id(id) => {
+                let info = self.gen.gen.types.get(*id);
+                !info.has_resource && !info.has_tuple
+            }
             _ => true,
         }
     }

--- a/tests/runtime/lists.rs
+++ b/tests/runtime/lists.rs
@@ -47,6 +47,10 @@ impl test::lists::test::Host for MyImports {
         assert_eq!(ptr[1][0], "baz");
     }
 
+    fn list_param5(&mut self, ptr: Vec<(u8, u32, u8)>) {
+        assert_eq!(ptr, [(1, 2, 3), (4, 5, 6)]);
+    }
+
     fn list_result(&mut self) -> Vec<u8> {
         vec![1, 2, 3, 4, 5]
     }

--- a/tests/runtime/lists/wasm.c
+++ b/tests/runtime/lists/wasm.c
@@ -79,6 +79,20 @@ void exports_lists_test_imports() {
   }
 
   {
+    lists_tuple3_u8_u32_u8_t data[2];
+    data[0].f0 = 1;
+    data[0].f1 = 2;
+    data[0].f2 = 3;
+    data[1].f0 = 4;
+    data[1].f1 = 5;
+    data[1].f2 = 6;
+    lists_list_tuple3_u8_u32_u8_t a;
+    a.len = 2;
+    a.ptr = data;
+    test_lists_test_list_param5(&a);
+  }
+
+  {
     lists_list_u8_t a;
     test_lists_test_list_result(&a);
     assert(a.len == 5);
@@ -299,6 +313,17 @@ void exports_test_lists_test_list_param4(lists_list_list_string_t *a) {
   assert(a->ptr[1].ptr[0].ptr[2] == 'z');
 
   lists_list_list_string_free(a);
+}
+
+void exports_test_lists_test_list_param5(lists_list_tuple3_u8_u32_u8_t *a) {
+  assert(a->len == 2);
+  assert(a->ptr[0].f0 == 1);
+  assert(a->ptr[0].f1 == 2);
+  assert(a->ptr[0].f2 == 3);
+  assert(a->ptr[1].f0 == 4);
+  assert(a->ptr[1].f1 == 5);
+  assert(a->ptr[1].f2 == 6);
+  lists_list_tuple3_u8_u32_u8_free(a);
 }
 
 void exports_test_lists_test_list_result(lists_list_u8_t *ret0) {

--- a/tests/runtime/lists/wasm.rs
+++ b/tests/runtime/lists/wasm.rs
@@ -28,6 +28,7 @@ impl Guest for Component {
             vec!["foo".to_owned(), "bar".to_owned()],
             vec!["baz".to_owned()],
         ]);
+        list_param5(&[(1, 2, 3), (4, 5, 6)]);
         assert_eq!(list_result(), [1, 2, 3, 4, 5]);
         assert_eq!(list_result2(), "hello!");
         assert_eq!(list_result3(), ["hello,", "world!"]);
@@ -107,6 +108,10 @@ impl exports::test::lists::test::Guest for Component {
         assert_eq!(ptr[0][0], "foo");
         assert_eq!(ptr[0][1], "bar");
         assert_eq!(ptr[1][0], "baz");
+    }
+
+    fn list_param5(ptr: Vec<(u8, u32, u8)>) {
+        assert_eq!(ptr, [(1, 2, 3), (4, 5, 6)]);
     }
 
     fn list_result() -> Vec<u8> {

--- a/tests/runtime/lists/world.wit
+++ b/tests/runtime/lists/world.wit
@@ -10,6 +10,7 @@ interface test {
   list-param2: func(a: string);
   list-param3: func(a: list<string>);
   list-param4: func(a: list<list<string>>);
+  list-param5: func(a: list<tuple<u8, u32, u8>>);
   list-result: func() -> list<u8>;
   list-result2: func() -> string;
   list-result3: func() -> list<string>;


### PR DESCRIPTION
This fixes the mistaken assumption that the tuple ABI in Rust is the same as the component model ABI and generates different code for lifting/lowering lists.

Closes #1112