### PR TITLE
fix a few stream/future issues

### DIFF
--- a/crates/guest-rust/rt/src/async_support/stream_support.rs
+++ b/crates/guest-rust/rt/src/async_support/stream_support.rs
@@ -28,11 +28,11 @@ fn ceiling(x: usize, y: usize) -> usize {
 
 #[doc(hidden)]
 pub struct StreamVtable<T> {
-    pub write: fn(future: u32, values: &[T]) -> Pin<Box<dyn Future<Output = Option<usize>>>>,
+    pub write: fn(future: u32, values: &[T]) -> Pin<Box<dyn Future<Output = Option<usize>> + '_>>,
     pub read: fn(
         future: u32,
         values: &mut [MaybeUninit<T>],
-    ) -> Pin<Box<dyn Future<Output = Option<usize>>>>,
+    ) -> Pin<Box<dyn Future<Output = Option<usize>> + '_>>,
     pub cancel_write: fn(future: u32),
     pub cancel_read: fn(future: u32),
     pub close_writable: fn(future: u32),

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -475,7 +475,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     .as_ref()
                     .map(|ty| {
                         self.gen
-                            .full_type_name_owned(ty, Identifier::StreamOrFuturePayload)
+                            .type_name_owned_with_id(ty, Identifier::StreamOrFuturePayload)
                     })
                     .unwrap_or_else(|| "()".into());
                 let ordinal = self.gen.gen.future_payloads.get_index_of(&name).unwrap();
@@ -496,7 +496,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 let op = &operands[0];
                 let name = self
                     .gen
-                    .full_type_name_owned(payload, Identifier::StreamOrFuturePayload);
+                    .type_name_owned_with_id(payload, Identifier::StreamOrFuturePayload);
                 let ordinal = self.gen.gen.stream_payloads.get_index_of(&name).unwrap();
                 let path = self.gen.path_to_root();
                 results.push(format!(

--- a/tests/codegen/streams.wit
+++ b/tests/codegen/streams.wit
@@ -1,5 +1,19 @@
 package foo:foo;
 
+interface transmit {
+  variant control {
+    read-stream(string),
+    read-future(string),
+    write-stream(string),
+    write-future(string),
+  }
+
+  exchange: func(control: stream<control>,
+                 caller-stream: stream<string>,
+                 caller-future1: future<string>,
+                 caller-future2: future<string>) -> tuple<stream<string>, future<string>, future<string>>;
+}
+
 interface streams {
   stream-u8-param: func(x: stream<u8>);
   stream-u16-param: func(x: stream<u16>);
@@ -82,4 +96,5 @@ interface streams {
 world the-streams {
   import streams;
   export streams;
+  export transmit;
 }


### PR DESCRIPTION
- The generated lift/lower code for stream/future payloads was not always calculating module paths correctly when generating type names.
- Also, we were moving raw pointers into `async move` blocks and returning them without capturing the pointed-to memory.  This would have been caught by runtime tests, but we don't have those yet since the Wasmtime async PR hasn't been merged yet.  Fortunately, it was easy enough to find and fix when I updated that PR to use the latest wit-bindgen.
- The generated lift/lower code for reading and writing streams needs to return a `Box<dyn Future>` that captures the lifetimes of the parameters.