### PR TITLE
c#: Remove Copy of data during import call for base types

### DIFF
--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -586,9 +586,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     Direction::Import => {
                         let ptr: String = self.locals.tmp("listPtr");
                         let handle: String = self.locals.tmp("gcHandle");
-                        // Dispite the name GCHandle.Alloc here this does not actually allocate memory on the heap. 
-                        // It pins the array with the garbage collector so that it can be passed to unmanaged code
-                        // It is required to free the pin after use which is done in the Cleanup section 
+                        // Despite the name GCHandle.Alloc here this does not actually allocate memory on the heap. 
+                        // It pins the array with the garbage collector so that it can be passed to unmanaged code.
+                        // It is required to free the pin after use which is done in the Cleanup section.
                         uwrite!(
                             self.src,
                             "


### PR DESCRIPTION
When calling an import we don't need to copy data to a new structure for canonical types. This avoid the extra copy of data in this scenario.

This isin prep for some more changes with https://github.com/bytecodealliance/wit-bindgen/issues/1080