### PR TITLE
drop borrows just prior to calling `task.return`

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -932,6 +932,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         ")".into()
                     });
                 }
+                if self.async_ {
+                    self.push_str(".await");
+                }
                 self.push_str(";\n");
             }
 


### PR DESCRIPTION
Prior to #1124, we were dropping borrows too late.  That PR fixed that problem, but dropped borrows too early and didn't allow application code to capture the borrows in the `Future` it returned.  This patch improves the situation by dropping borrows as late as possible, but no later.  As a side effect, it simplfies the code and makes implementing the generated trait(s) much more ergonomic.