### PR TITLE
refactor(rust): add default value for async usage

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -294,7 +294,7 @@ pub struct Opts {
     ///     - some=<value>[,<value>...], where each <value> is of the form:
     ///         - import:<name> or
     ///         - export:<name>
-    #[cfg_attr(feature = "clap", arg(long = "async", value_parser = parse_async))]
+    #[cfg_attr(feature = "clap", arg(long = "async", value_parser = parse_async, default_value = "none"))]
     pub async_: AsyncConfig,
 }
 


### PR DESCRIPTION
This commit introduces a default value for the `--async` option as used with Rust bindgen.

At present when using `wit-bindgen` the `--async` argument is required:

```
wit-bindgen rust test.wit --out-dir output
error: the following required arguments were not provided:
  --async <ASYNC>

Usage: wit-bindgen rust --async <ASYNC> --out-dir <OUT_DIR> <WIT>

For more information, try '--help'.
```