### PR TITLE
c#: Use span and memory apis for primitive type parameters on imports

### DIFF
--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -12,7 +12,7 @@ use wit_parser::{Docs, FunctionKind, Handle, Resolve, SizeAlign, Type, TypeDefKi
 
 /// FunctionBindgen generates the C# code for calling functions defined in wit
 pub(crate) struct FunctionBindgen<'a, 'b> {
-    pub(crate) interface_gen: &'b mut InterfaceGenerator<'a>,
+    pub(crate) interface_gen: &'b InterfaceGenerator<'a>,
     func_name: &'b str,
     kind: &'b FunctionKind,
     params: Box<[String]>,

--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -737,7 +737,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                             });
                         } else {
                             // With variants we can't use span since the Fixed statment can't always be applied to all the variants
-                            // Despite the name GCHandle.Alloc here this does not actually allocate memory on the heap. 
+                            // Despite the name GCHandle.Alloc here this does not re-allocate the object but it does make an
+                            // allocation for the handle in a special resource pool which can result in GC pressure.
                             // It pins the array with the garbage collector so that it can be passed to unmanaged code.
                             // It is required to free the pin after use which is done in the Cleanup section.
                             self.needs_cleanup = true;

--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -248,9 +248,9 @@ impl InterfaceGenerator<'_> {
             .join(", ");
 
         let mut funcs: Vec<(String, String)> = Vec::new();
-        funcs.push(self.gen_import_src(func, &results, ParameterType::Primitive));
+        funcs.push(self.gen_import_src(func, &results, ParameterType::ABI));
 
-        if func
+        let include_additional_functions = func
             .params
             .iter()
             .skip(if let FunctionKind::Method(_) = &func.kind {
@@ -258,8 +258,9 @@ impl InterfaceGenerator<'_> {
             } else {
                 0
             })
-            .any(|param| self.is_primative_list(&param.1))
-        {
+            .any(|param| self.is_primative_list(&param.1));
+
+        if include_additional_functions {
             funcs.push(self.gen_import_src(func, &results, ParameterType::Span));
             funcs.push(self.gen_import_src(func, &results, ParameterType::Memory));
         }
@@ -412,7 +413,7 @@ impl InterfaceGenerator<'_> {
             &func.kind,
             (0..sig.params.len()).map(|i| format!("p{i}")).collect(),
             results,
-            ParameterType::Primitive,
+            ParameterType::ABI,
         );
 
         abi::call(
@@ -541,7 +542,7 @@ impl InterfaceGenerator<'_> {
     }
 
     pub(crate) fn type_name_with_qualifier(&mut self, ty: &Type, qualifier: bool) -> String {
-        self.name_with_qualifier(ty, qualifier, ParameterType::Primitive)
+        self.name_with_qualifier(ty, qualifier, ParameterType::ABI)
     }
 
     fn is_primative_list(&mut self, ty: &Type) -> bool {
@@ -1240,7 +1241,7 @@ impl<'a> CoreInterfaceGenerator<'a> for InterfaceGenerator<'a> {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub(crate) enum ParameterType {
-    Primitive,
+    ABI,
     Span,
     Memory,
 }

--- a/tests/runtime/lists/wasm.cs
+++ b/tests/runtime/lists/wasm.cs
@@ -30,6 +30,8 @@ namespace ListsWorld {
             }
 
             TestInterop.ListParam(new byte[] { (byte)1, (byte)2, (byte)3, (byte)4 });
+            TestInterop.ListParam((new byte[] { (byte)1, (byte)2, (byte)3, (byte)4 }).AsSpan());
+            TestInterop.ListParam((new byte[] { (byte)1, (byte)2, (byte)3, (byte)4 }).AsMemory());
             TestInterop.ListParam2("foo");
             TestInterop.ListParam3(new List<String>() {
                 "foo",


### PR DESCRIPTION
Fixes: https://github.com/bytecodealliance/wit-bindgen/issues/1080 and follow up to #1122.

Putting in draft for now ~since it has parts of #1137~.

This generates both Span and Memory function signatures for and function that has a canonical list type.

Note that no tests have to change since the memory/span API' provide[ implicit operators](https://learn.microsoft.com/en-us/dotnet/api/system.readonlymemory-1.op_implicit?view=net-9.0) that automatically convert Byte Arrays to `Memory`. But I added an additional check to the test.