### PR TITLE
[Rust] fix length calculation in `stream.write` bindings

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -795,7 +795,7 @@ pub mod vtable{ordinal} {{
                         wit_import,
                         stream,
                         address.add(total * {size}),
-                        u32::try_from(values.len()).unwrap()
+                        u32::try_from(values.len() - (total * {size})).unwrap()
                     ).await
                 }};
 


### PR DESCRIPTION
When calculating the length we pass to the `stream.write` intrinsic, we need to subtract the number of bytes we've already written.  I forgot to do that in my original PR.