### PR TITLE
fix recursive `async_support::poll` calls

### DIFF
--- a/crates/guest-rust/rt/src/async_support.rs
+++ b/crates/guest-rust/rt/src/async_support.rs
@@ -94,9 +94,10 @@ fn dummy_waker() -> Waker {
 unsafe fn poll(state: *mut FutureState) -> Poll<()> {
     loop {
         if let Some(futures) = (*state).tasks.as_mut() {
+            let old = CURRENT;
             CURRENT = state;
             let poll = futures.poll_next_unpin(&mut Context::from_waker(&dummy_waker()));
-            CURRENT = ptr::null_mut();
+            CURRENT = old;
 
             if SPAWNED.is_empty() {
                 match poll {


### PR DESCRIPTION
Previously, a recursive call would overwrite the `CURRENT` global variable; now we save the old value so we can restore it later.