### PR TITLE
rust: Store raw intrinsics in vtables

### DIFF
--- a/crates/guest-rust/rt/src/async_support.rs
+++ b/crates/guest-rust/rt/src/async_support.rs
@@ -25,8 +25,8 @@ mod future_support;
 mod stream_support;
 
 pub use {
-    future_support::{FutureReader, FutureVtable, FutureWriter},
-    stream_support::{StreamReader, StreamVtable, StreamWriter},
+    future_support::{future_new, FutureReader, FutureVtable, FutureWriter},
+    stream_support::{stream_new, StreamReader, StreamVtable, StreamWriter},
 };
 
 pub use futures;

--- a/crates/guest-rust/rt/src/async_support/stream_support.rs
+++ b/crates/guest-rust/rt/src/async_support/stream_support.rs
@@ -35,12 +35,30 @@ pub struct StreamVtable<T> {
         future: u32,
         values: &mut [MaybeUninit<T>],
     ) -> Pin<Box<dyn Future<Output = Option<Result<usize, ErrorContext>>> + '_>>,
-    pub cancel_write: fn(future: u32),
-    pub cancel_read: fn(future: u32),
-    pub close_writable: fn(future: u32, err_ctx: u32),
-    pub close_readable: fn(future: u32),
+    pub cancel_write: unsafe extern "C" fn(future: u32) -> u32,
+    pub cancel_read: unsafe extern "C" fn(future: u32) -> u32,
+    pub close_writable: unsafe extern "C" fn(future: u32, err_ctx: u32),
+    pub close_readable: unsafe extern "C" fn(future: u32),
+    pub new: unsafe extern "C" fn() -> u32,
 }
 
+/// Helper function to create a new read/write pair for a component model
+/// stream.
+pub unsafe fn stream_new<T>(
+    vtable: &'static StreamVtable<T>,
+) -> (StreamWriter<T>, StreamReader<T>) {
+    let handle = unsafe { (vtable.new)() };
+    super::with_entry(handle, |entry| match entry {
+        Entry::Vacant(entry) => {
+            entry.insert(Handle::LocalOpen);
+        }
+        Entry::Occupied(_) => unreachable!(),
+    });
+    (
+        StreamWriter::new(handle, vtable),
+        StreamReader::new(handle, vtable),
+    )
+}
 struct CancelWriteOnDrop<T: 'static> {
     handle: Option<u32>,
     vtable: &'static StreamVtable<T>,
@@ -60,7 +78,11 @@ impl<T> Drop for CancelWriteOnDrop<T> {
                     Handle::LocalReady(..) => {
                         entry.insert(Handle::LocalOpen);
                     }
-                    Handle::Write => (self.vtable.cancel_write)(handle),
+                    Handle::Write => unsafe {
+                        // TODO: spec-wise this can return `BLOCKED` which seems
+                        // bad?
+                        (self.vtable.cancel_write)(handle);
+                    },
                 },
             });
         }
@@ -221,18 +243,20 @@ impl<T> Drop for StreamWriter<T> {
                     entry.insert(Handle::LocalClosed);
                 }
                 Handle::Read => unreachable!(),
-                Handle::Write | Handle::LocalClosed => {
+                Handle::Write | Handle::LocalClosed => unsafe {
                     entry.remove();
                     (self.vtable.close_writable)(self.handle, 0);
-                }
+                },
                 Handle::WriteClosedErr(_) => match entry.remove() {
                     // Care is taken  to avoid dropping the ErrorContext before close_writable is called.
                     // If the error context is dropped prematurely, the component may garbage collect
                     // the error context before it can be used/referenced by close_writable().
-                    Handle::WriteClosedErr(Some(e)) => {
+                    Handle::WriteClosedErr(Some(e)) => unsafe {
                         (self.vtable.close_writable)(self.handle, e.handle)
-                    }
-                    Handle::WriteClosedErr(None) => (self.vtable.close_writable)(self.handle, 0),
+                    },
+                    Handle::WriteClosedErr(None) => unsafe {
+                        (self.vtable.close_writable)(self.handle, 0)
+                    },
                     _ => unreachable!(),
                 },
             },
@@ -259,7 +283,11 @@ impl<T> Drop for CancelReadOnDrop<T> {
                     Handle::LocalWaiting(_) => {
                         entry.insert(Handle::LocalOpen);
                     }
-                    Handle::Read => (self.vtable.cancel_read)(handle),
+                    Handle::Read => unsafe {
+                        // TODO: spec-wise this can return `BLOCKED` which seems
+                        // bad?
+                        (self.vtable.cancel_read)(handle);
+                    },
                 },
             });
         }
@@ -457,10 +485,10 @@ impl<T> Drop for StreamReader<T> {
                         Handle::LocalOpen | Handle::LocalWaiting(_) => {
                             entry.insert(Handle::LocalClosed);
                         }
-                        Handle::Read | Handle::LocalClosed => {
+                        Handle::Read | Handle::LocalClosed => unsafe {
                             entry.remove();
                             (self.vtable.close_readable)(handle);
-                        }
+                        },
                         Handle::Write | Handle::WriteClosedErr(_) => unreachable!(),
                     },
                 });

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -479,7 +479,7 @@ pub mod wit_future {{
 
     #[doc(hidden)]
     pub trait FuturePayload: Unpin + Sized + 'static {{
-       fn new() -> (u32, &'static {async_support}::FutureVtable<Self>);
+        const VTABLE: &'static {async_support}::FutureVtable<Self>;
     }}"
             ));
             for code in self.future_payloads.values() {
@@ -489,17 +489,7 @@ pub mod wit_future {{
                 "\
     /// Creates a new Component Model `future` with the specified payload type.
     pub fn new<T: FuturePayload>() -> ({async_support}::FutureWriter<T>, {async_support}::FutureReader<T>) {{
-        let (handle, vtable) = T::new();
-        {async_support}::with_entry(handle, |entry| match entry {{
-            ::std::collections::hash_map::Entry::Vacant(entry) => {{
-                entry.insert({async_support}::Handle::LocalOpen);
-            }}
-            ::std::collections::hash_map::Entry::Occupied(_) => unreachable!(),
-        }});
-        (
-            {async_support}::FutureWriter::new(handle, vtable),
-            {async_support}::FutureReader::new(handle, vtable),
-        )
+        unsafe {{ {async_support}::future_new::<T>(T::VTABLE) }}
     }}
 }}
                 ",
@@ -514,7 +504,7 @@ pub mod wit_stream {{
     #![allow(dead_code, unused_variables, clippy::all)]
 
     pub trait StreamPayload: Unpin + Sized + 'static {{
-       fn new() -> (u32, &'static {async_support}::StreamVtable<Self>);
+        const VTABLE: &'static {async_support}::StreamVtable<Self>;
     }}"
             ));
             for code in self.stream_payloads.values() {
@@ -524,17 +514,7 @@ pub mod wit_stream {{
                 &format!("\
     /// Creates a new Component Model `stream` with the specified payload type.
     pub fn new<T: StreamPayload>() -> ({async_support}::StreamWriter<T>, {async_support}::StreamReader<T>) {{
-        let (handle, vtable) = T::new();
-        {async_support}::with_entry(handle, |entry| match entry {{
-            ::std::collections::hash_map::Entry::Vacant(entry) => {{
-                entry.insert({async_support}::Handle::LocalOpen);
-            }}
-            ::std::collections::hash_map::Entry::Occupied(_) => unreachable!(),
-        }});
-        (
-            {async_support}::StreamWriter::new(handle, vtable),
-            {async_support}::StreamReader::new(handle, vtable),
-        )
+        unsafe {{ {async_support}::stream_new::<T>(T::VTABLE) }}
     }}
 }}
                 "),


### PR DESCRIPTION
Instead of generating a wrapper-per-intrinsic try to instead store raw functions inside of vtables to push as much code as possible into `mod async_support`, as it's generally easier to grok code in one location rather than generated code.

Note that this does not update the `read` or `write` vtable functions as they're going to be trickier, if even possible, to expose the more raw version.

This shouldn't have any functional change, it's just a reorganizing. The `cancel_*` intrinsics are all marked with a `TODO`, however, to come back and reconsider the return value which is otherwise discarded right now.