### PR TITLE
feat(rust): do not yield to the host while guest tasks are ready

### DIFF
--- a/crates/guest-rust/rt/src/async_support.rs
+++ b/crates/guest-rust/rt/src/async_support.rs
@@ -112,6 +112,8 @@ unsafe fn poll(state: *mut FutureState) -> Poll<()> {
                         break Poll::Ready(());
                     }
                     Poll::Pending => {
+                        // TODO: Return `CallbackCode.YIELD` (see https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canon-lift)
+                        // to the host before polling again once a host implementation exists to support it.
                         if !waker.0.load(Ordering::Relaxed) {
                             break Poll::Pending;
                         }


### PR DESCRIPTION
cc @dicej 

This fixes https://github.com/bytecodealliance/wasip3-prototyping/issues/66

Note, that eventually we might want go get smarter about this (or not) e.g. see https://docs.rs/tokio/latest/tokio/task/index.html#cooperative-scheduling