### PR TITLE
Use `--release` on tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,8 @@ jobs:
           -p wit-bindgen-cli \
           -p wit-bindgen-${{ matrix.lang }} \
           --no-default-features \
-          --features ${{ matrix.lang }}
+          --features ${{ matrix.lang }} \
+          --release
 
   test_unit:
     name: Crate Unit Tests


### PR DESCRIPTION
I have a hunch this is why C# is so slow (the modules are big and there's a lot of them and unoptimized Cranelift is very slow).