### PR TITLE
rust: Flag futures/streams as owned handles

### DIFF
--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -198,6 +198,10 @@ impl Types {
                 // These are all u32 handles regardless of payload type, so no
                 // need to recurse.
                 info.has_resource = true;
+
+                // Flag these as being onwed handles as lowering these values
+                // should use the same ownership semantics as `own<T>`
+                info.has_own_handle = true;
             }
             TypeDefKind::Unknown => unreachable!(),
         }


### PR DESCRIPTION
This commit updates how bindings work for futures/streams in Rust by ensuring that the type information for them encodes that they behave like `own<T>` handles in that passing the value to an import for examples passes ownership of the value in bindings. This ensures that generates APIs appropriately model relinquishing ownership of the `FutureReader<T>` end, for example.