### PR TITLE
Squash more warnings in generated Rust code

### DIFF
--- a/crates/guest-rust/rt/src/async_support/stream_support.rs
+++ b/crates/guest-rust/rt/src/async_support/stream_support.rs
@@ -330,7 +330,7 @@ impl<T> StreamReader<T> {
     }
 
     #[doc(hidden)]
-    pub fn from_handle_and_vtable(handle: u32, vtable: &'static StreamVtable<T>) -> Self {
+    pub unsafe fn from_handle_and_vtable(handle: u32, vtable: &'static StreamVtable<T>) -> Self {
         super::with_entry(handle, |entry| match entry {
             Entry::Vacant(entry) => {
                 entry.insert(Handle::Read);

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -560,8 +560,10 @@ pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
     if size == 0 {
         return;
     }
-    let layout = alloc::Layout::from_size_align_unchecked(size, align);
-    alloc::dealloc(ptr, layout);
+    unsafe {
+        let layout = alloc::Layout::from_size_align_unchecked(size, align);
+        alloc::dealloc(ptr, layout);
+    }
 }
                     ",
                 );
@@ -575,7 +577,7 @@ pub unsafe fn string_lift(bytes: Vec<u8>) -> String {
     if cfg!(debug_assertions) {
         String::from_utf8(bytes).unwrap()
     } else {
-        String::from_utf8_unchecked(bytes)
+        unsafe { String::from_utf8_unchecked(bytes) }
     }
 }
                     ",
@@ -603,7 +605,7 @@ pub unsafe fn char_lift(val: u32) -> char {
     if cfg!(debug_assertions) {
         core::char::from_u32(val).unwrap()
     } else {
-        core::char::from_u32_unchecked(val)
+        unsafe { core::char::from_u32_unchecked(val) }
     }
 }
                     ",

--- a/crates/test/src/rust.rs
+++ b/crates/test/src/rust.rs
@@ -72,7 +72,11 @@ impl LanguageMethods for Rust {
     }
 
     fn default_bindgen_args(&self) -> &[&str] {
-        &["--generate-all"]
+        &["--generate-all", "--format"]
+    }
+
+    fn default_bindgen_args_for_codegen(&self) -> &[&str] {
+        &["--stubs"]
     }
 
     fn prepare(&self, runner: &mut Runner<'_>) -> Result<()> {
@@ -162,7 +166,6 @@ path = 'lib.rs'
                     .join(format!("{}.rs", compile.component.kind)),
             )
             .arg(compile.component.path.file_name().unwrap())
-            .arg("-Dwarnings")
             .arg("-o")
             .arg(&output);
         match compile.component.kind {
@@ -250,6 +253,7 @@ impl Runner<'_> {
         ))
         .arg("--target")
         .arg(&opts.rust_target)
+        .arg("-Dwarnings")
         .arg("-Cdebuginfo=1");
         for dep in state.wit_bindgen_deps.iter() {
             cmd.arg(&format!("-Ldependency={}", dep.display()));


### PR DESCRIPTION
Add `-Dwarnings` to the codegen tests and fixup various issues around `unsafe` and such by shuffling around `unsafe` blocks.