### PR TITLE
fix: correct README doc links for wit-bindgen-go to point to latest location

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ https://github.com/bytecodealliance/wit-bindgen/commit/86e8ae2b8b97f11b73b273345
 ### Guest: TinyGo
 
 The **new** TinyGo WIT bindings generator is currently in development at the
-[wasm-tools-go](https://github.com/bytecodealliance/wasm-tools-go) repository.
+[go.bytecodealliance.org](https://github.com/bytecodealliance/go-modules) repository.
 
 To install the `wit-bindgen-go` CLI, run:
 
 ```sh
-go install github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go
+go install go.bytecodealliance.org/cmd/wit-bindgen-go@latest
 ```
 > Note: it requires `wasm-tools` to be installed.
 


### PR DESCRIPTION
This PR is to correct the README doc links for `wit-bindgen-go` to point to the latest URL/repo location since it was moved subsequent to this originally being added.