### PR TITLE
Support language-specific configuration in `wit-bindgen test`

### DIFF
--- a/tests/runtime-new/demo/runner-opt.c
+++ b/tests/runtime-new/demo/runner-opt.c
@@ -1,0 +1,8 @@
+//@ [lang]
+//@ cflags = '-O'
+
+#include <runner.h>
+
+int main() {
+  a_b_the_test_x();
+}

--- a/tests/runtime-new/demo/runner-opt.rs
+++ b/tests/runtime-new/demo/runner-opt.rs
@@ -1,0 +1,8 @@
+//@ [lang]
+//@ rustflags = '-O'
+
+include!(env!("BINDINGS"));
+
+fn main() {
+    a::b::the_test::x();
+}


### PR DESCRIPTION
This commit extends the configuration format with a `lang` field to be able to pass things like compiler flags. To help port one of the Rust tests I plan on adding eventual functionality for allowing Rust tests to specify an auxiliary file to build as a crate.