### PR TITLE
[Rust] use cleanup list as necessary for stream/future writes

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -54,7 +54,22 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
         }
     }
 
-    fn emit_cleanup(&mut self) {
+    pub(crate) fn flush_cleanup(&mut self) {
+        if !self.cleanup.is_empty() {
+            self.needs_cleanup_list = true;
+            self.push_str("cleanup_list.extend_from_slice(&[");
+            for (ptr, layout) in mem::take(&mut self.cleanup) {
+                self.push_str("(");
+                self.push_str(&ptr);
+                self.push_str(", ");
+                self.push_str(&layout);
+                self.push_str("),");
+            }
+            self.push_str("]);\n");
+        }
+    }
+
+    pub(crate) fn emit_cleanup(&mut self) {
         if self.emitted_cleanup {
             return;
         }
@@ -244,18 +259,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
     }
 
     fn finish_block(&mut self, operands: &mut Vec<String>) {
-        if !self.cleanup.is_empty() {
-            self.needs_cleanup_list = true;
-            self.push_str("cleanup_list.extend_from_slice(&[");
-            for (ptr, layout) in mem::take(&mut self.cleanup) {
-                self.push_str("(");
-                self.push_str(&ptr);
-                self.push_str(", ");
-                self.push_str(&layout);
-                self.push_str("),");
-            }
-            self.push_str("]);\n");
-        }
+        self.flush_cleanup();
         let (prev_src, prev_cleanup) = self.block_storage.pop().unwrap();
         let src = mem::replace(&mut self.src, prev_src);
         self.cleanup = prev_cleanup;

--- a/tests/codegen/futures.wit
+++ b/tests/codegen/futures.wit
@@ -27,6 +27,10 @@ interface futures {
   future-f32-ret: func() -> future<f32>;
   future-f64-ret: func() -> future<f64>;
 
+  future-result-list-string-ret: func() -> future<result<list<string>>>;
+  future-result-list-list-u8-ret: func() -> future<result<list<list<u8>>>>;
+  future-list-list-list-u8-ret: func() -> future<list<list<list<u8>>>>;
+
   tuple-future: func(x: future<tuple<u8, s8>>) -> future<tuple<s64, u32>>;
   string-future-arg: func(a: future<string>);
   string-future-ret: func() -> future<string>;

--- a/tests/codegen/streams.wit
+++ b/tests/codegen/streams.wit
@@ -41,6 +41,10 @@ interface streams {
   stream-f32-ret: func() -> stream<f32>;
   stream-f64-ret: func() -> stream<f64>;
 
+  stream-result-list-string-ret: func() -> stream<result<list<string>>>;
+  stream-result-list-list-u8-ret: func() -> stream<result<list<list<u8>>>>;
+  stream-list-list-list-u8-ret: func() -> stream<list<list<list<u8>>>>;
+
   tuple-stream: func(x: stream<tuple<u8, s8>>) -> stream<tuple<s64, u32>>;
   string-stream-arg: func(a: stream<string>);
   string-stream-ret: func() -> stream<string>;


### PR DESCRIPTION
Previously, I had failed to consider (or test) the case where lowering values for stream/future writes would require intermediate allocations that need to be cleaned up.  That manifested as compiler errors due to generated code referencing a non-existent `cleanup_list` variable.

Fixes #1153