### PR TITLE
Refactor some ABI bits in `wit-bindgen-core`

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1877,7 +1877,7 @@ impl InterfaceGenerator<'_> {
 
             let mut f = FunctionBindgen::new(self, c_sig, &import_name);
             f.params = params;
-            abi::post_return(f.gen.resolve, func, &mut f, false);
+            abi::post_return(f.gen.resolve, func, &mut f);
             let FunctionBindgen { src, .. } = f;
             self.src.c_fns(&src);
             self.src.c_fns("}\n");

--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -495,7 +495,7 @@ impl InterfaceGenerator<'_> {
                 ParameterType::ABI,
             );
 
-            abi::post_return(bindgen.interface_gen.resolve, func, &mut bindgen, false);
+            abi::post_return(bindgen.interface_gen.resolve, func, &mut bindgen);
 
             let src = bindgen.src;
 

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -969,7 +969,7 @@ impl InterfaceGenerator<'_> {
                 (0..sig.results.len()).map(|i| format!("p{i}")).collect(),
             );
 
-            abi::post_return(bindgen.gen.resolve, func, &mut bindgen, false);
+            abi::post_return(bindgen.gen.resolve, func, &mut bindgen);
 
             let src = bindgen.src;
 

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1033,7 +1033,7 @@ pub mod vtable{ordinal} {{
             self.src.push_str("{ unsafe {\n");
 
             let mut f = FunctionBindgen::new(self, params, async_, self.wasm_import_module, false);
-            abi::post_return(f.r#gen.resolve, func, &mut f, async_);
+            abi::post_return(f.r#gen.resolve, func, &mut f);
             let FunctionBindgen {
                 needs_cleanup_list,
                 src,


### PR DESCRIPTION
Pass some variables around instead of storing them on `Generator`, removing the need to synthesize dummy values in a few contexts.