### PR TITLE
Implement serde::Deserialize for wit-bindgen-rust::Opts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1.0.72"
 bitflags = "2.3.3"
 heck = { version = "0.5" }
 pulldown-cmark = { version = "0.9", default-features = false }
+serde = { version = "1.0.218", features = ["derive"] }
 clap = { version = "4.3.19", features = ["derive"] }
 indexmap = "2.0.0"
 prettyplease = "0.2.20"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -25,6 +25,7 @@ clap = { workspace = true, optional = true }
 indexmap = { workspace = true }
 syn = { workspace = true }
 prettyplease = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
@@ -32,5 +33,4 @@ wit-bindgen = { path = '../guest-rust', features = ['async'] }
 wit-bindgen-rt = { path = '../guest-rust/rt' }
 test-helpers = { path = '../test-helpers' }
 # For use with the custom attributes test
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -3,6 +3,7 @@ use anyhow::{bail, Result};
 use core::panic;
 use heck::*;
 use indexmap::{IndexMap, IndexSet};
+use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Write as _};
 use std::mem;
@@ -133,7 +134,8 @@ fn parse_with(s: &str) -> Result<(String, WithOption), String> {
     Ok((k.to_string(), v))
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum AsyncConfig {
     #[default]
     None,
@@ -179,8 +181,9 @@ fn parse_async(s: &str) -> Result<AsyncConfig, String> {
     })
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[serde(rename_all = "kebab-case")]
 pub struct Opts {
     /// Whether or not a formatter is executed to format generated code.
     #[cfg_attr(feature = "clap", arg(long))]
@@ -315,6 +318,7 @@ pub struct Opts {
     ///         - import:<name> or
     ///         - export:<name>
     #[cfg_attr(feature = "clap", arg(long = "async", value_parser = parse_async, default_value = "none"))]
+    #[serde(rename = "async")]
     pub async_: AsyncConfig,
 }
 
@@ -1444,7 +1448,8 @@ fn group_by_resource<'a>(
     by_resource
 }
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum Ownership {
     /// Generated types will be composed entirely of owning fields, regardless
     /// of whether they are used as parameters to imports or not.
@@ -1498,7 +1503,8 @@ impl fmt::Display for Ownership {
 }
 
 /// Options for with "with" remappings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum WithOption {
     Path(String),
     Generate,

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -21,7 +21,7 @@ heck = { workspace = true }
 log = "0.4.26"
 rayon = "1.10.0"
 regex = "1.11.1"
-serde = { version = "1.0.218", features = ["derive"] }
+serde = { workspace = true }
 toml = "0.8.20"
 wasi-preview1-component-adapter-provider = "30.0.2"
 wac-parser = "0.6.1"


### PR DESCRIPTION
To allow deserialisation of bindgen options, for example from Cargo package metadata like in https://github.com/bytecodealliance/cargo-component/pull/384