### PR TITLE
Don't include all languages by default in `wit-bindgen test`

### DIFF
--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -100,9 +100,8 @@ pub struct Opts {
 
     /// Configuration of which languages are tested.
     ///
-    /// Passing `--lang rust` will only test Rust for example. Passing
-    /// `--lang=-rust` will test everything except Rust.
-    #[clap(short, long)]
+    /// Passing `--lang rust` will only test Rust for example.
+    #[clap(short, long, required = true, value_delimiter = ',')]
     languages: Vec<String>,
 }
 
@@ -1009,43 +1008,10 @@ status: {}",
 
     /// Returns whether `languages` is included in this testing session.
     fn include_language(&self, language: &Language) -> bool {
-        let lang = language.obj().display();
-        let mut any_positive = false;
-        let mut any_negative = false;
-        for opt in self.opts.languages.iter() {
-            for name in opt.split(',') {
-                if let Some(suffix) = name.strip_prefix('-') {
-                    any_negative = true;
-                    // If explicitly asked to not include this, don't include
-                    // it.
-                    if suffix == lang {
-                        return false;
-                    }
-                } else {
-                    any_positive = true;
-                    // If explicitly asked to include this, then include it.
-                    if name == lang {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        // By default include all languages.
-        if self.opts.languages.is_empty() {
-            return true;
-        }
-
-        // If any language was explicitly included then assume any non-mentioned
-        // language should be omitted.
-        if any_positive {
-            return false;
-        }
-
-        // And if there are only negative mentions (e.g. `-foo`) then assume
-        // everything else is allowed.
-        assert!(any_negative);
-        true
+        self.opts
+            .languages
+            .iter()
+            .any(|l| l == language.obj().display())
     }
 
     fn render_errors<'a>(&self, results: impl Iterator<Item = StepResult<'a>>) {

--- a/crates/test/src/moonbit.rs
+++ b/crates/test/src/moonbit.rs
@@ -1,8 +1,7 @@
-use std::process::Command;
-
-use serde::Deserialize;
-
 use crate::LanguageMethods;
+use anyhow::bail;
+use serde::Deserialize;
+use std::process::Command;
 
 /// MoonBit configuration of project files
 #[derive(Default, Deserialize)]
@@ -29,13 +28,12 @@ impl LanguageMethods for MoonBit {
 
     fn prepare(&self, runner: &mut crate::Runner<'_>) -> anyhow::Result<()> {
         println!("Testing if MoonBit toolchain exists...");
-        runner
+        if runner
             .run_command(Command::new("moon").arg("version"))
-            .inspect_err(|_| {
-                eprintln!(
-                    "MoonBit toolchain not found. Check out <https://www.moonbitlang.com/download>"
-                );
-            })?;
+            .is_err()
+        {
+            bail!("MoonBit toolchain not found. Check out <https://www.moonbitlang.com/download>");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Instead switch the `-l`/`--language` argument to a required argument. I'm backtracking on "include everything" being a reasonable default since I don't think most users actually want to test everything. Short of that this requires explicit opt-in for what to test.