### PR TITLE
Fix `StreamWriter::write_all` wrt WebAssembly/component-model#490

### DIFF
--- a/crates/guest-rust/rt/src/async_support/stream_support.rs
+++ b/crates/guest-rust/rt/src/async_support/stream_support.rs
@@ -160,6 +160,11 @@ impl<T> StreamWriter<T> {
                 break;
             }
             (status, buf) = self.write_buf(buf).await;
+
+            // FIXME(WebAssembly/component-model#490)
+            if status == StreamResult::Cancelled {
+                status = StreamResult::Complete(0);
+            }
         }
 
         // Return back any values that weren't written by shifting them to the


### PR DESCRIPTION
Handle the fact that cancellation/0-length writes look the same.