### PR TITLE
 Refactor how imported tasks and bindings work 

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -914,7 +914,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     }
                 } else {
                     // ... otherwise if parameters are indirect space is
-                    // allocated from them and each argument is lowered
+                    // allocated for them and each argument is lowered
                     // individually into memory.
                     let ElementInfo { size, align } = self
                         .bindgen

--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -1263,8 +1263,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::StreamLower { .. }
             | Instruction::StreamLift { .. }
             | Instruction::ErrorContextLower { .. }
-            | Instruction::ErrorContextLift { .. }
-            | Instruction::AsyncCallWasm { .. } => todo!(),
+            | Instruction::ErrorContextLift { .. } => todo!(),
         }
     }
 

--- a/crates/guest-rust/rt/src/async_support.rs
+++ b/crates/guest-rust/rt/src/async_support.rs
@@ -9,20 +9,16 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::fmt::{self, Debug, Display};
 use std::future::Future;
-use std::mem;
 use std::pin::Pin;
 use std::ptr;
-use std::string::String;
 use std::sync::Arc;
-use std::task::{Context, Poll, Wake};
+use std::task::{Context, Poll, Wake, Waker};
 use std::vec::Vec;
 
 use futures::channel::oneshot;
 use futures::future::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
-use once_cell::sync::Lazy;
 
 macro_rules! rtdebug {
     ($($f:tt)*) => {
@@ -30,7 +26,7 @@ macro_rules! rtdebug {
         // crate like `log` or such to reduce runtime deps. Intended to be used
         // during development for now.
         if false {
-            std::println!($($f)*);
+            std::eprintln!($($f)*);
         }
     }
 
@@ -38,30 +34,36 @@ macro_rules! rtdebug {
 
 mod abi_buffer;
 mod cabi;
+mod error_context;
 mod future_support;
 mod stream_support;
+mod subtask;
 mod waitable;
+mod waitable_set;
 
+use self::waitable_set::WaitableSet;
 pub use abi_buffer::*;
+pub use error_context::*;
 pub use future_support::*;
 pub use stream_support::*;
+#[doc(hidden)]
+pub use subtask::Subtask;
 
 pub use futures;
 
 type BoxFuture = Pin<Box<dyn Future<Output = ()> + 'static>>;
 
 /// Represents a task created by either a call to an async-lifted export or a
-/// future run using `block_on` or `poll_future`.
+/// future run using `block_on` or `first_poll`.
 struct FutureState {
-    /// Number of in-progress async-lowered import calls and/or stream/future reads/writes.
-    todo: usize,
     /// Remaining work to do (if any) before this task can be considered "done".
     ///
     /// Note that we won't tell the host the task is done until this is drained
-    /// and `todo` is zero.
-    tasks: Option<FuturesUnordered<BoxFuture>>,
+    /// and `waitables` is empty.
+    tasks: FuturesUnordered<BoxFuture>,
+
     /// The waitable set containing waitables created by this task, if any.
-    waitable_set: Option<u32>,
+    waitable_set: Option<WaitableSet>,
 
     /// State of all waitables in `waitable_set`, and the ptr/callback they're
     /// associated with.
@@ -69,13 +71,22 @@ struct FutureState {
 
     /// Raw structure used to pass to `cabi::wasip3_task_set`
     wasip3_task: cabi::wasip3_task,
+
+    /// Rust-level state for the waker, notably a bool as to whether this has
+    /// been woken.
+    waker: Arc<FutureWaker>,
+
+    /// Clone of `waker` field, but represented as `std::task::Waker`.
+    waker_clone: Waker,
 }
 
 impl FutureState {
     fn new(future: BoxFuture) -> FutureState {
+        let waker = Arc::new(FutureWaker::default());
         FutureState {
-            todo: 0,
-            tasks: Some([future].into_iter().collect()),
+            waker_clone: waker.clone().into(),
+            waker,
+            tasks: [future].into_iter().collect(),
             waitable_set: None,
             waitables: HashMap::new(),
             wasip3_task: cabi::wasip3_task {
@@ -88,20 +99,131 @@ impl FutureState {
         }
     }
 
-    fn get_or_create_waitable_set(&mut self) -> u32 {
-        *self.waitable_set.get_or_insert_with(waitable_set_new)
+    fn get_or_create_waitable_set(&mut self) -> &WaitableSet {
+        self.waitable_set.get_or_insert_with(WaitableSet::new)
     }
 
     fn add_waitable(&mut self, waitable: u32) {
-        unsafe { waitable_join(waitable, self.get_or_create_waitable_set()) }
+        self.get_or_create_waitable_set().join(waitable)
     }
 
     fn remove_waitable(&mut self, waitable: u32) {
-        unsafe { waitable_join(waitable, 0) }
+        WaitableSet::remove_waitable_from_all_sets(waitable)
     }
 
     fn remaining_work(&self) -> bool {
-        self.todo > 0 || !self.waitables.is_empty()
+        !self.waitables.is_empty()
+    }
+
+    fn callback(&mut self, event0: u32, event1: u32, event2: u32) -> u32 {
+        match event0 {
+            EVENT_NONE => {
+                rtdebug!("EVENT_NONE");
+            }
+            EVENT_CALL_STARTED => {
+                rtdebug!("EVENT_CALL_STARTED({event1:#x})");
+                self.deliver_waitable_event(event1, STATUS_STARTED)
+            }
+            EVENT_CALL_RETURNED => {
+                rtdebug!("EVENT_CALL_RETURNED({event1:#x})");
+                self.deliver_waitable_event(event1, STATUS_RETURNED)
+            }
+
+            EVENT_STREAM_READ | EVENT_STREAM_WRITE | EVENT_FUTURE_READ | EVENT_FUTURE_WRITE => {
+                rtdebug!(
+                    "EVENT_{{STREAM,FUTURE}}_{{READ,WRITE}}({event0:#x}, {event1:#x}, {event2:#x})"
+                );
+                self.deliver_waitable_event(event1, event2)
+            }
+
+            _ => unreachable!(),
+        }
+
+        loop {
+            match self.poll() {
+                // TODO: don't re-loop here once a host supports
+                // `CALLBACK_CODE_YIELD`.
+                CALLBACK_CODE_YIELD => {}
+                other => break other,
+            }
+        }
+    }
+
+    /// Deliver the `code` event to the `waitable` store within our map. This
+    /// waitable should be present because it's part of the waitable set which
+    /// is kept in-sync with our map.
+    fn deliver_waitable_event(&mut self, waitable: u32, code: u32) {
+        self.remove_waitable(waitable);
+        let (ptr, callback) = self.waitables.remove(&waitable).unwrap();
+        unsafe {
+            callback(ptr, code);
+        }
+    }
+
+    /// Poll this task until it either completes or can't make immediate
+    /// progress.
+    fn poll(&mut self) -> u32 {
+        // Finish our `wasip3_task` by initializing its self-referential pointer,
+        // and then register it for the duration of this function with
+        // `wasip3_task_set`. The previous value of `wasip3_task_set` will get
+        // restored when this function returns.
+        struct ResetTask(*mut cabi::wasip3_task);
+        impl Drop for ResetTask {
+            fn drop(&mut self) {
+                unsafe {
+                    cabi::wasip3_task_set(self.0);
+                }
+            }
+        }
+        let self_raw = self as *mut FutureState;
+        self.wasip3_task.ptr = self_raw.cast();
+        let prev = unsafe { cabi::wasip3_task_set(&mut self.wasip3_task) };
+        let _reset = ResetTask(prev);
+
+        let mut context = Context::from_waker(&self.waker_clone);
+
+        loop {
+            // Reset the waker before polling to clear out any pending
+            // notification, if any.
+            self.waker.0.store(false, Ordering::Relaxed);
+
+            // Poll our future, handling `SPAWNED` around this.
+            let poll;
+            unsafe {
+                poll = self.tasks.poll_next_unpin(&mut context);
+                if !SPAWNED.is_empty() {
+                    self.tasks.extend(SPAWNED.drain(..));
+                }
+            }
+
+            match poll {
+                // A future completed, yay! Keep going to see if more have
+                // completed.
+                Poll::Ready(Some(())) => (),
+
+                // The `FuturesUnordered` list is empty meaning that there's no
+                // more work left to do, so we're done.
+                Poll::Ready(None) => {
+                    assert!(!self.remaining_work());
+                    assert!(self.tasks.is_empty());
+                    break CALLBACK_CODE_EXIT;
+                }
+
+                // Some future within `FuturesUnordered` is not ready yet. If
+                // our `waker` was signaled then that means this is a yield
+                // operation, otherwise it means we're blocking on something.
+                Poll::Pending => {
+                    assert!(!self.tasks.is_empty());
+                    if self.waker.0.load(Ordering::Relaxed) {
+                        break CALLBACK_CODE_YIELD;
+                    }
+
+                    assert!(self.remaining_work());
+                    let waitable = self.waitable_set.as_ref().unwrap().as_raw();
+                    break CALLBACK_CODE_WAIT | (waitable << 4);
+                }
+            }
+        }
     }
 }
 
@@ -130,176 +252,69 @@ unsafe extern "C" fn waitable_unregister(ptr: *mut c_void, waitable: u32) -> *mu
     }
 }
 
-impl Drop for FutureState {
-    fn drop(&mut self) {
-        if let Some(set) = self.waitable_set.take() {
-            waitable_set_drop(set);
-        }
+#[derive(Default)]
+struct FutureWaker(AtomicBool);
+
+impl Wake for FutureWaker {
+    fn wake(self: Arc<Self>) {
+        Self::wake_by_ref(&self)
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.store(true, Ordering::Relaxed)
     }
 }
-
-/// The current task being polled (or null if none).
-static mut CURRENT: *mut FutureState = ptr::null_mut();
-
-/// Map of any in-progress calls to async-lowered imports, keyed by the
-/// identifiers issued by the host.
-static mut CALLS: Lazy<HashMap<i32, oneshot::Sender<u32>>> = Lazy::new(HashMap::new);
 
 /// Any newly-deferred work queued by calls to the `spawn` function while
 /// polling the current task.
 static mut SPAWNED: Vec<BoxFuture> = Vec::new();
 
-const EVENT_NONE: i32 = 0;
-const _EVENT_CALL_STARTING: i32 = 1;
-const EVENT_CALL_STARTED: i32 = 2;
-const EVENT_CALL_RETURNED: i32 = 3;
-const EVENT_STREAM_READ: i32 = 5;
-const EVENT_STREAM_WRITE: i32 = 6;
-const EVENT_FUTURE_READ: i32 = 7;
-const EVENT_FUTURE_WRITE: i32 = 8;
+const EVENT_NONE: u32 = 0;
+const _EVENT_CALL_STARTING: u32 = 1;
+const EVENT_CALL_STARTED: u32 = 2;
+const EVENT_CALL_RETURNED: u32 = 3;
+const EVENT_STREAM_READ: u32 = 5;
+const EVENT_STREAM_WRITE: u32 = 6;
+const EVENT_FUTURE_READ: u32 = 7;
+const EVENT_FUTURE_WRITE: u32 = 8;
 
-const CALLBACK_CODE_EXIT: i32 = 0;
-const _CALLBACK_CODE_YIELD: i32 = 1;
-const CALLBACK_CODE_WAIT: i32 = 2;
-const _CALLBACK_CODE_POLL: i32 = 3;
+const CALLBACK_CODE_EXIT: u32 = 0;
+const CALLBACK_CODE_YIELD: u32 = 1;
+const CALLBACK_CODE_WAIT: u32 = 2;
+const _CALLBACK_CODE_POLL: u32 = 3;
 
 const STATUS_STARTING: u32 = 1;
 const STATUS_STARTED: u32 = 2;
 const STATUS_RETURNED: u32 = 3;
 
-/// Poll the specified task until it either completes or can't make immediate
-/// progress.
-unsafe fn poll(state: *mut FutureState) -> Poll<()> {
-    #[derive(Default)]
-    struct FutureWaker(AtomicBool);
-
-    impl Wake for FutureWaker {
-        fn wake(self: Arc<Self>) {
-            Self::wake_by_ref(&self)
-        }
-
-        fn wake_by_ref(self: &Arc<Self>) {
-            self.0.store(true, Ordering::Relaxed)
-        }
-    }
-
-    // Finish our `wasip3_task` by initializing its self-referential pointer,
-    // and then register it for the duration of this function with
-    // `wasip3_task_set`. The previous value of `wasip3_task_set` will get
-    // restored when this function returns.
-    struct ResetTask(*mut cabi::wasip3_task);
-    impl Drop for ResetTask {
-        fn drop(&mut self) {
-            unsafe {
-                cabi::wasip3_task_set(self.0);
-            }
-        }
-    }
-    (*state).wasip3_task.ptr = state.cast();
-    let prev = cabi::wasip3_task_set(&mut (*state).wasip3_task);
-    let _reset = ResetTask(prev);
-
-    loop {
-        if let Some(futures) = (*state).tasks.as_mut() {
-            let old = CURRENT;
-            CURRENT = state;
-            let waker: Arc<FutureWaker> = Arc::default();
-            let poll =
-                futures.poll_next_unpin(&mut Context::from_waker(&Arc::clone(&waker).into()));
-            CURRENT = old;
-
-            if SPAWNED.is_empty() {
-                match poll {
-                    Poll::Ready(Some(())) => (),
-                    Poll::Ready(None) => {
-                        (*state).tasks = None;
-                        break Poll::Ready(());
-                    }
-                    Poll::Pending => {
-                        // TODO: Return `CallbackCode.YIELD` (see
-                        // https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canon-lift)
-                        // to the host before polling again once a host
-                        // implementation exists to support it.
-                        if !waker.0.load(Ordering::Relaxed) {
-                            break Poll::Pending;
-                        }
-                    }
-                }
-            } else {
-                futures.extend(SPAWNED.drain(..));
-            }
-        } else {
-            break Poll::Ready(());
-        }
-    }
-}
-
 /// Poll the future generated by a call to an async-lifted export once, calling
 /// the specified closure (presumably backed by a call to `task.return`) when it
 /// generates a value.
 ///
-/// This will return a non-null pointer representing the task if it hasn't
-/// completed immediately; otherwise it returns null.
+/// This will return an appropriate status code to be returned from the
+/// exported function.
 #[doc(hidden)]
 pub fn first_poll<T: 'static>(
     future: impl Future<Output = T> + 'static,
     fun: impl FnOnce(&T) + 'static,
-) -> i32 {
+) -> u32 {
+    // Allocate a new `FutureState` which will track all state necessary for
+    // our exported task.
     let state = Box::into_raw(Box::new(FutureState::new(Box::pin(
         future.map(|v| fun(&v)),
     ))));
-    let done = unsafe { poll(state).is_ready() };
-    unsafe { callback_code(state, done) }
-}
 
-/// Await the completion of a call to an async-lowered import.
-#[doc(hidden)]
-pub async unsafe fn await_result(
-    import: unsafe extern "C" fn(*mut u8, *mut u8) -> i32,
-    params: *mut u8,
-    results: *mut u8,
-) {
-    let result = import(params, results) as u32;
-    let status = result >> 30;
-    let call = (result & !(0b11 << 30)) as i32;
-
-    if status != STATUS_RETURNED {
-        assert!(!CURRENT.is_null());
-        (*CURRENT).todo += 1;
+    // Store our `FutureState` into our context-local-storage slot and then
+    // pretend we got EVENT_NONE to kick off everything.
+    //
+    // SAFETY: we should own `context.set` as we're the root level exported
+    // task, and then `callback` is only invoked when context-local storage is
+    // valid.
+    unsafe {
+        assert!(context_get().is_null());
+        context_set(state.cast());
+        callback(EVENT_NONE, 0, 0)
     }
-
-    let trap_on_drop = TrapOnDrop;
-
-    match status {
-        STATUS_STARTING | STATUS_STARTED => {
-            (*CURRENT).add_waitable(call as u32);
-            let (tx, rx) = oneshot::channel();
-            CALLS.insert(call, tx);
-            rx.await.unwrap();
-        }
-        STATUS_RETURNED => {}
-        _ => unreachable!("unrecognized async call status"),
-    }
-
-    mem::forget(trap_on_drop);
-
-    struct TrapOnDrop;
-
-    impl Drop for TrapOnDrop {
-        fn drop(&mut self) {
-            trap_because_of_future_drop();
-        }
-    }
-}
-
-#[cold]
-fn trap_because_of_future_drop() {
-    panic!(
-        "an imported function is being dropped/cancelled before being fully \
-         awaited, but that is not sound at this time so the program is going \
-         to be aborted; for more information see \
-         https://github.com/bytecodealliance/wit-bindgen/issues/1175"
-    );
 }
 
 /// stream/future read/write results defined by the Component Model ABI.
@@ -309,193 +324,35 @@ mod results {
     pub const CANCELED: u32 = 0;
 }
 
-/// Call the `subtask.drop` canonical built-in function.
-fn subtask_drop(subtask: u32) {
-    #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn subtask_drop(_: u32) {
-        unreachable!()
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[link(wasm_import_module = "$root")]
-    extern "C" {
-        #[link_name = "[subtask-drop]"]
-        fn subtask_drop(_: u32);
-    }
-    unsafe { subtask_drop(subtask) }
-}
-
-unsafe fn callback_code(state: *mut FutureState, done: bool) -> i32 {
-    if done && !(*state).remaining_work() {
-        context_set(0);
-        drop(Box::from_raw(state));
-        CALLBACK_CODE_EXIT
-    } else {
-        context_set(i32::try_from(state as isize).unwrap() as u32);
-        CALLBACK_CODE_WAIT | (((*state).waitable_set.unwrap() as i32) << 4)
-    }
-}
-
 /// Handle a progress notification from the host regarding either a call to an
 /// async-lowered import or a stream/future read/write operation.
+///
+/// # Unsafety
+///
+/// This function assumes that `context_get()` returns a `FutureState`.
 #[doc(hidden)]
-pub unsafe fn callback(event0: i32, event1: i32, event2: i32) -> i32 {
-    let state = isize::try_from(context_get()).unwrap() as *mut FutureState;
+pub unsafe fn callback(event0: u32, event1: u32, event2: u32) -> u32 {
+    // Acquire our context-local state, assert it's not-null, and then reset
+    // the state to null while we're running to help prevent any unintended
+    // usage.
+    let state = context_get().cast::<FutureState>();
     assert!(!state.is_null());
-
-    callback_with_state(state, event0, event1, event2)
-}
-
-unsafe fn callback_with_state(
-    state: *mut FutureState,
-    event0: i32,
-    event1: i32,
-    event2: i32,
-) -> i32 {
-    match event0 {
-        EVENT_NONE => {
-            rtdebug!("EVENT_NONE");
-            let done = poll(state).is_ready();
-            callback_code(state, done)
-        }
-        EVENT_CALL_STARTED => {
-            rtdebug!("EVENT_CALL_STARTED");
-            callback_code(state, false)
-        }
-        EVENT_CALL_RETURNED => {
-            rtdebug!("EVENT_CALL_RETURNED({event1:#x}, {event2:#x})");
-            (*state).remove_waitable(event1 as _);
-
-            if let Some(call) = CALLS.remove(&event1) {
-                _ = call.send(event2 as _);
-            }
-
-            let done = poll(state).is_ready();
-
-            if event0 == EVENT_CALL_RETURNED {
-                subtask_drop(event1 as u32);
-            }
-
-            (*state).todo -= 1;
-
-            callback_code(state, done)
-        }
-
-        EVENT_STREAM_READ | EVENT_STREAM_WRITE | EVENT_FUTURE_READ | EVENT_FUTURE_WRITE => {
-            rtdebug!(
-                "EVENT_{{STREAM,FUTURE}}_{{READ,WRITE}}({event0:#x}, {event1:#x}, {event2:#x})"
-            );
-            (*state).remove_waitable(event1 as u32);
-            let (ptr, callback) = (*state).waitables.remove(&(event1 as u32)).unwrap();
-            callback(ptr, event2 as u32);
-
-            let done = poll(state).is_ready();
-            callback_code(state, done)
-        }
-
-        _ => unreachable!(),
-    }
-}
-
-/// Represents the Component Model `error-context` type.
-#[derive(PartialEq, Eq)]
-pub struct ErrorContext {
-    handle: u32,
-}
-
-impl ErrorContext {
-    /// Call the `error-context.new` canonical built-in function.
-    pub fn new(debug_message: &str) -> ErrorContext {
-        #[cfg(not(target_arch = "wasm32"))]
-        unsafe fn context_new(_: *const u8, _: usize) -> i32 {
-            unreachable!()
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        #[link(wasm_import_module = "$root")]
-        extern "C" {
-            #[link_name = "[error-context-new-utf8]"]
-            fn context_new(_: *const u8, _: usize) -> i32;
-        }
-
-        unsafe {
-            let handle = context_new(debug_message.as_ptr(), debug_message.len());
-            // SAFETY: Handles (including error context handles are guaranteed to
-            // fit inside u32 by the Component Model ABI
-            ErrorContext::from_handle(u32::try_from(handle).unwrap())
-        }
+    unsafe {
+        context_set(ptr::null_mut());
     }
 
-    #[doc(hidden)]
-    pub fn from_handle(handle: u32) -> Self {
-        Self { handle }
-    }
-
-    #[doc(hidden)]
-    pub fn handle(&self) -> u32 {
-        self.handle
-    }
-
-    /// Extract the debug message from a given [`ErrorContext`]
-    pub fn debug_message(&self) -> String {
-        #[repr(C)]
-        struct RetPtr {
-            ptr: *mut u8,
-            len: usize,
+    // Use `state` to run the `callback` function in the context of our event
+    // codes we received. If the callback decides to exit then we're done with
+    // our future so deallocate it. Otherwise put our future back in
+    // context-local storage and forward the code.
+    unsafe {
+        let rc = (*state).callback(event0, event1, event2);
+        if rc == CALLBACK_CODE_EXIT {
+            drop(Box::from_raw(state));
+        } else {
+            context_set(state.cast());
         }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        fn error_context_debug_message(_: u32, _: &mut RetPtr) {
-            unreachable!()
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        #[link(wasm_import_module = "$root")]
-        extern "C" {
-            #[link_name = "[error-context-debug-message-utf8]"]
-            fn error_context_debug_message(_: u32, _: &mut RetPtr);
-        }
-
-        unsafe {
-            let mut ret = RetPtr {
-                ptr: ptr::null_mut(),
-                len: 0,
-            };
-            error_context_debug_message(self.handle, &mut ret);
-            String::from_raw_parts(ret.ptr, ret.len, ret.len)
-        }
-    }
-}
-
-impl Debug for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ErrorContext")
-            .field("debug_message", &self.debug_message())
-            .finish()
-    }
-}
-
-impl Display for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.debug_message(), f)
-    }
-}
-
-impl std::error::Error for ErrorContext {}
-
-impl Drop for ErrorContext {
-    fn drop(&mut self) {
-        #[cfg(target_arch = "wasm32")]
-        {
-            #[link(wasm_import_module = "$root")]
-            extern "C" {
-                #[link_name = "[error-context-drop]"]
-                fn error_drop(_: u32);
-            }
-            if self.handle != 0 {
-                unsafe { error_drop(self.handle) }
-            }
-        }
+        rc
     }
 }
 
@@ -516,10 +373,11 @@ pub fn spawn(future: impl Future<Output = ()> + 'static) {
 pub fn block_on<T: 'static>(future: impl Future<Output = T> + 'static) -> T {
     let (tx, mut rx) = oneshot::channel();
     let state = &mut FutureState::new(Box::pin(future.map(move |v| drop(tx.send(v)))) as BoxFuture);
+    let mut event = (EVENT_NONE, 0, 0);
     loop {
-        match unsafe { poll(state) } {
-            Poll::Ready(()) => break rx.try_recv().unwrap().unwrap(),
-            Poll::Pending => waitable_set_wait(state),
+        match state.callback(event.0, event.1, event.2) {
+            CALLBACK_CODE_EXIT => break rx.try_recv().unwrap().unwrap(),
+            _ => event = state.waitable_set.as_ref().unwrap().wait(),
         }
     }
 }
@@ -565,9 +423,9 @@ pub fn backpressure_set(enabled: bool) {
     unsafe { backpressure_set(if enabled { 1 } else { 0 }) }
 }
 
-fn context_get() -> u32 {
+fn context_get() -> *mut u8 {
     #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn get() -> u32 {
+    unsafe fn get() -> *mut u8 {
         unreachable!()
     }
 
@@ -575,15 +433,15 @@ fn context_get() -> u32 {
     #[link(wasm_import_module = "$root")]
     extern "C" {
         #[link_name = "[context-get-1]"]
-        fn get() -> u32;
+        fn get() -> *mut u8;
     }
 
     unsafe { get() }
 }
 
-fn context_set(value: u32) {
+unsafe fn context_set(value: *mut u8) {
     #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn set(_: u32) {
+    unsafe fn set(_: *mut u8) {
         unreachable!()
     }
 
@@ -591,71 +449,8 @@ fn context_set(value: u32) {
     #[link(wasm_import_module = "$root")]
     extern "C" {
         #[link_name = "[context-set-1]"]
-        fn set(value: u32);
+        fn set(value: *mut u8);
     }
 
     unsafe { set(value) }
-}
-
-fn waitable_set_new() -> u32 {
-    #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn new() -> u32 {
-        unreachable!()
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[link(wasm_import_module = "$root")]
-    extern "C" {
-        #[link_name = "[waitable-set-new]"]
-        fn new() -> u32;
-    }
-
-    unsafe { new() }
-}
-
-fn waitable_set_drop(set: u32) {
-    #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn drop(_: u32) {
-        unreachable!()
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[link(wasm_import_module = "$root")]
-    extern "C" {
-        #[link_name = "[waitable-set-drop]"]
-        fn drop(set: u32);
-    }
-
-    unsafe { drop(set) }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn waitable_join(_: u32, _: u32) {
-    unreachable!()
-}
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "$root")]
-extern "C" {
-    #[link_name = "[waitable-join]"]
-    fn waitable_join(waitable: u32, set: u32);
-}
-
-fn waitable_set_wait(state: &mut FutureState) {
-    #[cfg(not(target_arch = "wasm32"))]
-    unsafe fn wait(_: u32, _: *mut i32) -> i32 {
-        unreachable!();
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[link(wasm_import_module = "$root")]
-    extern "C" {
-        #[link_name = "[waitable-set-wait]"]
-        fn wait(_: u32, _: *mut i32) -> i32;
-    }
-
-    unsafe {
-        let mut payload = [0i32; 2];
-        let event0 = wait(state.get_or_create_waitable_set(), payload.as_mut_ptr());
-        callback_with_state(state as *mut _, event0, payload[0], payload[1]);
-    }
 }

--- a/crates/guest-rust/rt/src/async_support/error_context.rs
+++ b/crates/guest-rust/rt/src/async_support/error_context.rs
@@ -1,0 +1,94 @@
+//! Raw bindings to `error-context` in the canonical ABI.
+
+use std::fmt::{self, Debug, Display};
+use std::ptr;
+use std::string::String;
+
+/// Represents the Component Model `error-context` type.
+#[derive(PartialEq, Eq)]
+pub struct ErrorContext {
+    handle: u32,
+}
+
+impl ErrorContext {
+    /// Call the `error-context.new` canonical built-in function.
+    pub fn new(debug_message: &str) -> ErrorContext {
+        unsafe {
+            let handle = new(debug_message.as_ptr(), debug_message.len());
+            ErrorContext::from_handle(handle)
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn from_handle(handle: u32) -> Self {
+        Self { handle }
+    }
+
+    #[doc(hidden)]
+    pub fn handle(&self) -> u32 {
+        self.handle
+    }
+
+    /// Extract the debug message from a given [`ErrorContext`]
+    pub fn debug_message(&self) -> String {
+        unsafe {
+            let mut ret = RetPtr {
+                ptr: ptr::null_mut(),
+                len: 0,
+            };
+            debug_message(self.handle, &mut ret);
+            String::from_raw_parts(ret.ptr, ret.len, ret.len)
+        }
+    }
+}
+
+impl Debug for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ErrorContext")
+            .field("debug_message", &self.debug_message())
+            .finish()
+    }
+}
+
+impl Display for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.debug_message(), f)
+    }
+}
+
+impl std::error::Error for ErrorContext {}
+
+impl Drop for ErrorContext {
+    fn drop(&mut self) {
+        #[cfg(target_arch = "wasm32")]
+        unsafe {
+            drop(self.handle)
+        }
+    }
+}
+
+#[repr(C)]
+struct RetPtr {
+    ptr: *mut u8,
+    len: usize,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn new(_: *const u8, _: usize) -> u32 {
+    unreachable!()
+}
+#[cfg(not(target_arch = "wasm32"))]
+fn debug_message(_: u32, _: &mut RetPtr) {
+    unreachable!()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "$root")]
+extern "C" {
+    #[link_name = "[error-context-new-utf8]"]
+    fn new(_: *const u8, _: usize) -> u32;
+    #[link_name = "[error-context-drop]"]
+    fn drop(_: u32);
+    #[link_name = "[error-context-debug-message-utf8]"]
+    fn debug_message(_: u32, _: &mut RetPtr);
+}

--- a/crates/guest-rust/rt/src/async_support/subtask.rs
+++ b/crates/guest-rust/rt/src/async_support/subtask.rs
@@ -1,0 +1,226 @@
+//! Bindings used to manage subtasks, or invocations of imported functions.
+//!
+//! See `future_support` for some more discussion but the basic idea is the same
+//! where we require that everything is passed by ownership to primarily deal
+//! with the possibility of leaking futures. By always requiring ownership we
+//! can guarantee that even when a future is leaked all its parameters passed to
+//! the canonical ABI are additionally leaked with it which should be memory
+//! safe.
+
+use crate::async_support::waitable::{WaitableOp, WaitableOperation};
+use crate::async_support::{STATUS_RETURNED, STATUS_STARTED, STATUS_STARTING};
+use crate::Cleanup;
+use std::alloc::Layout;
+use std::future::Future;
+use std::marker;
+use std::num::NonZeroU32;
+use std::ptr;
+
+/// Raw operations used to invoke an imported asynchronous function.
+///
+/// This trait is implemented by generated bindings and is used to implement
+/// asynchronous imports.
+///
+/// # Unsafety
+///
+/// All operations/constants must be self-consistent for how this module expects
+/// them all to be used.
+pub unsafe trait Subtask {
+    /// The in-memory layout of both parameters and results allocated with
+    /// parameters coming first.
+    const ABI_LAYOUT: Layout;
+
+    /// The offset, in bytes, from the start of `ABI_LAYOUT` to where the
+    /// results will be stored.
+    const RESULTS_OFFSET: usize;
+
+    /// The parameters to this task.
+    type Params;
+    /// The results of this task.
+    type Results;
+
+    /// The raw function import using `[async-lower]` and the canonical ABI.
+    unsafe fn call_import(params: *mut u8, results: *mut u8) -> u32;
+
+    /// Bindings-generated version of lowering `params` into a heap-allocated
+    /// `dst`.
+    unsafe fn params_lower(params: Self::Params, dst: *mut u8);
+
+    /// Bindings-generated version of deallocating any lists stored within
+    /// `dst`.
+    unsafe fn params_dealloc_lists(dst: *mut u8);
+
+    /// Bindings-generated version of lifting the results stored at `src`.
+    unsafe fn results_lift(src: *mut u8) -> Self::Results;
+
+    /// Helper function to actually perform this asynchronous call with
+    /// `params`.
+    fn call(params: Self::Params) -> impl Future<Output = Self::Results>
+    where
+        Self: Sized,
+    {
+        WaitableOperation::<SubtaskOps<Self>>::new(Start { params })
+    }
+}
+
+struct SubtaskOps<T>(marker::PhantomData<T>);
+
+struct Start<T: Subtask> {
+    params: T::Params,
+}
+
+unsafe impl<T: Subtask> WaitableOp for SubtaskOps<T> {
+    type Start = Start<T>;
+    type InProgress = InProgress<T>;
+    type Result = T::Results;
+    type Cancel = ();
+
+    fn start(state: Self::Start) -> (u32, Self::InProgress) {
+        unsafe {
+            let (ptr_params, cleanup) = Cleanup::new(T::ABI_LAYOUT);
+            let ptr_results = ptr_params.add(T::RESULTS_OFFSET);
+            T::params_lower(state.params, ptr_params);
+            let result = T::call_import(ptr_params, ptr_results);
+            // FIXME(bytecodealliance/wasip3-prototyping#99) the decoding of the
+            // result here isn't standards-compliant.
+            let code = result >> 30;
+            let subtask =
+                NonZeroU32::new((result << 2) >> 2).map(|handle| SubtaskHandle { handle });
+
+            (
+                code,
+                InProgress {
+                    params_and_results: cleanup,
+                    subtask,
+                    started: false,
+                    _marker: marker::PhantomData,
+                },
+            )
+        }
+    }
+
+    fn start_cancelled(_state: Self::Start) -> Self::Cancel {}
+
+    fn in_progress_update(
+        mut state: Self::InProgress,
+        code: u32,
+    ) -> Result<Self::Result, Self::InProgress> {
+        match code {
+            // Nothing new to do in this state, we're still waiting for the task
+            // to start.
+            STATUS_STARTING => {
+                assert!(!state.started);
+                Err(state)
+            }
+
+            // Still not done yet, but we can record that this is started and
+            // otherwise deallocate lists in the parameters.
+            STATUS_STARTED => {
+                state.flag_started();
+                Err(state)
+            }
+
+            STATUS_RETURNED => {
+                // Conditionally flag as started if we haven't otherwise
+                // explicitly transitioned through `STATUS_STARTED`.
+                if !state.started {
+                    state.flag_started();
+                }
+
+                // Now that our results have been written we can read them.
+                //
+                // Note that by dropping `state` here we'll both deallocate the
+                // params/results storage area as well as the subtask handle
+                // itself.
+                unsafe { Ok(T::results_lift(state.ptr_results())) }
+            }
+            other => panic!("unknown code {other:#x}"),
+        }
+    }
+
+    fn in_progress_waitable(state: &Self::InProgress) -> u32 {
+        // This shouldn't get called in the one case this isn't present: when
+        // `STATUS_RETURNED` is returned and no waitable is created. That's the
+        // `unwrap()` condition here.
+        state.subtask.as_ref().unwrap().handle.get()
+    }
+
+    fn in_progress_cancel(_: &Self::InProgress) -> u32 {
+        // FIXME: plan is to implement cancellation in the canonical ABI in the
+        // near future, this will get filled out soon in theory.
+        trap_because_of_future_cancel()
+    }
+
+    fn result_into_cancel(_result: Self::Result) -> Self::Cancel {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+struct SubtaskHandle {
+    handle: NonZeroU32,
+}
+
+impl Drop for SubtaskHandle {
+    fn drop(&mut self) {
+        unsafe {
+            subtask_drop(self.handle.get());
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        unsafe fn subtask_drop(_: u32) {
+            unreachable!()
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[link(wasm_import_module = "$root")]
+        extern "C" {
+            #[link_name = "[subtask-drop]"]
+            fn subtask_drop(handle: u32);
+        }
+    }
+}
+
+struct InProgress<T: Subtask> {
+    params_and_results: Option<Cleanup>,
+    started: bool,
+    subtask: Option<SubtaskHandle>,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<T: Subtask> InProgress<T> {
+    fn flag_started(&mut self) {
+        assert!(!self.started);
+        self.started = true;
+
+        // SAFETY: the initial entrypoint of `call` requires that the vtable is
+        // setup correctly and we're obeying the invariants of the vtable,
+        // deallocating lists in an allocation that we exclusively own.
+        unsafe {
+            T::params_dealloc_lists(self.ptr_params());
+        }
+    }
+
+    fn ptr_params(&self) -> *mut u8 {
+        self.params_and_results
+            .as_ref()
+            .map(|c| c.ptr.as_ptr())
+            .unwrap_or(ptr::null_mut())
+    }
+
+    fn ptr_results(&self) -> *mut u8 {
+        // SAFETY: the `T` trait has unsafely promised us that the offset is
+        // in-bounds of the allocation layout.
+        unsafe { self.ptr_params().add(T::RESULTS_OFFSET) }
+    }
+}
+
+#[cold]
+fn trap_because_of_future_cancel() -> ! {
+    panic!(
+        "an imported function is being dropped/cancelled before being fully \
+         awaited, but that is not sound at this time so the program is going \
+         to be aborted; for more information see \
+         https://github.com/bytecodealliance/wit-bindgen/issues/1175"
+    )
+}

--- a/crates/guest-rust/rt/src/async_support/waitable_set.rs
+++ b/crates/guest-rust/rt/src/async_support/waitable_set.rs
@@ -1,0 +1,69 @@
+//! Low-level FFI-like bindings around `waitable-set` in the canonical ABI.
+
+use std::num::NonZeroU32;
+
+pub struct WaitableSet(NonZeroU32);
+
+impl WaitableSet {
+    pub fn new() -> WaitableSet {
+        WaitableSet(NonZeroU32::new(unsafe { new() }).unwrap())
+    }
+
+    pub fn join(&self, waitable: u32) {
+        unsafe { join(waitable, self.0.get()) }
+    }
+
+    pub fn remove_waitable_from_all_sets(waitable: u32) {
+        unsafe { join(waitable, 0) }
+    }
+
+    pub fn wait(&self) -> (u32, u32, u32) {
+        unsafe {
+            let mut payload = [0; 2];
+            let event0 = wait(self.0.get(), &mut payload);
+            (event0, payload[0], payload[1])
+        }
+    }
+
+    pub fn as_raw(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl Drop for WaitableSet {
+    fn drop(&mut self) {
+        unsafe {
+            drop(self.0.get());
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn new() -> u32 {
+    unreachable!()
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn drop(_: u32) {
+    unreachable!()
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn join(_: u32, _: u32) {
+    unreachable!()
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn wait(_: u32, _: *mut [u32; 2]) -> u32 {
+    unreachable!();
+}
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "$root")]
+extern "C" {
+    #[link_name = "[waitable-set-new]"]
+    fn new() -> u32;
+    #[link_name = "[waitable-set-drop]"]
+    fn drop(set: u32);
+    #[link_name = "[waitable-join]"]
+    fn join(waitable: u32, set: u32);
+    #[link_name = "[waitable-set-wait]"]
+    fn wait(_: u32, _: *mut [u32; 2]) -> u32;
+}

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -82,7 +82,7 @@ pub extern "wasm" fn f32_to_i64(value : Float) -> Int64 =
 // set pseudo header; allocate extra bytes for string
 pub extern "wasm" fn malloc(size : Int) -> Int =
   #|(func (param i32) (result i32) (local i32)
-  #| local.get 0 i32.const 4 i32.add call $moonbit.gc.malloc 
+  #| local.get 0 i32.const 4 i32.add call $moonbit.gc.malloc
   #| local.tee 1 i32.const 0 call $moonbit.init_array8
   #| local.get 1 i32.const 8 i32.add)
 
@@ -2667,8 +2667,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             | Instruction::StreamLower { .. }
             | Instruction::StreamLift { .. }
             | Instruction::ErrorContextLower { .. }
-            | Instruction::ErrorContextLift { .. }
-            | Instruction::AsyncCallWasm { .. } => todo!(),
+            | Instruction::ErrorContextLift { .. } => todo!(),
         }
     }
 

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -859,17 +859,6 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str(");\n");
             }
 
-            Instruction::AsyncCallWasm { name, .. } => {
-                let func = self.declare_import(name, &[WasmType::Pointer; 2], &[WasmType::I32]);
-
-                let async_support = self.r#gen.r#gen.async_support_path();
-                let operands = operands.join(", ");
-                uwriteln!(
-                    self.src,
-                    "{async_support}::await_result({func}, {operands}).await;"
-                );
-            }
-
             Instruction::CallInterface { func, .. } => {
                 if self.async_ {
                     self.push_str(&format!("let result = "));


### PR DESCRIPTION
Some more details in the commit messages, but the main changes here are:

* Imported subtasks are managed entirely differently now.
* Imported functions now take all arguments by ownership, nothing is borrowed except for borrowed resources.
* This fixes an invalid-free of a stack pointer when the `block_on` intrinsic is used.
  * Lots of refactoring was needed to achieve this in a "clean" way
* In the future it should be much easier to "slot in" cancellation of imported subtasks.
