### PR TITLE
Add `#[serde(default)]` to `wit-bindgen-rust::Opts`

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -194,7 +194,7 @@ fn parse_async(s: &str) -> Result<AsyncConfig, String> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize),
-    serde(rename_all = "kebab-case")
+    serde(default, rename_all = "kebab-case")
 )]
 pub struct Opts {
     /// Whether or not a formatter is executed to format generated code.


### PR DESCRIPTION
I missed adding `#[serde(default)]` when I added the `serde::Deserialize` implementation to `wit-bindgen-rust::Opts` in #1244. So every single field in the struct currently needs to be specified in the serialised options to be deserialisable. This PR corrects that