### PR TITLE
fix(moonbit): Update keywords

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -2880,7 +2880,7 @@ impl ToMoonBitIdent for str {
             | "struct" | "enum" | "trait" | "traitalias" | "derive" | "while" | "break"
             | "continue" | "import" | "return" | "throw" | "raise" | "try" | "catch" | "pub"
             | "priv" | "readonly" | "true" | "false" | "_" | "test" | "loop" | "for" | "in"
-            | "impl" | "with" | "guard" | "async" | "is" => {
+            | "impl" | "with" | "guard" | "async" | "is" | "init" | "main" => {
                 format!("{self}_")
             }
             _ => self.to_snake_case(),

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -2871,13 +2871,16 @@ trait ToMoonBitIdent: ToOwned {
 
 impl ToMoonBitIdent for str {
     fn to_moonbit_ident(&self) -> String {
-        // Escape MoonBit keywords
+        // Escape MoonBit keywords and reserved keywords
         match self {
-            "continue" | "for" | "match" | "if" | "pub" | "priv" | "readonly" | "break"
-            | "raise" | "try" | "except" | "catch" | "else" | "enum" | "struct" | "type"
-            | "trait" | "return" | "let" | "mut" | "while" | "loop" | "extern" | "with"
-            | "throw" | "init" | "main" | "test" | "in" | "guard" | "typealias" | "const"
-            | "method" | "move" | "do" | "static" | "final" => {
+            "module" | "move" | "ref" | "static" | "super" | "unsafe" | "use" | "where"
+            | "await" | "dyn" | "abstract" | "do" | "final" | "macro" | "override" | "typeof"
+            | "virtual" | "yield" | "local" | "method" | "alias" | "assert" | "as" | "else"
+            | "extern" | "fn" | "if" | "let" | "const" | "match" | "mut" | "type" | "typealias"
+            | "struct" | "enum" | "trait" | "traitalias" | "derive" | "while" | "break"
+            | "continue" | "import" | "return" | "throw" | "raise" | "try" | "catch" | "pub"
+            | "priv" | "readonly" | "true" | "false" | "_" | "test" | "loop" | "for" | "in"
+            | "impl" | "with" | "guard" | "async" | "is" => {
                 format!("{self}_")
             }
             _ => self.to_snake_case(),


### PR DESCRIPTION
Keyword list taken from https://github.com/moonbitlang/moonbit-compiler/blob/main/src/lex_keyword_tbl.ml

I removed `expect`, `main`, and `init`, as they're not listed as reserved in the compiler.
@peter-jerry-ye can you confirm that it's safe to remove them?
Keeping this draft until that's confirmed.