### PR TITLE
Conditionally use `wac` or `wasm-compose` for `wit-bindgen test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +135,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -142,7 +151,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "codegen-macro"
 version = "0.0.0"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "quote",
 ]
 
@@ -341,6 +350,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -350,6 +365,20 @@ name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "indexmap"
@@ -580,6 +609,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +739,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
 ]
 
 [[package]]
@@ -814,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,10 +917,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wac-graph"
@@ -908,6 +993,27 @@ name = "wasi-preview1-component-adapter-provider"
 version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddbd7f2a9e3635abe5d4df93b12cadc8d6818079785ee4fab3719ae3c85a064e"
+
+[[package]]
+name = "wasm-compose"
+version = "0.229.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b2e985adc26dec5d6b9d40bf95923fbabb5bc5244582430016f88a129ebf48"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "im-rc",
+ "indexmap",
+ "log",
+ "petgraph",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "smallvec",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
+ "wat",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -1098,7 +1204,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "heck",
+ "heck 0.5.0",
  "wasm-encoder 0.229.0",
  "wasm-metadata 0.229.0",
  "wit-bindgen-core",
@@ -1128,7 +1234,7 @@ name = "wit-bindgen-core"
 version = "0.41.0"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -1138,7 +1244,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "wasm-metadata 0.229.0",
  "wit-bindgen-core",
@@ -1152,7 +1258,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "heck",
+ "heck 0.5.0",
  "pulldown-cmark",
  "wit-bindgen-core",
 ]
@@ -1163,7 +1269,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "heck",
+ "heck 0.5.0",
  "wit-bindgen-core",
 ]
 
@@ -1183,7 +1289,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "serde",
@@ -1216,7 +1322,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "log",
  "rayon",
@@ -1227,6 +1333,7 @@ dependencies = [
  "wac-parser",
  "wac-types",
  "wasi-preview1-component-adapter-provider",
+ "wasm-compose",
  "wasm-encoder 0.229.0",
  "wasmparser 0.229.0",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ wasm-encoder = "0.229.0"
 wasm-metadata = { version = "0.229.0", default-features = false }
 wit-parser = "0.229.0"
 wit-component = "0.229.0"
+wasm-compose = "0.229.0"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.41.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.41.0' }

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -27,6 +27,7 @@ wasi-preview1-component-adapter-provider = "30.0.2"
 wac-parser = "0.6.1"
 wac-types = "0.6.1"
 wac-graph = "0.6.1"
+wasm-compose = { workspace = true }
 indexmap = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true, features = ["features"] }


### PR DESCRIPTION
While `wac` is being merged upstream into `wasm-tools` fall back to using `wasm-compose` when `wac` is not otherwise necessary. This ensures that there's a composition tool used which is at the same version as all the other wasm-tools tools which `wac` doesn't guarantee just yet.