### PR TITLE
Add some more async tests

### DIFF
--- a/crates/guest-rust/rt/src/async_support/future_support.rs
+++ b/crates/guest-rust/rt/src/async_support/future_support.rs
@@ -437,6 +437,7 @@ impl<T> fmt::Display for FutureWriteError<T> {
 impl<T> std::error::Error for FutureWriteError<T> {}
 
 /// Result of [`FutureWrite::cancel`].
+#[derive(Debug)]
 pub enum FutureWriteCancel<T: 'static> {
     /// The cancel request raced with the receipt of the sent value, and the
     /// value was actually sent. Neither the value nor the writer are made

--- a/crates/guest-rust/rt/src/async_support/subtask.rs
+++ b/crates/guest-rust/rt/src/async_support/subtask.rs
@@ -149,8 +149,8 @@ unsafe impl<T: Subtask> WaitableOp for SubtaskOps<T> {
         trap_because_of_future_cancel()
     }
 
-    fn result_into_cancel(_result: Self::Result) -> Self::Cancel {
-        todo!()
+    fn result_into_cancel(result: Self::Result) -> Self::Cancel {
+        drop(result);
     }
 }
 

--- a/crates/guest-rust/rt/src/async_support/waitable.rs
+++ b/crates/guest-rust/rt/src/async_support/waitable.rs
@@ -322,6 +322,15 @@ where
         if let Some(cx) = cx {
             let handle = S::in_progress_waitable(in_progress);
             self.register_waker(handle, cx);
+        } else {
+            // This should not be dynamically reachable and, if it were, it may
+            // mean that this needs to be re-thought and/or the caller should be
+            // adjusted. Conservatively panic for now to defer fleshing this out
+            // for later.
+            panic!(
+                "unexpected poll to completion in a non-future way (no context) \
+                 and this operation is still pending"
+            );
         }
         Poll::Pending
     }

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -895,6 +895,7 @@ pub mod rt {
 
 #[cfg(feature = "async")]
 pub use wit_bindgen_rt::async_support::{
-    AbiBuffer, FutureRead, FutureReader, FutureWrite, FutureWriter, StreamRead, StreamReader,
-    StreamResult, StreamWrite, StreamWriter,
+    block_on, spawn, AbiBuffer, FutureRead, FutureReader, FutureWrite, FutureWriteCancel,
+    FutureWriteError, FutureWriter, StreamRead, StreamReader, StreamResult, StreamWrite,
+    StreamWriter,
 };

--- a/tests/runtime-async/async/future-cancel-read/runner.rs
+++ b/tests/runtime-async/async/future-cancel-read/runner.rs
@@ -1,0 +1,17 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::*;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new();
+        cancel_before_read(rx).await;
+        drop(tx);
+
+        let (tx, rx) = wit_future::new();
+        cancel_after_read(rx).await;
+        drop(tx);
+
+        start_read_then_cancel().await;
+    });
+}

--- a/tests/runtime-async/async/future-cancel-read/test.rs
+++ b/tests/runtime-async/async/future-cancel-read/test.rs
@@ -1,0 +1,43 @@
+use wit_bindgen::FutureReader;
+
+use futures::task::noop_waker_ref;
+use std::future::{Future, IntoFuture};
+use std::task::Context;
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn cancel_before_read(x: FutureReader<u32>) {
+        let mut read = Box::pin(x.into_future());
+        let reader = read.as_mut().cancel().unwrap_err();
+        drop(reader);
+    }
+
+    async fn cancel_after_read(x: FutureReader<u32>) {
+        let mut read = Box::pin(x.into_future());
+        assert!(read
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        let reader = read.as_mut().cancel().unwrap_err();
+        drop(reader);
+    }
+
+    async fn start_read_then_cancel() {
+        // FIXME(wasip3-prototyping#137)
+        if false {
+            let (tx, rx) = wit_future::new::<u32>();
+            let mut read = Box::pin(rx.into_future());
+            assert!(read
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            drop(tx);
+            assert!(read.as_mut().cancel().unwrap().is_none());
+        }
+    }
+}

--- a/tests/runtime-async/async/future-cancel-read/test.wit
+++ b/tests/runtime-async/async/future-cancel-read/test.wit
@@ -1,0 +1,15 @@
+package my:test;
+
+interface i {
+  cancel-before-read: async func(x: future<u32>);
+  cancel-after-read: async func(x: future<u32>);
+  start-read-then-cancel: async func();
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/future-cancel-write/runner.rs
+++ b/tests/runtime-async/async/future-cancel-write/runner.rs
@@ -1,0 +1,78 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::{read_and_drop, take_then_close};
+use futures::task::noop_waker_ref;
+use std::future::Future;
+use std::task::Context;
+use wit_bindgen::FutureWriteCancel;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        // cancel from the other end
+        let (tx, rx) = wit_future::new();
+        let f1 = async { tx.write("hello".into()).await };
+        let f2 = async { take_then_close(rx) };
+        let (result, ()) = futures::join!(f1, f2);
+        assert_eq!(result.unwrap_err().value, "hello");
+
+        // cancel before we actually hit the intrinsic
+        let (tx, _rx) = wit_future::new::<String>();
+        let mut future = Box::pin(tx.write("hello2".into()));
+        let tx = match future.as_mut().cancel() {
+            FutureWriteCancel::Cancelled(val, tx) => {
+                assert_eq!(val, "hello2");
+                tx
+            }
+            _ => unreachable!(),
+        };
+
+        // cancel after we hit the intrinsic
+        let mut future = Box::pin(tx.write("hello3".into()));
+        assert!(future
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        match future.as_mut().cancel() {
+            FutureWriteCancel::Cancelled(val, _) => {
+                assert_eq!(val, "hello3");
+            }
+            _ => unreachable!(),
+        };
+
+        // cancel after we hit the intrinsic and then close the other end
+        //
+        // FIXME(wasip3-prototyping#137)
+        if false {
+            let (tx, rx) = wit_future::new::<String>();
+            let mut future = Box::pin(tx.write("hello3".into()));
+            assert!(future
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            drop(rx);
+            match future.as_mut().cancel() {
+                FutureWriteCancel::Closed(val) => assert_eq!(val, "hello3"),
+                other => panic!("expected closed, got: {other:?}"),
+            };
+        }
+
+        // Start a write, wait for it to be pending, then go complete the write
+        // in some async work, then cancel it and witness that it was written,
+        // not cancelled.
+        //
+        // FIXME(wasip3-prototyping#138)
+        if false {
+            let (tx, rx) = wit_future::new::<String>();
+            let mut future = Box::pin(tx.write("hello3".into()));
+            assert!(future
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            read_and_drop(rx).await;
+            match future.as_mut().cancel() {
+                FutureWriteCancel::AlreadySent => {}
+                other => panic!("expected sent, got: {other:?}"),
+            };
+        }
+    });
+}

--- a/tests/runtime-async/async/future-cancel-write/test.rs
+++ b/tests/runtime-async/async/future-cancel-write/test.rs
@@ -1,0 +1,16 @@
+use wit_bindgen::FutureReader;
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    fn take_then_close(x: FutureReader<String>) {
+        drop(x)
+    }
+    async fn read_and_drop(x: FutureReader<String>) {
+        x.await.unwrap();
+    }
+}

--- a/tests/runtime-async/async/future-cancel-write/test.wit
+++ b/tests/runtime-async/async/future-cancel-write/test.wit
@@ -1,0 +1,14 @@
+package my:test;
+
+interface i {
+  take-then-close: func(x: future<string>);
+  read-and-drop: async func(x: future<string>);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/pending-import/runner.rs
+++ b/tests/runtime-async/async/pending-import/runner.rs
@@ -1,0 +1,67 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::*;
+use futures::task::noop_waker_ref;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+fn main() {
+    // Test that Rust-level polling twice works.
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new();
+        let mut import = Box::pin(pending_import(rx));
+        assert!(import
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        assert!(import
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        tx.write(()).await.unwrap();
+        import.await;
+    });
+
+    // Start the imported function call, get it pending, then let it complete by
+    // finishing `tx`, then yield a few times to ensure that the runtime gets
+    // the completion of the task-at-hand, and then drop it without completing
+    // it.
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new();
+        let mut import = Box::pin(pending_import(rx));
+        assert!(import
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        tx.write(()).await.unwrap();
+
+        for _ in 0..5 {
+            yield_().await;
+        }
+        drop(import);
+    });
+}
+
+async fn yield_() {
+    #[derive(Default)]
+    struct Yield {
+        yielded: bool,
+    }
+
+    impl Future for Yield {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<()> {
+            if self.yielded {
+                Poll::Ready(())
+            } else {
+                self.yielded = true;
+                context.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    Yield::default().await;
+}

--- a/tests/runtime-async/async/pending-import/test.rs
+++ b/tests/runtime-async/async/pending-import/test.rs
@@ -1,0 +1,13 @@
+use wit_bindgen::FutureReader;
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn pending_import(x: FutureReader<()>) {
+        x.await.unwrap();
+    }
+}

--- a/tests/runtime-async/async/pending-import/test.wit
+++ b/tests/runtime-async/async/pending-import/test.wit
@@ -1,0 +1,13 @@
+package my:test;
+
+interface i {
+  pending-import: async func(x: future);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/ping-pong/runner.rs
+++ b/tests/runtime-async/async/ping-pong/runner.rs
@@ -1,0 +1,22 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::{ping, pong};
+
+fn main() {
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new();
+        let f1 = ping(rx, "world".into());
+        let f2 = async { tx.write("hello".into()).await.unwrap() };
+        let (rx2, ()) = futures::join!(f1, f2);
+        let m2 = rx2.await.unwrap();
+        assert_eq!(m2, "helloworld");
+
+        let (tx, rx) = wit_future::new();
+        let f1 = async move {
+            let m3 = pong(rx).await;
+            assert_eq!(m3, "helloworld");
+        };
+        let f2 = async { tx.write(m2).await.unwrap() };
+        let ((), ()) = futures::join!(f1, f2);
+    });
+}

--- a/tests/runtime-async/async/ping-pong/test.rs
+++ b/tests/runtime-async/async/ping-pong/test.rs
@@ -1,0 +1,22 @@
+use wit_bindgen::FutureReader;
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn ping(x: FutureReader<String>, y: String) -> FutureReader<String> {
+        let msg = x.await.unwrap() + y.as_str();
+        let (tx, rx) = wit_future::new();
+        wit_bindgen::spawn(async move {
+            tx.write(msg).await.unwrap();
+        });
+        rx
+    }
+
+    async fn pong(x: FutureReader<String>) -> String {
+        x.await.unwrap()
+    }
+}

--- a/tests/runtime-async/async/ping-pong/test.wit
+++ b/tests/runtime-async/async/ping-pong/test.wit
@@ -1,0 +1,14 @@
+package my:test;
+
+interface i {
+  ping: async func(x: future<string>, y: string) -> future<string>;
+  pong: async func(x: future<string>) -> string;
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}


### PR DESCRIPTION
I went through various parts of the guest runtime and sprinkled `if true { panic!() }` throughout. Anything that wasn't hit got a test. This led to a few issues in wasip3-prototyping:

* https://github.com/bytecodealliance/wasip3-prototyping/issues/137
* https://github.com/bytecodealliance/wasip3-prototyping/issues/138
* https://github.com/bytecodealliance/wasip3-prototyping/issues/139
* https://github.com/bytecodealliance/wasip3-prototyping/issues/140

so not all tests are fully enabled yet but they should get enabled as bugs get fixed.

Additionally this starts to use `CALLBACK_CODE_YIELD`. That's disabled for callbacks due to bytecodealliance/wasip3-prototyping#140 but it's enabled for `block_on` where it translates to a `waitable-set.poll` instead of a `waitable-set.wait`.