### PR TITLE
Async bindings generation for C

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,10 +132,11 @@ jobs:
         curl -L https://github.com/bytecodealliance/wasip3-prototyping/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz | tar xJvf -
         echo "WASMTIME=`pwd`/wasmtime-dev-x86_64-linux/wasmtime" >> $GITHUB_ENV
     - run: |
-        cargo run test --languages rust tests/runtime-async \
+        cargo run test --languages rust,c tests/runtime-async \
           --artifacts target/artifacts \
           --rust-wit-bindgen-path ./crates/guest-rust \
           --rust-target wasm32-wasip1 \
+          --c-target wasm32-wasip1 \
           --runner "$WASMTIME -W component-model-async"
 
   test_unit:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "anyhow",
  "clap",
  "heck 0.5.0",
+ "indexmap",
  "wasm-encoder 0.229.0",
  "wasm-metadata 0.229.0",
  "wit-bindgen-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,9 @@ name = "wit-bindgen-core"
 version = "0.41.0"
 dependencies = [
  "anyhow",
+ "clap",
  "heck 0.5.0",
+ "serde",
  "wit-parser",
 ]
 

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -23,3 +23,7 @@ wasm-metadata = { workspace = true }
 anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
+indexmap = { workspace = true }
+
+[features]
+clap = ['dep:clap', 'wit-bindgen-core/clap']

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -2,13 +2,14 @@ mod component_type_object;
 
 use anyhow::Result;
 use heck::*;
+use indexmap::IndexSet;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::mem;
 use wit_bindgen_core::abi::{self, AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType};
 use wit_bindgen_core::{
-    dealias, uwrite, uwriteln, wit_parser::*, AnonymousTypeGenerator, Direction, Files,
-    InterfaceGenerator as _, Ns, WorldGenerator,
+    dealias, uwrite, uwriteln, wit_parser::*, AnonymousTypeGenerator, AsyncFilterSet, Direction,
+    Files, InterfaceGenerator as _, Ns, WorldGenerator,
 };
 use wit_component::StringEncoding;
 
@@ -26,6 +27,7 @@ struct C {
     needs_union_float_int32: bool,
     needs_union_int64_double: bool,
     needs_union_double_int64: bool,
+    needs_async: bool,
     prim_names: HashSet<String>,
     world: String,
     sizes: SizeAlign,
@@ -35,6 +37,7 @@ struct C {
     dtor_funcs: HashMap<TypeId, String>,
     type_names: HashMap<TypeId, String>,
     resources: HashMap<TypeId, ResourceInfo>,
+    futures: IndexSet<TypeId>,
 }
 
 #[derive(Default)]
@@ -70,7 +73,14 @@ pub struct Opts {
     pub no_helpers: bool,
 
     /// Set component string encoding
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = StringEncoding::default()))]
+    #[cfg_attr(
+        feature = "clap",
+        arg(
+            long,
+            default_value_t = StringEncoding::default(),
+            value_name = "ENCODING",
+        ),
+    )]
     pub string_encoding: StringEncoding,
 
     /// Skip optional null pointer and boolean result argument signature
@@ -88,17 +98,27 @@ pub struct Opts {
     pub rename: Vec<(String, String)>,
 
     /// Rename the world in the generated source code and file names.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "NAME"))]
     pub rename_world: Option<String>,
 
     /// Add the specified suffix to the name of the custome section containing
     /// the component type.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "STRING"))]
     pub type_section_suffix: Option<String>,
 
     /// Configure the autodropping of borrows in exported functions.
-    #[cfg_attr(feature = "clap", arg(long, default_value_t = Enabled::default()))]
+    #[cfg_attr(
+        feature = "clap",
+        arg(
+            long,
+            default_value_t = Enabled::default(),
+            value_name = "ENABLED",
+        ),
+    )]
     pub autodrop_borrows: Enabled,
+
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    pub async_: AsyncFilterSet,
 }
 
 #[cfg(feature = "clap")]
@@ -374,27 +394,30 @@ impl WorldGenerator for C {
         }
         if self.needs_union_int32_float {
             uwriteln!(
-                self.src.c_helpers,
+                self.src.c_defs,
                 "\nunion int32_float {{ int32_t a; float b; }};"
             );
         }
         if self.needs_union_float_int32 {
             uwriteln!(
-                self.src.c_helpers,
+                self.src.c_defs,
                 "\nunion float_int32 {{ float a; int32_t b; }};"
             );
         }
         if self.needs_union_int64_double {
             uwriteln!(
-                self.src.c_helpers,
+                self.src.c_defs,
                 "\nunion int64_double {{ int64_t a; double b; }};"
             );
         }
         if self.needs_union_double_int64 {
             uwriteln!(
-                self.src.c_helpers,
+                self.src.c_defs,
                 "\nunion double_int64 {{ double a; int64_t b; }};"
             );
+        }
+        if self.needs_async || self.futures.len() > 0 {
+            self.generate_async_helpers();
         }
         let version = env!("CARGO_PKG_VERSION");
         let mut h_str = wit_bindgen_core::Source::default();
@@ -430,36 +453,6 @@ impl WorldGenerator for C {
         c_str.push_str(&self.src.c_defs);
         c_str.push_str(&self.src.c_fns);
 
-        if self.needs_string {
-            uwriteln!(
-                h_str,
-                "
-                typedef struct {snake}_string_t {{\n\
-                  {ty} *ptr;\n\
-                  size_t len;\n\
-                }} {snake}_string_t;",
-                ty = self.char_type(),
-            );
-        }
-        if self.src.h_defs.len() > 0 {
-            h_str.push_str(&self.src.h_defs);
-        }
-
-        h_str.push_str(&self.src.h_fns);
-
-        if !self.opts.no_helpers && self.src.h_helpers.len() > 0 {
-            uwriteln!(h_str, "\n// Helper Functions");
-            h_str.push_str(&self.src.h_helpers);
-            h_str.push_str("\n");
-        }
-
-        if !self.opts.no_helpers && self.src.c_helpers.len() > 0 {
-            uwriteln!(c_str, "\n// Helper Functions");
-            c_str.push_str(self.src.c_helpers.as_mut_string());
-        }
-
-        uwriteln!(c_str, "\n// Component Adapters");
-
         // Declare a statically-allocated return area, if needed. We only do
         // this for export bindings, because import bindings allocate their
         // return-area on the stack.
@@ -477,6 +470,50 @@ impl WorldGenerator for C {
                     .format(POINTER_SIZE_EXPRESSION),
             );
         }
+
+        if self.needs_string {
+            uwriteln!(
+                h_str,
+                "
+                typedef struct {snake}_string_t {{\n\
+                  {ty} *ptr;\n\
+                  size_t len;\n\
+                }} {snake}_string_t;",
+                ty = self.char_type(),
+            );
+        }
+
+        if self.src.h_async.len() > 0 {
+            uwriteln!(h_str, "\n// Async Helper Functions");
+            h_str.push_str(&self.src.h_async);
+            h_str.push_str("\n");
+        }
+
+        if self.src.h_defs.len() > 0 {
+            h_str.push_str(&self.src.h_defs);
+        }
+
+        h_str.push_str(&self.src.h_fns);
+
+        if !self.opts.no_helpers && self.src.h_helpers.len() > 0 {
+            uwriteln!(h_str, "\n// Helper Functions");
+            h_str.push_str(&self.src.h_helpers);
+            h_str.push_str("\n");
+        }
+
+        if !self.opts.no_helpers && self.src.c_helpers.len() > 0 {
+            uwriteln!(c_str, "\n// Helper Functions");
+            c_str.push_str(self.src.c_helpers.as_mut_string());
+        }
+
+        if self.src.c_async.len() > 0 {
+            uwriteln!(c_str, "\n// Async Helper Functions");
+            c_str.push_str(&self.src.c_async);
+            c_str.push_str("\n");
+        }
+
+        uwriteln!(c_str, "\n// Component Adapters");
+
         c_str.push_str(&self.src.c_adapters);
 
         uwriteln!(
@@ -573,7 +610,7 @@ impl C {
                 dst.push_str("string_t");
                 self.needs_string = true;
             }
-            Type::ErrorContext => todo!("C error context type name"),
+            Type::ErrorContext => dst.push_str("error_context"),
             Type::Id(id) => {
                 if let Some(name) = self.type_names.get(id) {
                     dst.push_str(name);
@@ -648,6 +685,157 @@ impl C {
                 self.perform_cast(&inner, second)
             }
         }
+    }
+
+    fn generate_async_helpers(&mut self) {
+        let snake = self.world.to_snake_case();
+        let shouty = self.world.to_shouty_snake_case();
+        uwriteln!(
+            self.src.h_async,
+            "
+typedef uint32_t {snake}_subtask_status_t;
+typedef uint32_t {snake}_subtask_t;
+#define {shouty}_SUBTASK_STATE(status) (({snake}_subtask_state_t) ((status) & 0xf))
+#define {shouty}_SUBTASK_HANDLE(status) (({snake}_subtask_t) ((status) >> 4))
+
+typedef enum {snake}_subtask_state {{
+    {shouty}_SUBTASK_STARTING,
+    {shouty}_SUBTASK_STARTED,
+    {shouty}_SUBTASK_RETURNED,
+    {shouty}_SUBTASK_STARTED_CANCELLED,
+    {shouty}_SUBTASK_RETURNED_CANCELLED,
+}} {snake}_subtask_state_t;
+
+{snake}_subtask_status_t {snake}_subtask_cancel({snake}_subtask_t subtask);
+void {snake}_subtask_drop({snake}_subtask_t subtask);
+
+typedef uint32_t {snake}_callback_code_t;
+#define {shouty}_CALLBACK_CODE_EXIT 0
+#define {shouty}_CALLBACK_CODE_YIELD 1
+#define {shouty}_CALLBACK_CODE_WAIT(set) (2 | (set << 4))
+#define {shouty}_CALLBACK_CODE_POLL(set) (3 | (set << 4))
+
+typedef enum {snake}_event_code {{
+    {shouty}_EVENT_NONE,
+    {shouty}_EVENT_SUBTASK,
+    {shouty}_EVENT_STREAM_READ,
+    {shouty}_EVENT_STREAM_WRITE,
+    {shouty}_EVENT_FUTURE_READ,
+    {shouty}_EVENT_FUTURE_WRITE,
+    {shouty}_EVENT_CANCEL,
+}} {snake}_event_code_t;
+
+typedef struct {snake}_event {{
+    {snake}_event_code_t event;
+    uint32_t waitable;
+    uint32_t code;
+}} {snake}_event_t;
+
+typedef uint32_t {snake}_waitable_set_t;
+{snake}_waitable_set_t {snake}_waitable_set_new(void);
+void {snake}_waitable_join(uint32_t waitable, {snake}_waitable_set_t set);
+void {snake}_waitable_set_drop({snake}_waitable_set_t set);
+void {snake}_waitable_set_wait({snake}_waitable_set_t set, {snake}_event_t *event);
+void {snake}_waitable_set_poll({snake}_waitable_set_t set, {snake}_event_t *event);
+
+void {snake}_task_cancel(void);
+
+typedef uint32_t {snake}_waitable_status_t;
+#define {shouty}_WAITABLE_STATE(status) (({snake}_waitable_state_t) ((status) & 0xf))
+#define {shouty}_WAITABLE_COUNT(status) ((uint32_t) ((status) >> 4))
+#define {shouty}_WAITABLE_STATUS_BLOCKED (({snake}_waitable_status_t) -1)
+
+typedef enum {snake}_waitable_state {{
+    {shouty}_WAITABLE_COMPLETED,
+    {shouty}_WAITABLE_CLOSED,
+    {shouty}_WAITABLE_CANCELLED,
+}} {snake}_waitable_state_t;
+
+void {snake}_backpressure_set(bool enable);
+void* {snake}_context_get(void);
+void {snake}_context_set(void*);
+            "
+        );
+        uwriteln!(
+            self.src.c_async,
+            r#"
+__attribute__((__import_module__("$root"), __import_name__("[subtask-cancel]")))
+extern uint32_t __subtask_cancel(uint32_t handle);
+
+{snake}_subtask_status_t {snake}_subtask_cancel({snake}_subtask_t subtask) {{
+    return __subtask_cancel(subtask);
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[subtask-drop]")))
+extern void __subtask_drop(uint32_t handle);
+
+void {snake}_subtask_drop({snake}_subtask_t subtask) {{
+    __subtask_drop(subtask);
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[waitable-set-new]")))
+extern uint32_t __waitable_set_new(void);
+
+{snake}_waitable_set_t {snake}_waitable_set_new(void) {{
+    return __waitable_set_new();
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[waitable-join]")))
+extern void __waitable_join(uint32_t, uint32_t);
+
+void {snake}_waitable_join(uint32_t waitable, {snake}_waitable_set_t set) {{
+    __waitable_join(waitable, set);
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[waitable-set-drop]")))
+extern void __waitable_set_drop(uint32_t);
+
+void {snake}_waitable_set_drop({snake}_waitable_set_t set) {{
+    __waitable_set_drop(set);
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[waitable-set-wait]")))
+extern uint32_t __waitable_set_wait(uint32_t, uint32_t*);
+__attribute__((__import_module__("$root"), __import_name__("[waitable-set-poll]")))
+extern uint32_t __waitable_set_poll(uint32_t, uint32_t*);
+
+void {snake}_waitable_set_wait({snake}_waitable_set_t set, {snake}_event_t *event) {{
+    event->event = __waitable_set_wait(set, &event->waitable);
+}}
+
+void {snake}_waitable_set_poll({snake}_waitable_set_t set, {snake}_event_t *event) {{
+    event->event = __waitable_set_poll(set, &event->waitable);
+}}
+
+__attribute__((__import_module__("[export]$root"), __import_name__("[task-cancel]")))
+extern void __task_cancel(void);
+
+void {snake}_task_cancel() {{
+    __task_cancel();
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[backpressure-set]")))
+extern void __backpressure_set(bool enable);
+
+void {snake}_backpressure_set(bool enable) {{
+    __backpressure_set(enable);
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[context-get-0]")))
+extern void* __context_get(void);
+
+void* {snake}_context_get() {{
+    return __context_get();
+}}
+
+__attribute__((__import_module__("$root"), __import_name__("[context-set-0]")))
+extern void __context_set(void*);
+
+void {snake}_context_set(void *val) {{
+    return __context_set(val);
+}}
+            "#
+        );
     }
 }
 
@@ -783,8 +971,20 @@ pub fn push_ty_name(resolve: &Resolve, ty: &Type, src: &mut String) {
                     src.push_str("list_");
                     push_ty_name(resolve, ty, src);
                 }
-                TypeDefKind::Future(_) => todo!(),
-                TypeDefKind::Stream(_) => todo!(),
+                TypeDefKind::Future(ty) => {
+                    src.push_str("future_");
+                    match ty {
+                        Some(ty) => push_ty_name(resolve, ty, src),
+                        None => src.push_str("void"),
+                    }
+                }
+                TypeDefKind::Stream(ty) => {
+                    src.push_str("stream_");
+                    match ty {
+                        Some(ty) => push_ty_name(resolve, ty, src),
+                        None => src.push_str("void"),
+                    }
+                }
                 TypeDefKind::Handle(Handle::Own(resource)) => {
                     src.push_str("own_");
                     push_ty_name(resolve, &Type::Id(*resource), src);
@@ -963,7 +1163,11 @@ impl Return {
             TypeDefKind::Type(t) => return self.return_single(resolve, t, orig_ty, sig_flattening),
 
             // Flags are returned as their bare values, and enums and handles are scalars
-            TypeDefKind::Flags(_) | TypeDefKind::Enum(_) | TypeDefKind::Handle(_) => {
+            TypeDefKind::Flags(_)
+            | TypeDefKind::Enum(_)
+            | TypeDefKind::Handle(_)
+            | TypeDefKind::Future(_)
+            | TypeDefKind::Stream(_) => {
                 self.scalar = Some(Scalar::Type(*orig_ty));
                 return;
             }
@@ -1000,8 +1204,6 @@ impl Return {
             | TypeDefKind::List(_)
             | TypeDefKind::Variant(_) => {}
 
-            TypeDefKind::Future(_) => todo!("return_single for future"),
-            TypeDefKind::Stream(_) => todo!("return_single for stream"),
             TypeDefKind::Resource => todo!("return_single for resource"),
             TypeDefKind::Unknown => unreachable!(),
         }
@@ -1349,14 +1551,18 @@ void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
         self.finish_typedef_struct(id);
     }
 
-    fn type_future(&mut self, id: TypeId, name: &str, ty: &Option<Type>, docs: &Docs) {
-        _ = (id, name, ty, docs);
-        todo!()
+    fn type_future(&mut self, id: TypeId, _name: &str, _ty: &Option<Type>, docs: &Docs) {
+        self.src.h_defs("\n");
+        self.docs(docs, SourceType::HDefs);
+        self.src.h_defs("\ntypedef uint32_t ");
+        self.print_typedef_target(id);
     }
 
-    fn type_stream(&mut self, id: TypeId, name: &str, ty: &Option<Type>, docs: &Docs) {
-        _ = (id, name, ty, docs);
-        todo!()
+    fn type_stream(&mut self, id: TypeId, _name: &str, _ty: &Option<Type>, docs: &Docs) {
+        self.src.h_defs("\n");
+        self.docs(docs, SourceType::HDefs);
+        self.src.h_defs("\ntypedef uint32_t ");
+        self.print_typedef_target(id);
     }
 
     fn type_builtin(&mut self, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
@@ -1443,12 +1649,14 @@ impl<'a> wit_bindgen_core::AnonymousTypeGenerator<'a> for InterfaceGenerator<'a>
         self.print_typedef_target(id);
     }
 
-    fn anonymous_type_future(&mut self, _id: TypeId, _ty: &Option<Type>, _docs: &Docs) {
-        todo!("print_anonymous_type for future");
+    fn anonymous_type_future(&mut self, id: TypeId, _ty: &Option<Type>, _docs: &Docs) {
+        self.src.h_defs("\ntypedef uint32_t ");
+        self.print_typedef_target(id);
     }
 
-    fn anonymous_type_stream(&mut self, _id: TypeId, _ty: &Option<Type>, _docs: &Docs) {
-        todo!("print_anonymous_type for stream");
+    fn anonymous_type_stream(&mut self, id: TypeId, _ty: &Option<Type>, _docs: &Docs) {
+        self.src.h_defs("\ntypedef uint32_t ");
+        self.print_typedef_target(id);
     }
 
     fn anonymous_type_type(&mut self, _id: TypeId, _ty: &Type, _docs: &Docs) {
@@ -1623,8 +1831,9 @@ impl InterfaceGenerator<'_> {
                 }
                 self.src.c_helpers("}\n");
             }
-            TypeDefKind::Future(_) => todo!("print_dtor for future"),
-            TypeDefKind::Stream(_) => todo!("print_dtor for stream"),
+            TypeDefKind::Future(_) | TypeDefKind::Stream(_) => {
+                self.free(&Type::Id(id), "*ptr");
+            }
             TypeDefKind::Resource => {}
             TypeDefKind::Handle(Handle::Borrow(id) | Handle::Own(id)) => {
                 self.free(&Type::Id(*id), "*ptr");
@@ -1680,8 +1889,22 @@ impl InterfaceGenerator<'_> {
     }
 
     fn import(&mut self, interface_name: Option<&WorldKey>, func: &Function) {
+        let async_ = self
+            .gen
+            .opts
+            .async_
+            .is_async(self.resolve, interface_name, func, true);
+        if async_ {
+            self.gen.needs_async = true;
+        }
+
         self.docs(&func.docs, SourceType::HFns);
-        let sig = self.resolve.wasm_signature(AbiVariant::GuestImport, func);
+        let (variant, import_prefix) = if async_ {
+            (AbiVariant::GuestImportAsync, "[async-lower]")
+        } else {
+            (AbiVariant::GuestImport, "")
+        };
+        let sig = self.resolve.wasm_signature(variant, func);
 
         self.src.c_fns("\n");
 
@@ -1690,7 +1913,7 @@ impl InterfaceGenerator<'_> {
         // signature.
         uwriteln!(
             self.src.c_fns,
-            "__attribute__((__import_module__(\"{}\"), __import_name__(\"{}\")))",
+            "__attribute__((__import_module__(\"{}\"), __import_name__(\"{import_prefix}{}\")))",
             match interface_name {
                 Some(name) => self.resolve.name_world_key(name),
                 None => "$root".to_string(),
@@ -1722,11 +1945,23 @@ impl InterfaceGenerator<'_> {
         // Print the public facing signature into the header, and since that's
         // what we are defining also print it into the C file.
         self.src.h_fns("extern ");
-        let c_sig = self.print_sig(interface_name, func, !self.gen.opts.no_sig_flattening);
+        let c_sig = self.print_sig(interface_name, func, async_);
         self.src.c_adapters("\n");
         self.src.c_adapters(&c_sig.sig);
         self.src.c_adapters(" {\n");
 
+        if async_ {
+            self.import_body_async(func, c_sig, &import_name);
+        } else {
+            self.import_body_sync(func, c_sig, &import_name);
+        }
+
+        self.src.c_adapters("}\n");
+
+        self.generate_async_futures_and_streams("", func, interface_name);
+    }
+
+    fn import_body_sync(&mut self, func: &Function, c_sig: CSig, import_name: &str) {
         // construct optional adapters from maybe pointers to real optional
         // structs internally
         let mut optional_adapters = String::from("");
@@ -1793,11 +2028,43 @@ impl InterfaceGenerator<'_> {
         }
 
         self.src.c_adapters(&String::from(src));
-        self.src.c_adapters("}\n");
+    }
+
+    fn import_body_async(&mut self, func: &Function, sig: CSig, import_name: &str) {
+        let params = match &func.params[..] {
+            [] => "NULL".to_string(),
+            _ => format!("(uint8_t*) {}", sig.params[0].1),
+        };
+        let results = match &func.result {
+            None => "NULL".to_string(),
+            Some(_) => format!("(uint8_t*) {}", sig.params.last().unwrap().1),
+        };
+
+        uwriteln!(
+            self.src.c_adapters,
+            "return {import_name}({params}, {results});"
+        );
     }
 
     fn export(&mut self, func: &Function, interface_name: Option<&WorldKey>) {
-        let sig = self.resolve.wasm_signature(AbiVariant::GuestExport, func);
+        let async_ = self
+            .gen
+            .opts
+            .async_
+            .is_async(self.resolve, interface_name, func, false);
+
+        let (variant, prefix) = if async_ {
+            self.gen.needs_async = true;
+            (AbiVariant::GuestExportAsync, "[async-lift]")
+        } else {
+            (AbiVariant::GuestExport, "")
+        };
+
+        let mut sig = self.resolve.wasm_signature(variant, func);
+        if async_ {
+            assert_eq!(sig.results, [WasmType::Pointer]);
+            sig.results[0] = WasmType::I32;
+        }
 
         self.src.c_fns("\n");
 
@@ -1806,13 +2073,13 @@ impl InterfaceGenerator<'_> {
 
         // Print the actual header for this function into the header file, and
         // it's what we'll be calling.
-        let h_sig = self.print_sig(interface_name, func, !self.gen.opts.no_sig_flattening);
+        let h_sig = self.print_sig(interface_name, func, async_);
 
         // Generate, in the C source file, the raw wasm signature that has the
         // canonical ABI.
         uwriteln!(
             self.src.c_adapters,
-            "\n__attribute__((__export_name__(\"{export_name}\")))"
+            "\n__attribute__((__export_name__(\"{prefix}{export_name}\")))"
         );
         let name = self.c_func_name(interface_name, func);
         let import_name = self.gen.names.tmp(&format!("__wasm_export_{name}"));
@@ -1842,17 +2109,76 @@ impl InterfaceGenerator<'_> {
         // Perform all lifting/lowering and append it to our src.
         abi::call(
             f.gen.resolve,
-            AbiVariant::GuestExport,
+            variant,
             LiftLower::LiftArgsLowerResults,
             func,
             &mut f,
-            false,
+            async_,
         );
-        let FunctionBindgen { src, .. } = f;
+        let FunctionBindgen {
+            src,
+            deferred_task_return,
+            ..
+        } = f;
         self.src.c_adapters(&src);
         self.src.c_adapters("}\n");
 
-        if abi::guest_export_needs_post_return(self.resolve, func) {
+        if async_ {
+            let snake = self.gen.world.to_snake_case();
+            let return_ty = match &func.result {
+                Some(ty) => format!("{} ret", self.gen.type_name(ty)),
+                None => "void".to_string(),
+            };
+            let DeferredTaskReturn::Emitted {
+                body: mut task_return_body,
+                name: task_return_name,
+                params: task_return_params,
+            } = deferred_task_return
+            else {
+                unreachable!()
+            };
+            let task_return_param_tys = task_return_params
+                .iter()
+                .map(|(ty, _expr)| wasm_type(*ty))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let task_return_param_exprs = task_return_params
+                .iter()
+                .map(|(_ty, expr)| expr.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let task_return_body = task_return_body.as_mut_string();
+            uwriteln!(
+                self.src.h_fns,
+                "{snake}_callback_code_t {name}_callback({snake}_event_t *event);",
+            );
+            uwriteln!(self.src.h_helpers, "void {name}_return({return_ty});");
+            let import_module = match interface_name {
+                Some(name) => self.resolve.name_world_key(name),
+                None => "$root".to_string(),
+            };
+            uwriteln!(
+                self.src.c_helpers,
+                r#"
+__attribute__((__export_name__("[callback]{prefix}{export_name}")))
+uint32_t {import_name}_callback(uint32_t event_raw, uint32_t waitable, uint32_t code) {{
+    {snake}_event_t event;
+    event.event = event_raw;
+    event.waitable = waitable;
+    event.code = code;
+    return {name}_callback(&event);
+}}
+
+__attribute__((__import_module__("[export]{import_module}"), __import_name__("{task_return_name}")))
+void {import_name}__task_return({task_return_param_tys});
+
+void {name}_return({return_ty}) {{
+    {task_return_body}
+    {import_name}__task_return({task_return_param_exprs});
+}}
+                "#
+            );
+        } else if abi::guest_export_needs_post_return(self.resolve, func) {
             uwriteln!(
                 self.src.c_fns,
                 "__attribute__((__weak__, __export_name__(\"cabi_post_{export_name}\")))"
@@ -1882,13 +2208,15 @@ impl InterfaceGenerator<'_> {
             self.src.c_fns(&src);
             self.src.c_fns("}\n");
         }
+
+        self.generate_async_futures_and_streams("[export]", func, interface_name);
     }
 
     fn print_sig(
         &mut self,
         interface_name: Option<&WorldKey>,
         func: &Function,
-        sig_flattening: bool,
+        async_: bool,
     ) -> CSig {
         let name = self.c_func_name(interface_name, func);
         self.gen.names.insert(&name).expect("duplicate symbols");
@@ -1897,20 +2225,125 @@ impl InterfaceGenerator<'_> {
         let mut result_rets = false;
         let mut result_rets_has_ok_type = false;
 
-        let ret = self.classify_ret(func, sig_flattening);
-        match &ret.scalar {
-            None | Some(Scalar::Void) => self.src.h_fns("void"),
-            Some(Scalar::OptionBool(_id)) => self.src.h_fns("bool"),
-            Some(Scalar::ResultBool(ok, _err)) => {
-                result_rets = true;
-                result_rets_has_ok_type = ok.is_some();
-                self.src.h_fns("bool");
+        let ret = if async_ && !self.in_import {
+            Return {
+                scalar: func.result.map(Scalar::Type),
+                retptrs: Vec::new(),
             }
-            Some(Scalar::Type(ty)) => self.print_ty(SourceType::HFns, ty),
+        } else {
+            self.classify_ret(func)
+        };
+        if async_ {
+            let snake = self.gen.world.to_snake_case();
+            if self.in_import {
+                uwrite!(self.src.h_fns, "{snake}_subtask_status_t");
+            } else {
+                uwrite!(self.src.h_fns, "{snake}_callback_code_t");
+            }
+        } else {
+            match &ret.scalar {
+                None | Some(Scalar::Void) => self.src.h_fns("void"),
+                Some(Scalar::OptionBool(_id)) => self.src.h_fns("bool"),
+                Some(Scalar::ResultBool(ok, _err)) => {
+                    result_rets = true;
+                    result_rets_has_ok_type = ok.is_some();
+                    self.src.h_fns("bool");
+                }
+                Some(Scalar::Type(ty)) => self.print_ty(SourceType::HFns, ty),
+            }
         }
         self.src.h_fns(" ");
         self.src.h_fns(&name);
         self.src.h_fns("(");
+        let mut params = Vec::new();
+        let mut retptrs = Vec::new();
+        if async_ && self.in_import {
+            let mut printed = false;
+            match &func.params[..] {
+                [] => {}
+                [(_name, ty)] => {
+                    printed = true;
+                    let name = "arg".to_string();
+                    self.print_ty(SourceType::HFns, ty);
+                    self.src.h_fns(" *");
+                    self.src.h_fns(&name);
+                    params.push((true, name));
+                }
+                multiple => {
+                    printed = true;
+                    let names = multiple
+                        .iter()
+                        .map(|(name, ty)| (to_c_ident(name), self.gen.type_name(ty)))
+                        .collect::<Vec<_>>();
+                    uwriteln!(self.src.h_defs, "typedef struct {name}_args {{");
+                    for (name, ty) in names {
+                        uwriteln!(self.src.h_defs, "{ty} {name};");
+                    }
+                    uwriteln!(self.src.h_defs, "}} {name}_args_t;");
+                    uwrite!(self.src.h_fns, "{name}_args_t *args");
+                    params.push((true, "args".to_string()));
+                }
+            }
+            if let Some(ty) = &func.result {
+                if printed {
+                    self.src.h_fns(", ");
+                } else {
+                    printed = true;
+                }
+                let name = "result".to_string();
+                self.print_ty(SourceType::HFns, ty);
+                self.src.h_fns(" *");
+                self.src.h_fns(&name);
+                params.push((true, name));
+            }
+            if !printed {
+                self.src.h_fns("void");
+            }
+        } else if async_ && !self.in_import {
+            params = self.print_sig_params(func);
+        } else {
+            params = self.print_sig_params(func);
+            let single_ret = ret.retptrs.len() == 1;
+            for (i, ty) in ret.retptrs.iter().enumerate() {
+                if i > 0 || func.params.len() > 0 {
+                    self.src.h_fns(", ");
+                }
+                self.print_ty(SourceType::HFns, ty);
+                self.src.h_fns(" *");
+                let name: String = if result_rets {
+                    assert!(i <= 1);
+                    if i == 0 && result_rets_has_ok_type {
+                        "ret".into()
+                    } else {
+                        "err".into()
+                    }
+                } else if single_ret {
+                    "ret".into()
+                } else {
+                    format!("ret{}", i)
+                };
+                self.src.h_fns(&name);
+                retptrs.push(name);
+            }
+            if func.params.len() == 0 && ret.retptrs.len() == 0 {
+                self.src.h_fns("void");
+            }
+        }
+        self.src.h_fns(")");
+
+        let sig = self.src.h_fns[start..].to_string();
+        self.src.h_fns(";\n");
+
+        CSig {
+            sig,
+            name,
+            params,
+            ret,
+            retptrs,
+        }
+    }
+
+    fn print_sig_params(&mut self, func: &Function) -> Vec<(bool, String)> {
         let mut params = Vec::new();
         for (i, (name, ty)) in func.params.iter().enumerate() {
             if i > 0 {
@@ -1920,7 +2353,7 @@ impl InterfaceGenerator<'_> {
             // optional param pointer sig_flattening
             let optional_type = if let Type::Id(id) = ty {
                 if let TypeDefKind::Option(option_ty) = &self.resolve.types[*id].kind {
-                    if sig_flattening {
+                    if !self.gen.opts.no_sig_flattening {
                         Some(option_ty)
                     } else {
                         None
@@ -1931,7 +2364,7 @@ impl InterfaceGenerator<'_> {
             } else {
                 None
             };
-            let (print_ty, print_name) = if sig_flattening {
+            let (print_ty, print_name) = if !self.gen.opts.no_sig_flattening {
                 if let Some(option_ty) = optional_type {
                     (option_ty, format!("maybe_{}", to_c_ident(name)))
                 } else {
@@ -1948,52 +2381,15 @@ impl InterfaceGenerator<'_> {
             self.src.h_fns(&print_name);
             params.push((optional_type.is_none() && pointer, to_c_ident(name)));
         }
-        let mut retptrs = Vec::new();
-        let single_ret = ret.retptrs.len() == 1;
-        for (i, ty) in ret.retptrs.iter().enumerate() {
-            if i > 0 || func.params.len() > 0 {
-                self.src.h_fns(", ");
-            }
-            self.print_ty(SourceType::HFns, ty);
-            self.src.h_fns(" *");
-            let name: String = if result_rets {
-                assert!(i <= 1);
-                if i == 0 && result_rets_has_ok_type {
-                    "ret".into()
-                } else {
-                    "err".into()
-                }
-            } else if single_ret {
-                "ret".into()
-            } else {
-                format!("ret{}", i)
-            };
-            self.src.h_fns(&name);
-            retptrs.push(name);
-        }
-        if func.params.len() == 0 && ret.retptrs.len() == 0 {
-            self.src.h_fns("void");
-        }
-        self.src.h_fns(")");
-
-        let sig = self.src.h_fns[start..].to_string();
-        self.src.h_fns(";\n");
-
-        CSig {
-            sig,
-            name,
-            params,
-            ret,
-            retptrs,
-        }
+        params
     }
 
-    fn classify_ret(&mut self, func: &Function, sig_flattening: bool) -> Return {
+    fn classify_ret(&mut self, func: &Function) -> Return {
         let mut ret = Return::default();
         match &func.result {
             None => ret.scalar = Some(Scalar::Void),
             Some(ty) => {
-                ret.return_single(self.resolve, ty, ty, sig_flattening);
+                ret.return_single(self.resolve, ty, ty, !self.gen.opts.no_sig_flattening);
             }
         }
         return ret;
@@ -2106,6 +2502,176 @@ impl InterfaceGenerator<'_> {
             false
         }
     }
+
+    fn generate_async_futures_and_streams(
+        &mut self,
+        prefix: &str,
+        func: &Function,
+        interface: Option<&WorldKey>,
+    ) {
+        let module = format!(
+            "{prefix}{}",
+            interface
+                .map(|name| self.resolve.name_world_key(name))
+                .unwrap_or_else(|| "$root".into())
+        );
+        for (index, ty) in func
+            .find_futures_and_streams(self.resolve)
+            .into_iter()
+            .enumerate()
+        {
+            let func_name = &func.name;
+
+            match &self.resolve.types[ty].kind {
+                TypeDefKind::Future(payload_type) => {
+                    self.generate_async_future_or_stream(
+                        PayloadFor::Future,
+                        &module,
+                        index,
+                        func_name,
+                        ty,
+                        payload_type.as_ref(),
+                    );
+                }
+                TypeDefKind::Stream(payload_type) => {
+                    self.generate_async_future_or_stream(
+                        PayloadFor::Stream,
+                        &module,
+                        index,
+                        func_name,
+                        ty,
+                        payload_type.as_ref(),
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    fn generate_async_future_or_stream(
+        &mut self,
+        payload_for: PayloadFor,
+        module: &str,
+        index: usize,
+        func_name: &str,
+        ty: TypeId,
+        payload_type: Option<&Type>,
+    ) {
+        if !self.gen.futures.insert(ty) {
+            return;
+        }
+        let ty = self.gen.type_name(&Type::Id(ty));
+        let name = ty.strip_suffix("_t").unwrap();
+        let snake = self.gen.world.to_snake_case();
+        let kind = match payload_for {
+            PayloadFor::Future => "future",
+            PayloadFor::Stream => "stream",
+        };
+        let payload_len_arg = match payload_for {
+            PayloadFor::Future => "",
+            PayloadFor::Stream => ", size_t",
+        };
+        let (read_arg_ty, read_arg_expr, write_arg_ty, write_arg_expr) =
+            match (payload_for, payload_type) {
+                (PayloadFor::Future, None) => ("".to_string(), "NULL", "".to_string(), "NULL"),
+                (PayloadFor::Future, Some(ty)) => {
+                    let ty = self.gen.type_name(ty);
+                    (
+                        format!(", {ty} *buf"),
+                        "(uint8_t*) buf",
+                        format!(", const {ty} *buf"),
+                        "(const uint8_t*) buf",
+                    )
+                }
+                (PayloadFor::Stream, None) => (
+                    ", size_t amt".to_string(),
+                    "NULL, amt",
+                    ", size_t amt".to_string(),
+                    "NULL, amt",
+                ),
+                (PayloadFor::Stream, Some(ty)) => {
+                    let ty = self.gen.type_name(ty);
+                    (
+                        format!(", {ty} *buf, size_t amt"),
+                        "(uint8_t*) buf, amt",
+                        format!(", const {ty} *buf, size_t amt"),
+                        "(const uint8_t*) buf, amt",
+                    )
+                }
+            };
+
+        // TODO: this is a hack around space-stripping in `source.rs`, ideally
+        // wouldn't be necessary.
+        let empty = "";
+        uwriteln!(
+            self.src.h_helpers,
+            r#"
+typedef uint32_t {name}_writer_t;
+
+{ty} {name}_new({name}_writer_t *writer);
+{snake}_waitable_status_t {name}_read({ty} reader{read_arg_ty});
+{snake}_waitable_status_t {name}_write({name}_writer_t writer{write_arg_ty});
+{snake}_waitable_status_t {name}_cancel_read({ty} reader);
+{snake}_waitable_status_t {name}_cancel_write({name}_writer_t writer);
+void {name}_close_readable({ty} reader);{empty}
+void {name}_close_writable({name}_writer_t writer);
+            "#,
+        );
+        uwriteln!(
+            self.src.c_helpers,
+            r#"
+__attribute__((__import_module__("{module}"), __import_name__("[{kind}-new-{index}]{func_name}")))
+extern uint64_t {name}__new(void);
+__attribute__((__import_module__("{module}"), __import_name__("[async-lower][{kind}-read-{index}]{func_name}")))
+extern uint32_t {name}__read(uint32_t, uint8_t*{payload_len_arg});
+__attribute__((__import_module__("{module}"), __import_name__("[async-lower][{kind}-write-{index}]{func_name}")))
+extern uint32_t {name}__write(uint32_t, const uint8_t*{payload_len_arg});
+__attribute__((__import_module__("{module}"), __import_name__("[{kind}-cancel-read-{index}]{func_name}")))
+extern uint32_t {name}__cancel_read(uint32_t);
+__attribute__((__import_module__("{module}"), __import_name__("[{kind}-cancel-write-{index}]{func_name}")))
+extern uint32_t {name}__cancel_write(uint32_t);
+__attribute__((__import_module__("{module}"), __import_name__("[{kind}-close-readable-{index}]{func_name}")))
+extern void {name}__close_readable(uint32_t);
+__attribute__((__import_module__("{module}"), __import_name__("[{kind}-close-writable-{index}]{func_name}")))
+extern void {name}__close_writable(uint32_t);
+
+{ty} {name}_new({name}_writer_t *writer) {{
+    uint64_t packed = {name}__new();
+    *writer = (uint32_t) (packed >> 32);
+    return (uint32_t) packed;
+}}
+
+{snake}_waitable_status_t {name}_read({ty} reader{read_arg_ty}) {{
+    return {name}__read(reader, {read_arg_expr});
+}}
+
+{snake}_waitable_status_t {name}_write({name}_writer_t writer{write_arg_ty}) {{
+    return {name}__write(writer, {write_arg_expr});
+}}
+
+{snake}_waitable_status_t {name}_cancel_read({ty} reader){empty} {{
+    return {name}__cancel_read(reader);
+}}
+
+{snake}_waitable_status_t {name}_cancel_write({name}_writer_t writer) {{
+    return {name}__cancel_write(writer);
+}}
+
+void {name}_close_readable({ty} reader){empty} {{
+    {name}__close_readable(reader);
+}}
+
+void {name}_close_writable({name}_writer_t writer) {{
+    {name}__close_writable(writer);
+}}
+            "#,
+        );
+    }
+}
+
+enum PayloadFor {
+    Future,
+    Stream,
 }
 
 struct DroppableBorrow {
@@ -2128,12 +2694,27 @@ struct FunctionBindgen<'a, 'b> {
     import_return_pointer_area_size: ArchitectureSize,
     import_return_pointer_area_align: Alignment,
 
+    /// TODO
+    deferred_task_return: DeferredTaskReturn,
+
     /// Borrows observed during lifting an export, that will need to be dropped when the guest
     /// function exits.
     borrows: Vec<DroppableBorrow>,
 
     /// Forward declarations for temporary storage of borrow copies.
     borrow_decls: wit_bindgen_core::Source,
+}
+
+enum DeferredTaskReturn {
+    None,
+    Generating {
+        prev_src: wit_bindgen_core::Source,
+    },
+    Emitted {
+        name: String,
+        params: Vec<(WasmType, String)>,
+        body: wit_bindgen_core::Source,
+    },
 }
 
 impl<'a, 'b> FunctionBindgen<'a, 'b> {
@@ -2158,6 +2739,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
             import_return_pointer_area_align: Default::default(),
             borrow_decls: Default::default(),
             borrows: Vec::new(),
+            deferred_task_return: DeferredTaskReturn::None,
         }
     }
 
@@ -2780,7 +3362,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.src.push_str(");\n");
             }
 
-            Instruction::CallInterface { func, .. } => {
+            Instruction::CallInterface { func, async_ } => {
                 let mut args = String::new();
                 for (i, (op, (byref, _))) in operands.iter().zip(&self.sig.params).enumerate() {
                     if i > 0 {
@@ -2804,6 +3386,27 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         }
                         args.push_str(op);
                     }
+                }
+                if *async_ {
+                    let ret = self.locals.tmp("ret");
+                    let snake = self.gen.gen.world.to_snake_case();
+                    uwriteln!(
+                        self.src,
+                        "{snake}_callback_code_t {ret} = {}({args});",
+                        self.sig.name,
+                    );
+                    uwriteln!(self.src, "return {ret};");
+                    if func.result.is_some() {
+                        results.push("ret".to_string());
+                    }
+                    assert!(matches!(
+                        self.deferred_task_return,
+                        DeferredTaskReturn::None
+                    ));
+                    self.deferred_task_return = DeferredTaskReturn::Generating {
+                        prev_src: mem::take(&mut self.src),
+                    };
+                    return;
                 }
                 match &self.sig.ret.scalar {
                     None => {
@@ -3072,6 +3675,39 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 results.extend(operands.iter().take(*amt).map(|v| v.clone()));
             }
 
+            Instruction::AsyncTaskReturn { name, params } => {
+                let body = match &mut self.deferred_task_return {
+                    DeferredTaskReturn::Generating { prev_src } => {
+                        mem::swap(&mut self.src, prev_src);
+                        mem::take(prev_src)
+                    }
+                    _ => unreachable!(),
+                };
+                assert_eq!(params.len(), operands.len());
+                self.deferred_task_return = DeferredTaskReturn::Emitted {
+                    name: name.to_string(),
+                    body,
+                    params: params
+                        .iter()
+                        .zip(operands)
+                        .map(|(a, b)| (a.clone(), b.clone()))
+                        .collect(),
+                };
+            }
+
+            Instruction::FutureLift { .. } => {
+                results.push(format!("((uint32_t) {})", operands[0]));
+            }
+            Instruction::FutureLower { .. } => {
+                results.push(format!("((int32_t) {})", operands[0]));
+            }
+            Instruction::StreamLift { .. } => {
+                results.push(format!("((uint32_t) {})", operands[0]));
+            }
+            Instruction::StreamLower { .. } => {
+                results.push(format!("((int32_t) {})", operands[0]));
+            }
+
             i => unimplemented!("{:?}", i),
         }
     }
@@ -3094,10 +3730,12 @@ struct Source {
     h_defs: wit_bindgen_core::Source,
     h_fns: wit_bindgen_core::Source,
     h_helpers: wit_bindgen_core::Source,
+    h_async: wit_bindgen_core::Source,
     c_defs: wit_bindgen_core::Source,
     c_fns: wit_bindgen_core::Source,
     c_helpers: wit_bindgen_core::Source,
     c_adapters: wit_bindgen_core::Source,
+    c_async: wit_bindgen_core::Source,
 }
 
 impl Source {
@@ -3111,10 +3749,12 @@ impl Source {
         self.h_defs.push_str(&append_src.h_defs);
         self.h_fns.push_str(&append_src.h_fns);
         self.h_helpers.push_str(&append_src.h_helpers);
+        self.h_async.push_str(&append_src.h_async);
         self.c_defs.push_str(&append_src.c_defs);
         self.c_fns.push_str(&append_src.c_fns);
         self.c_helpers.push_str(&append_src.c_helpers);
         self.c_adapters.push_str(&append_src.c_adapters);
+        self.c_async.push_str(&append_src.c_async);
     }
     fn h_defs(&mut self, s: &str) {
         self.h_defs.push_str(s);
@@ -3178,8 +3818,8 @@ pub fn is_arg_by_pointer(resolve: &Resolve, ty: &Type) -> bool {
             TypeDefKind::Flags(_) => false,
             TypeDefKind::Handle(_) => false,
             TypeDefKind::Tuple(_) | TypeDefKind::Record(_) | TypeDefKind::List(_) => true,
-            TypeDefKind::Future(_) => todo!("is_arg_by_pointer for future"),
-            TypeDefKind::Stream(_) => todo!("is_arg_by_pointer for stream"),
+            TypeDefKind::Future(_) => false,
+            TypeDefKind::Stream(_) => false,
             TypeDefKind::Resource => todo!("is_arg_by_pointer for resource"),
             TypeDefKind::Unknown => unreachable!(),
         },

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,3 +18,9 @@ doctest = false
 wit-parser = { workspace = true }
 anyhow = { workspace = true }
 heck = { workspace = true }
+serde = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+
+[features]
+serde = ['dep:serde']
+clap = ['dep:clap']

--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -1141,7 +1141,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         // value was stored at. Allocate some space here
                         // (statically) and then write the result into that
                         // memory, returning the pointer at the end.
-                        AbiVariant::GuestExport => {
+                        AbiVariant::GuestExport | AbiVariant::GuestExportAsync => {
                             let ElementInfo { size, align } =
                                 self.bindgen.sizes().params(&func.result);
                             let ptr = self.bindgen.return_pointer(size, align);
@@ -1153,9 +1153,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                             self.stack.push(ptr);
                         }
 
-                        AbiVariant::GuestImportAsync
-                        | AbiVariant::GuestExportAsync
-                        | AbiVariant::GuestExportAsyncStackful => {
+                        AbiVariant::GuestImportAsync | AbiVariant::GuestExportAsyncStackful => {
                             unreachable!()
                         }
                     }

--- a/crates/core/src/async_.rs
+++ b/crates/core/src/async_.rs
@@ -1,0 +1,200 @@
+use anyhow::{bail, Result};
+use std::collections::HashSet;
+use std::fmt;
+use wit_parser::{Function, FunctionKind, Resolve, WorldKey};
+
+/// Structure used to parse the command line argument `--async` consistently
+/// across guest generators.
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[derive(Clone, Default, Debug)]
+pub struct AsyncFilterSet {
+    /// Determines which functions to lift or lower `async`, if any.
+    ///
+    /// This option can be passed multiple times and additionally accepts
+    /// comma-separated values for each option passed. Each individual argument
+    /// passed here can be one of:
+    ///
+    /// - `all` - all imports and exports will be async
+    /// - `-all` - force all imports and exports to be sync
+    /// - `foo:bar/baz#method` - force this method to be async
+    /// - `import:foo:bar/baz#method` - force this method to be async, but only
+    ///   as an import
+    /// - `-export:foo:bar/baz#method` - force this export to be sync
+    ///
+    /// If a method is not listed in this option then the WIT's default bindings
+    /// mode will be used. If the WIT function is defined as `async` then async
+    /// bindings will be generated, otherwise sync bindings will be generated.
+    ///
+    /// Options are processed in the order they are passed here, so if a method
+    /// matches two directives passed the least-specific one should be last.
+    #[cfg_attr(
+        feature = "clap",
+        arg(
+            long = "async",
+            value_parser = parse_async,
+            value_delimiter =',',
+            value_name = "FILTER",
+        ),
+    )]
+    #[cfg_attr(feature = "serde", serde(rename = "async"))]
+    async_: Vec<Async>,
+
+    #[cfg_attr(feature = "clap", arg(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
+    used_options: HashSet<usize>,
+}
+
+#[cfg(feature = "clap")]
+fn parse_async(s: &str) -> Result<Async, String> {
+    Ok(Async::parse(s))
+}
+
+impl AsyncFilterSet {
+    /// Returns a set where all functions should be async or not depending on
+    /// `async_` provided.
+    pub fn all(async_: bool) -> AsyncFilterSet {
+        AsyncFilterSet {
+            async_: vec![Async {
+                enabled: async_,
+                filter: AsyncFilter::All,
+            }],
+            used_options: HashSet::new(),
+        }
+    }
+
+    /// Returns whether the `func` provided is to be bound `async` or not.
+    pub fn is_async(
+        &mut self,
+        resolve: &Resolve,
+        interface: Option<&WorldKey>,
+        func: &Function,
+        is_import: bool,
+    ) -> bool {
+        let name_to_test = match interface {
+            Some(key) => format!("{}#{}", resolve.name_world_key(key), func.name),
+            None => func.name.clone(),
+        };
+        for (i, opt) in self.async_.iter().enumerate() {
+            let name = match &opt.filter {
+                AsyncFilter::All => {
+                    self.used_options.insert(i);
+                    return opt.enabled;
+                }
+                AsyncFilter::Function(s) => s,
+                AsyncFilter::Import(s) => {
+                    if !is_import {
+                        continue;
+                    }
+                    s
+                }
+                AsyncFilter::Export(s) => {
+                    if is_import {
+                        continue;
+                    }
+                    s
+                }
+            };
+            if *name == name_to_test {
+                self.used_options.insert(i);
+                return opt.enabled;
+            }
+        }
+
+        match &func.kind {
+            FunctionKind::Freestanding
+            | FunctionKind::Method(_)
+            | FunctionKind::Static(_)
+            | FunctionKind::Constructor(_) => false,
+            FunctionKind::AsyncFreestanding
+            | FunctionKind::AsyncMethod(_)
+            | FunctionKind::AsyncStatic(_) => true,
+        }
+    }
+
+    /// Intended to be used in the header comment of generated code to help
+    /// indicate what options were specified.
+    pub fn debug_opts(&self) -> impl Iterator<Item = String> + '_ {
+        self.async_.iter().map(|opt| opt.to_string())
+    }
+
+    /// Tests whether all `--async` options were used throughout bindings
+    /// generation, returning an error if any were unused.
+    pub fn ensure_all_used(&self) -> Result<()> {
+        for (i, opt) in self.async_.iter().enumerate() {
+            if self.used_options.contains(&i) {
+                continue;
+            }
+            if !matches!(opt.filter, AsyncFilter::All) {
+                bail!("unused async option: {opt}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns whether any option explicitly requests that async is enabled.
+    pub fn any_enabled(&self) -> bool {
+        self.async_.iter().any(|o| o.enabled)
+    }
+
+    /// Pushes a new option into this set.
+    pub fn push(&mut self, directive: &str) {
+        self.async_.push(Async::parse(directive));
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+struct Async {
+    enabled: bool,
+    filter: AsyncFilter,
+}
+
+impl Async {
+    fn parse(s: &str) -> Async {
+        let (s, enabled) = match s.strip_prefix('-') {
+            Some(s) => (s, false),
+            None => (s, true),
+        };
+        let filter = match s {
+            "all" => AsyncFilter::All,
+            other => match other.strip_prefix("import:") {
+                Some(s) => AsyncFilter::Import(s.to_string()),
+                None => match other.strip_prefix("export:") {
+                    Some(s) => AsyncFilter::Export(s.to_string()),
+                    None => AsyncFilter::Function(s.to_string()),
+                },
+            },
+        };
+        Async { enabled, filter }
+    }
+}
+
+impl fmt::Display for Async {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.enabled {
+            write!(f, "-")?;
+        }
+        self.filter.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+enum AsyncFilter {
+    All,
+    Function(String),
+    Import(String),
+    Export(String),
+}
+
+impl fmt::Display for AsyncFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AsyncFilter::All => write!(f, "all"),
+            AsyncFilter::Function(s) => write!(f, "{s}"),
+            AsyncFilter::Import(s) => write!(f, "import:{s}"),
+            AsyncFilter::Export(s) => write!(f, "export:{s}"),
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,8 @@ mod types;
 pub use types::{TypeInfo, Types};
 mod path;
 pub use path::name_package_module;
+mod async_;
+pub use async_::AsyncFilterSet;
 
 #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Direction {

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -8,7 +8,8 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{braced, token, LitStr, Token};
 use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackageGroup, WorldId};
-use wit_bindgen_rust::{Async, AsyncFilter, Opts, Ownership, WithOption};
+use wit_bindgen_core::AsyncFilterSet;
+use wit_bindgen_rust::{Opts, Ownership, WithOption};
 
 #[proc_macro]
 pub fn generate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -155,7 +156,7 @@ impl Parse for Config {
                             return Err(Error::new(span, "cannot specify second async config"));
                         }
                         async_configured = true;
-                        if val.iter().any(|v| v.enabled) && !cfg!(feature = "async") {
+                        if val.any_enabled() && !cfg!(feature = "async") {
                             return Err(Error::new(
                                 span,
                                 "must enable `async` feature to enable async imports and/or exports",
@@ -394,7 +395,7 @@ enum Opt {
     GenerateUnusedTypes(syn::LitBool),
     Features(Vec<syn::LitStr>),
     DisableCustomSectionLinkHelpers(syn::LitBool),
-    Async(Vec<Async>, Span),
+    Async(AsyncFilterSet, Span),
     Debug(syn::LitBool),
 }
 
@@ -559,21 +560,15 @@ impl Parse for Opt {
             input.parse::<Token![:]>()?;
             if input.peek(syn::LitBool) {
                 let enabled = input.parse::<syn::LitBool>()?.value;
-                Ok(Opt::Async(
-                    vec![Async {
-                        enabled,
-                        filter: AsyncFilter::All,
-                    }],
-                    span,
-                ))
+                Ok(Opt::Async(AsyncFilterSet::all(enabled), span))
             } else {
-                let mut vals = Vec::new();
+                let mut set = AsyncFilterSet::default();
                 let contents;
                 syn::bracketed!(contents in input);
-                for val in contents.parse_terminated(parse_async, Token![,])? {
-                    vals.push(val);
+                for val in contents.parse_terminated(|p| p.parse::<syn::LitStr>(), Token![,])? {
+                    set.push(&val.value());
                 }
-                Ok(Opt::Async(vals, span))
+                Ok(Opt::Async(set, span))
             }
         } else {
             Err(l.error())
@@ -632,9 +627,4 @@ fn with_field_parse(input: ParseStream<'_>) -> Result<(String, WithOption)> {
 fn fmt(input: &str) -> Result<String> {
     let syntax_tree = syn::parse_file(&input)?;
     Ok(prettyplease::unparse(&syntax_tree))
-}
-
-fn parse_async(input: ParseStream<'_>) -> Result<Async> {
-    let value = input.parse::<syn::LitStr>()?.value();
-    Ok(Async::parse(&value))
 }

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -34,3 +34,7 @@ wit-bindgen-rt = { path = '../guest-rust/rt' }
 test-helpers = { path = '../test-helpers' }
 # For use with the custom attributes test
 serde_json = "1"
+
+[features]
+serde = ['dep:serde', 'wit-bindgen-core/serde']
+clap = ['dep:clap', 'wit-bindgen-core/clap']

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1134,6 +1134,8 @@ unsafe fn call_import(params: *mut u8, results: *mut u8) -> u32 {{
 
     fn print_export_sig(&mut self, func: &Function, async_: bool) -> Vec<String> {
         self.src.push_str("(");
+        // FIXME: this should use `GuestExportAsync` once that's fixed in
+        // wit-parser
         let sig = self.resolve.wasm_signature(AbiVariant::GuestExport, func);
         let mut params = Vec::new();
         for (i, param) in sig.params.iter().enumerate() {

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -9,8 +9,8 @@ use std::mem;
 use std::str::FromStr;
 use wit_bindgen_core::abi::{Bitcast, WasmType};
 use wit_bindgen_core::{
-    dealias, name_package_module, uwrite, uwriteln, wit_parser::*, Files, InterfaceGenerator as _,
-    Source, Types, WorldGenerator,
+    dealias, name_package_module, uwrite, uwriteln, wit_parser::*, AsyncFilterSet, Files,
+    InterfaceGenerator as _, Source, Types, WorldGenerator,
 };
 
 mod bindgen;
@@ -52,7 +52,6 @@ struct RustWasm {
 
     future_payloads: IndexMap<String, String>,
     stream_payloads: IndexMap<String, String>,
-    used_async_options: HashSet<usize>,
 }
 
 #[derive(Default)]
@@ -139,67 +138,6 @@ fn parse_with(s: &str) -> Result<(String, WithOption), String> {
     Ok((k.to_string(), v))
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub struct Async {
-    pub enabled: bool,
-    pub filter: AsyncFilter,
-}
-
-impl Async {
-    pub fn parse(s: &str) -> Async {
-        let (s, enabled) = match s.strip_prefix('-') {
-            Some(s) => (s, false),
-            None => (s, true),
-        };
-        let filter = match s {
-            "all" => AsyncFilter::All,
-            other => match other.strip_prefix("import:") {
-                Some(s) => AsyncFilter::Import(s.to_string()),
-                None => match other.strip_prefix("export:") {
-                    Some(s) => AsyncFilter::Export(s.to_string()),
-                    None => AsyncFilter::Function(s.to_string()),
-                },
-            },
-        };
-        Async { enabled, filter }
-    }
-}
-
-impl fmt::Display for Async {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if !self.enabled {
-            write!(f, "-")?;
-        }
-        self.filter.fmt(f)
-    }
-}
-
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub enum AsyncFilter {
-    All,
-    Function(String),
-    Import(String),
-    Export(String),
-}
-
-impl fmt::Display for AsyncFilter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AsyncFilter::All => write!(f, "all"),
-            AsyncFilter::Function(s) => write!(f, "{s}"),
-            AsyncFilter::Import(s) => write!(f, "import:{s}"),
-            AsyncFilter::Export(s) => write!(f, "export:{s}"),
-        }
-    }
-}
-
-#[cfg(feature = "clap")]
-fn parse_async(s: &str) -> Result<Async, String> {
-    Ok(Async::parse(s))
-}
-
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 #[cfg_attr(
@@ -225,7 +163,7 @@ pub struct Opts {
     pub raw_strings: bool,
 
     /// Names of functions to skip generating bindings for.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "NAME"))]
     pub skip: Vec<String>,
 
     /// If true, generate stub implementations for any exported functions,
@@ -236,7 +174,7 @@ pub struct Opts {
     /// Optionally prefix any export names with the specified value.
     ///
     /// This is useful to avoid name conflicts when testing.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "STRING"))]
     pub export_prefix: Option<String>,
 
     /// Whether to generate owning or borrowing type definitions.
@@ -258,7 +196,7 @@ pub struct Opts {
     /// The optional path to the wit-bindgen runtime module to use.
     ///
     /// This defaults to `wit_bindgen::rt`.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "PATH"))]
     pub runtime_path: Option<String>,
 
     /// The optional path to the bitflags crate to use.
@@ -271,7 +209,7 @@ pub struct Opts {
     /// specified multiple times to add multiple attributes.
     ///
     /// These derive attributes will be added to any generated structs or enums
-    #[cfg_attr(feature = "clap", arg(long, short = 'd'))]
+    #[cfg_attr(feature = "clap", arg(long, short = 'd', value_name = "DERIVE"))]
     pub additional_derive_attributes: Vec<String>,
 
     /// Variants and records to ignore when applying additional derive attributes.
@@ -280,7 +218,7 @@ pub struct Opts {
     /// This feature allows some variants and records to use types for which adding traits will cause
     /// compilation to fail, such as serde::Deserialize on wasi:io/streams.
     ///
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "NAME"))]
     pub additional_derive_ignore: Vec<String>,
 
     /// Remapping of wit interface and type names to Rust module names and types.
@@ -298,7 +236,7 @@ pub struct Opts {
 
     /// Add the specified suffix to the name of the custome section containing
     /// the component type.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "STRING"))]
     pub type_section_suffix: Option<String>,
 
     /// Disable a workaround used to prevent libc ctors/dtors from being invoked
@@ -308,11 +246,11 @@ pub struct Opts {
 
     /// Changes the default module used in the generated `export!` macro to
     /// something other than `self`.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "NAME"))]
     pub default_bindings_module: Option<String>,
 
     /// Alternative name to use for the `export!` macro if one is generated.
-    #[cfg_attr(feature = "clap", arg(long))]
+    #[cfg_attr(feature = "clap", arg(long, value_name = "NAME"))]
     pub export_macro_name: Option<String>,
 
     /// Ensures that the `export!` macro will be defined as `pub` so it is a
@@ -332,35 +270,9 @@ pub struct Opts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub disable_custom_section_link_helpers: bool,
 
-    /// Determines which functions to lift or lower `async`, if any.
-    ///
-    /// This option can be passed multiple times and additionally accepts
-    /// comma-separated values for each option passed. Each individual argument
-    /// passed here can be one of:
-    ///
-    /// - `all` - all imports and exports will be async
-    /// - `-all` - force all imports and exports to be sync
-    /// - `foo:bar/baz#method` - force this method to be async
-    /// - `import:foo:bar/baz#method` - force this method to be async, but only
-    ///   as an import
-    /// - `-export:foo:bar/baz#method` - force this export to be sync
-    ///
-    /// If a method is not listed in this option then the WIT's default bindings
-    /// mode will be used. If the WIT function is defined as `async` then async
-    /// bindings will be generated, otherwise sync bindings will be generated.
-    ///
-    /// Options are processed in the order they are passed here, so if a method
-    /// matches two directives passed the least-specific one should be last.
-    #[cfg_attr(
-        feature = "clap",
-        arg(
-            long = "async",
-            value_parser = parse_async,
-            value_delimiter =',',
-        ),
-    )]
-    #[cfg_attr(feature = "serde", serde(rename = "async"))]
-    pub async_: Vec<Async>,
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub async_: AsyncFilterSet,
 }
 
 impl Opts {
@@ -1044,45 +956,9 @@ macro_rules! __export_{world_name}_impl {{
         func: &Function,
         is_import: bool,
     ) -> bool {
-        let name_to_test = match interface {
-            Some(key) => format!("{}#{}", resolve.name_world_key(key), func.name),
-            None => func.name.clone(),
-        };
-        for (i, opt) in self.opts.async_.iter().enumerate() {
-            let name = match &opt.filter {
-                AsyncFilter::All => {
-                    self.used_async_options.insert(i);
-                    return opt.enabled;
-                }
-                AsyncFilter::Function(s) => s,
-                AsyncFilter::Import(s) => {
-                    if !is_import {
-                        continue;
-                    }
-                    s
-                }
-                AsyncFilter::Export(s) => {
-                    if is_import {
-                        continue;
-                    }
-                    s
-                }
-            };
-            if *name == name_to_test {
-                self.used_async_options.insert(i);
-                return opt.enabled;
-            }
-        }
-
-        match &func.kind {
-            FunctionKind::Freestanding
-            | FunctionKind::Method(_)
-            | FunctionKind::Static(_)
-            | FunctionKind::Constructor(_) => false,
-            FunctionKind::AsyncFreestanding
-            | FunctionKind::AsyncMethod(_)
-            | FunctionKind::AsyncStatic(_) => true,
-        }
+        self.opts
+            .async_
+            .is_async(resolve, interface, func, is_import)
     }
 }
 
@@ -1180,7 +1056,7 @@ impl WorldGenerator for RustWasm {
                 "//   * disable_custom_section_link_helpers"
             );
         }
-        for opt in self.opts.async_.iter() {
+        for opt in self.opts.async_.debug_opts() {
             uwriteln!(self.src_preamble, "//   * async: {opt}");
         }
         self.types.analyze(resolve);
@@ -1500,14 +1376,7 @@ impl WorldGenerator for RustWasm {
 
         // Error about unused async configuration to help catch configuration
         // errors.
-        for (i, opt) in self.opts.async_.iter().enumerate() {
-            if self.used_async_options.contains(&i) {
-                continue;
-            }
-            if !matches!(opt.filter, AsyncFilter::All) {
-                bail!("unused async option: {opt}");
-            }
-        }
+        self.opts.async_.ensure_all_used()?;
 
         Ok(())
     }

--- a/crates/test/src/config.rs
+++ b/crates/test/src/config.rs
@@ -110,6 +110,10 @@ pub struct WitConfig {
     #[serde(default, rename = "async")]
     pub async_: bool,
 
+    /// Whether or not this test uses `error-context`
+    #[serde(default)]
+    pub error_context: bool,
+
     /// When set to `true` disables the passing of per-language default bindgen
     /// arguments. For example with Rust it avoids passing `--generate-all` by
     /// default to bindings generation.

--- a/crates/test/src/rust.rs
+++ b/crates/test/src/rust.rs
@@ -18,7 +18,7 @@ pub struct RustOpts {
     #[clap(long, conflicts_with = "rust_wit_bindgen_path", value_name = "X.Y.Z")]
     rust_wit_bindgen_version: Option<String>,
 
-    /// A custom version to use for the `wit-bindgen` dependency.
+    /// Name of the Rust target to compile for.
     #[clap(long, default_value = "wasm32-wasip2", value_name = "TARGET")]
     rust_target: String,
 }

--- a/tests/codegen/error-context.wit
+++ b/tests/codegen/error-context.wit
@@ -1,4 +1,5 @@
 //@ async = true
+//@ error-context = true
 
 package foo:foo;
 

--- a/tests/runtime-async/async/cancel-import/runner.c
+++ b/tests/runtime-async/async/cancel-import/runner.c
@@ -1,0 +1,72 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <runner.h>
+
+int main() {
+  // Call an import and cancel it.
+  {
+    test_future_void_writer_t writer;
+    test_future_void_t reader = test_future_void_new(&writer);
+    runner_subtask_status_t status = test_async_pending_import(&reader);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+    runner_subtask_t subtask = RUNNER_SUBTASK_HANDLE(status);
+    assert(subtask != 0);
+    status = runner_subtask_cancel(subtask);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED_CANCELLED);
+    assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+
+    runner_waitable_status_t status2 = test_future_void_write(writer);
+    assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(status2) == 0);
+    test_future_void_close_writable(writer);
+  }
+
+  // One import in "started", one in "starting", then cancel both.
+  {
+    test_future_void_writer_t writer1;
+    test_future_void_t reader1 = test_future_void_new(&writer1);
+    test_future_void_writer_t writer2;
+    test_future_void_t reader2 = test_future_void_new(&writer2);
+
+    // start up one task, it'll be in "STARTED"
+    runner_subtask_status_t status = test_async_pending_import(&reader1);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+    runner_subtask_t subtask1 = RUNNER_SUBTASK_HANDLE(status);
+    assert(subtask1 != 0);
+
+    // Start up a second task after setting the backpressure flag, forcing it
+    // to be in the "STARTING" state.
+    test_backpressure_set(true);
+    status = test_async_pending_import(&reader2);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTING);
+    runner_subtask_t subtask2 = RUNNER_SUBTASK_HANDLE(status);
+    assert(subtask2 != 0);
+
+    // Now cancel both tasks, witnessing slightly different cancellation codes.
+    status = runner_subtask_cancel(subtask1);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED_CANCELLED);
+    assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+    status = runner_subtask_cancel(subtask2);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED_CANCELLED);
+    assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+
+    // We still own the readable end of `reader2` and `writer2` since the
+    // subtask didn't actually start, so close it here.
+    test_future_void_close_readable(reader2);
+
+    // Assert both write ends are closed
+    runner_waitable_status_t status2 = test_future_void_write(writer1);
+    assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(status2) == 0);
+    test_future_void_close_writable(writer1);
+
+    status2 = test_future_void_write(writer2);
+    assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(status2) == 0);
+    test_future_void_close_writable(writer2);
+
+    // reset the backpressure flag
+    test_backpressure_set(false);
+  }
+}

--- a/tests/runtime-async/async/cancel-import/runner.c
+++ b/tests/runtime-async/async/cancel-import/runner.c
@@ -55,7 +55,7 @@ int main() {
     // subtask didn't actually start, so close it here.
     test_future_void_close_readable(reader2);
 
-    // Assert both write ends are closed
+    // Assert both read ends are closed from the POV of the write ends
     runner_waitable_status_t status2 = test_future_void_write(writer1);
     assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_CLOSED);
     assert(RUNNER_WAITABLE_COUNT(status2) == 0);

--- a/tests/runtime-async/async/cancel-import/runner.rs
+++ b/tests/runtime-async/async/cancel-import/runner.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 fn main() {
-    // Cancel an import in-progress
+    println!("test cancelling an import in progress");
     wit_bindgen::block_on(async {
         let (tx, rx) = wit_future::new();
         let mut import = Box::pin(pending_import(rx));
@@ -19,7 +19,7 @@ fn main() {
         tx.write(()).await.unwrap_err();
     });
 
-    // Cancel an import before it starts
+    println!("test cancelling an import before it starts");
     wit_bindgen::block_on(async {
         let (tx, rx) = wit_future::new();
         let import = Box::pin(pending_import(rx));
@@ -27,7 +27,7 @@ fn main() {
         tx.write(()).await.unwrap_err();
     });
 
-    // Cancel an import in the "started" state
+    println!("test cancelling an import in the started state");
     wit_bindgen::block_on(async {
         let (tx1, rx1) = wit_future::new();
         let (tx2, rx2) = wit_future::new();
@@ -63,6 +63,7 @@ fn main() {
     });
 
     // Race an import's cancellation with a status code saying it's done.
+    println!("test cancellation with a status code saying it's done");
     wit_bindgen::block_on(async {
         // Start a subtask and get it into the "started" state
         let (tx, rx) = wit_future::new();
@@ -88,6 +89,7 @@ fn main() {
 
     // Race an import's cancellation with a pending status code indicating that
     // it's transitioning from started => returned.
+    println!("race cancellation with pending status code");
     wit_bindgen::block_on(async {
         // Start a subtask and get it into the "started" state
         let (tx1, rx1) = wit_future::new();

--- a/tests/runtime-async/async/cancel-import/test.c
+++ b/tests/runtime-async/async/cancel-import/test.c
@@ -1,0 +1,54 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <stdlib.h>
+#include <test.h>
+
+struct my_task {
+  test_waitable_set_t set;
+  exports_test_future_void_t future;
+};
+
+test_callback_code_t exports_test_async_pending_import(exports_test_future_void_t x) {
+  struct my_task *task = malloc(sizeof(struct my_task));
+  assert(task != NULL);
+  test_waitable_status_t status = exports_test_future_void_read(x);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+  task->future = x;
+  task->set = test_waitable_set_new();
+  test_waitable_join(task->future, task->set);
+
+  test_context_set(task);
+  return TEST_CALLBACK_CODE_WAIT(task->set);
+}
+
+test_callback_code_t exports_test_async_pending_import_callback(test_event_t *event) {
+  struct my_task *task = test_context_get();
+  if (event->event == TEST_EVENT_CANCEL) {
+    assert(event->waitable == 0);
+    assert(event->code == 0);
+
+    test_waitable_status_t status = exports_test_future_void_cancel_read(task->future);
+    assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_CANCELLED);
+    assert(TEST_WAITABLE_COUNT(status) == 0);
+    test_task_cancel();
+  } else {
+    assert(event->event == TEST_EVENT_FUTURE_READ);
+    assert(event->waitable == task->future);
+    assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+    assert(TEST_WAITABLE_COUNT(event->code) == 1);
+    exports_test_async_pending_import_return();
+  }
+
+  test_waitable_join(task->future, 0);
+  exports_test_future_void_close_readable(task->future);
+  test_waitable_set_drop(task->set);
+
+  free(task);
+
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+void exports_test_backpressure_set(bool x) {
+  test_backpressure_set(x);
+}

--- a/tests/runtime-async/async/future-cancel-read/runner.c
+++ b/tests/runtime-async/async/future-cancel-read/runner.c
@@ -1,0 +1,33 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <runner.h>
+
+/* extern runner_subtask_status_t test_async_cancel_before_read(test_future_u32_t *arg); */
+/* extern runner_subtask_status_t test_async_cancel_after_read(test_future_u32_t *arg); */
+/* extern runner_subtask_status_t test_async_start_read_then_cancel(void); */
+
+int main() {
+  {
+    test_future_u32_writer_t writer;
+    test_future_u32_t reader = test_future_u32_new(&writer);
+
+    runner_subtask_status_t status = test_async_cancel_before_read(&reader);
+    assert(status == RUNNER_SUBTASK_RETURNED);
+    test_future_u32_close_writable(writer);
+  }
+
+  {
+    test_future_u32_writer_t writer;
+    test_future_u32_t reader = test_future_u32_new(&writer);
+
+    runner_subtask_status_t status = test_async_cancel_after_read(&reader);
+    assert(status == RUNNER_SUBTASK_RETURNED);
+    test_future_u32_close_writable(writer);
+  }
+
+  {
+    runner_subtask_status_t status = test_async_start_read_then_cancel();
+    assert(status == RUNNER_SUBTASK_RETURNED);
+  }
+}

--- a/tests/runtime-async/async/future-cancel-read/test.c
+++ b/tests/runtime-async/async/future-cancel-read/test.c
@@ -1,0 +1,55 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+// This is a test of a Rust-ism, nothing to do in C.
+test_callback_code_t exports_test_async_cancel_before_read(exports_test_future_u32_t x) {
+  exports_test_future_u32_close_readable(x);
+  exports_test_async_cancel_before_read_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_callback_code_t exports_test_async_cancel_before_read_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_callback_code_t exports_test_async_cancel_after_read(exports_test_future_u32_t x) {
+  uint32_t result;
+  test_waitable_status_t status = exports_test_future_u32_read(x, &result);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+  status = exports_test_future_u32_cancel_read(x);
+  assert(status == TEST_WAITABLE_CANCELLED);
+
+  exports_test_future_u32_close_readable(x);
+
+  exports_test_async_cancel_after_read_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_callback_code_t exports_test_async_cancel_after_read_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_callback_code_t exports_test_async_start_read_then_cancel() {
+  exports_test_future_u32_writer_t writer;
+  exports_test_future_u32_t reader = exports_test_future_u32_new(&writer);
+
+  uint32_t result;
+  test_waitable_status_t status = exports_test_future_u32_read(reader, &result);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+  status = exports_test_future_u32_cancel_read(reader);
+  assert(status == TEST_WAITABLE_CANCELLED);
+
+  exports_test_future_u32_close_readable(reader);
+  exports_test_future_u32_close_writable(writer);
+
+  exports_test_async_start_read_then_cancel_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_callback_code_t exports_test_async_start_read_then_cancel_callback(test_event_t *event) {
+  assert(0);
+}

--- a/tests/runtime-async/async/future-cancel-read/test.rs
+++ b/tests/runtime-async/async/future-cancel-read/test.rs
@@ -28,16 +28,13 @@ impl crate::exports::my::test::i::Guest for Component {
     }
 
     async fn start_read_then_cancel() {
-        // FIXME(wasip3-prototyping#137)
-        if false {
-            let (tx, rx) = wit_future::new::<u32>();
-            let mut read = Box::pin(rx.into_future());
-            assert!(read
-                .as_mut()
-                .poll(&mut Context::from_waker(noop_waker_ref()))
-                .is_pending());
-            drop(tx);
-            assert!(read.as_mut().cancel().unwrap().is_none());
-        }
+        let (tx, rx) = wit_future::new::<u32>();
+        let mut read = Box::pin(rx.into_future());
+        assert!(read
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        drop(tx);
+        assert!(read.as_mut().cancel().unwrap().is_none());
     }
 }

--- a/tests/runtime-async/async/future-cancel-write/runner.c
+++ b/tests/runtime-async/async/future-cancel-write/runner.c
@@ -1,0 +1,63 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <runner.h>
+
+int main() {
+  runner_event_t event;
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_string_t string;
+  runner_string_set(&string, "hello");
+
+  {
+    test_future_string_writer_t writer;
+    test_future_string_t reader = test_future_string_new(&writer);
+
+    runner_waitable_status_t status = test_future_string_write(writer, &string);
+    assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+    test_take_then_close(reader);
+
+    runner_waitable_join(writer, set);
+    runner_waitable_set_wait(set, &event);
+    assert(event.event == RUNNER_EVENT_FUTURE_WRITE);
+    assert(event.waitable == writer);
+    assert(event.code == RUNNER_WAITABLE_CLOSED);
+
+    runner_waitable_join(writer, 0);
+    test_future_string_close_writable(writer);
+  }
+
+  {
+    test_future_string_writer_t writer;
+    test_future_string_t reader = test_future_string_new(&writer);
+
+    runner_waitable_status_t status = test_future_string_write(writer, &string);
+    assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+    status = test_future_string_cancel_write(writer);
+    assert(RUNNER_WAITABLE_STATE(status) == RUNNER_WAITABLE_CANCELLED);
+    assert(RUNNER_WAITABLE_COUNT(status) == 0);
+
+    test_future_string_close_writable(writer);
+    test_future_string_close_readable(reader);
+  }
+
+  {
+    test_future_string_writer_t writer;
+    test_future_string_t reader = test_future_string_new(&writer);
+
+    runner_waitable_status_t status = test_future_string_write(writer, &string);
+    assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+    runner_subtask_status_t status2 = test_async_read_and_drop(&reader);
+    assert(status2 == RUNNER_SUBTASK_RETURNED);
+
+    status = test_future_string_cancel_write(writer);
+    assert(RUNNER_WAITABLE_STATE(status) == RUNNER_WAITABLE_COMPLETED);
+    assert(RUNNER_WAITABLE_COUNT(status) == 1);
+
+    test_future_string_close_writable(writer);
+  }
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/future-cancel-write/runner.rs
+++ b/tests/runtime-async/async/future-cancel-write/runner.rs
@@ -40,39 +40,31 @@ fn main() {
         };
 
         // cancel after we hit the intrinsic and then close the other end
-        //
-        // FIXME(wasip3-prototyping#137)
-        if false {
-            let (tx, rx) = wit_future::new::<String>();
-            let mut future = Box::pin(tx.write("hello3".into()));
-            assert!(future
-                .as_mut()
-                .poll(&mut Context::from_waker(noop_waker_ref()))
-                .is_pending());
-            drop(rx);
-            match future.as_mut().cancel() {
-                FutureWriteCancel::Closed(val) => assert_eq!(val, "hello3"),
-                other => panic!("expected closed, got: {other:?}"),
-            };
-        }
+        let (tx, rx) = wit_future::new::<String>();
+        let mut future = Box::pin(tx.write("hello3".into()));
+        assert!(future
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        drop(rx);
+        match future.as_mut().cancel() {
+            FutureWriteCancel::Closed(val) => assert_eq!(val, "hello3"),
+            other => panic!("expected closed, got: {other:?}"),
+        };
 
         // Start a write, wait for it to be pending, then go complete the write
         // in some async work, then cancel it and witness that it was written,
         // not cancelled.
-        //
-        // FIXME(wasip3-prototyping#138)
-        if false {
-            let (tx, rx) = wit_future::new::<String>();
-            let mut future = Box::pin(tx.write("hello3".into()));
-            assert!(future
-                .as_mut()
-                .poll(&mut Context::from_waker(noop_waker_ref()))
-                .is_pending());
-            read_and_drop(rx).await;
-            match future.as_mut().cancel() {
-                FutureWriteCancel::AlreadySent => {}
-                other => panic!("expected sent, got: {other:?}"),
-            };
-        }
+        let (tx, rx) = wit_future::new::<String>();
+        let mut future = Box::pin(tx.write("hello3".into()));
+        assert!(future
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending());
+        read_and_drop(rx).await;
+        match future.as_mut().cancel() {
+            FutureWriteCancel::AlreadySent => {}
+            other => panic!("expected sent, got: {other:?}"),
+        };
     });
 }

--- a/tests/runtime-async/async/future-cancel-write/test.c
+++ b/tests/runtime-async/async/future-cancel-write/test.c
@@ -1,0 +1,25 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+void exports_test_take_then_close(exports_test_future_string_t x) {
+  exports_test_future_string_close_readable(x);
+}
+
+test_callback_code_t exports_test_async_read_and_drop(exports_test_future_string_t x) {
+  test_string_t string;
+  test_waitable_status_t status = exports_test_future_string_read(x, &string);
+  assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(status) == 1);
+
+  exports_test_future_string_close_readable(x);
+  test_string_free(&string);
+
+  exports_test_async_read_and_drop_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_callback_code_t exports_test_async_read_and_drop_callback(test_event_t *event) {
+  assert(0);
+}

--- a/tests/runtime-async/async/pending-import/runner.c
+++ b/tests/runtime-async/async/pending-import/runner.c
@@ -1,0 +1,33 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <runner.h>
+#include <stdio.h>
+
+int main() {
+  test_future_void_writer_t writer;
+  test_future_void_t reader = test_future_void_new(&writer);
+  runner_subtask_status_t status = test_async_pending_import(&reader);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t subtask = RUNNER_SUBTASK_HANDLE(status);
+  assert(subtask != 0);
+
+  runner_waitable_status_t status2 = test_future_void_write(writer);
+  assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status2) == 1);
+  test_future_void_close_writable(writer);
+
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_waitable_join(subtask, set);
+
+  runner_event_t event;
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == subtask);
+  assert(event.code == RUNNER_SUBTASK_RETURNED);
+
+  runner_waitable_join(subtask, 0);
+  runner_subtask_drop(subtask);
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/pending-import/test.c
+++ b/tests/runtime-async/async/pending-import/test.c
@@ -1,0 +1,40 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <stdlib.h>
+#include <test.h>
+
+struct my_task {
+  test_waitable_set_t set;
+  exports_test_future_void_t future;
+};
+
+test_callback_code_t exports_test_async_pending_import(exports_test_future_void_t x) {
+  struct my_task *task = malloc(sizeof(struct my_task));
+  assert(task != NULL);
+  test_waitable_status_t status = exports_test_future_void_read(x);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+  task->future = x;
+  task->set = test_waitable_set_new();
+  test_waitable_join(task->future, task->set);
+
+  test_context_set(task);
+  return TEST_CALLBACK_CODE_WAIT(task->set);
+}
+
+test_callback_code_t exports_test_async_pending_import_callback(test_event_t *event) {
+  struct my_task *task = test_context_get();
+  assert(event->event == TEST_EVENT_FUTURE_READ);
+  assert(event->waitable == task->future);
+  assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(event->code) == 1);
+  exports_test_async_pending_import_return();
+
+  test_waitable_join(task->future, 0);
+  exports_test_future_void_close_readable(task->future);
+  test_waitable_set_drop(task->set);
+
+  free(task);
+
+  return TEST_CALLBACK_CODE_EXIT;
+}

--- a/tests/runtime-async/async/ping-pong/runner.c
+++ b/tests/runtime-async/async/ping-pong/runner.c
@@ -1,0 +1,76 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <string.h>
+#include <runner.h>
+
+int main() {
+  test_future_string_writer_t writer;
+  test_future_string_t reader = test_future_string_new(&writer);
+
+  // Start the "ping" subtask
+  test_async_ping_args_t args;
+  args.x = reader;
+  runner_string_set(&args.y, "world");
+  test_future_string_t ping_result;
+  runner_subtask_status_t status = test_async_ping(&args, &ping_result);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t ping = RUNNER_SUBTASK_HANDLE(status);
+
+  // Issue a write into the future we sent to "ping"
+  runner_string_t string_tmp;
+  runner_string_set(&string_tmp, "hello");
+  runner_waitable_status_t status2 = test_future_string_write(writer, &string_tmp);
+  assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status2) == 1);
+  test_future_string_close_writable(writer);
+
+  // Wait for the subtask to complete
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_waitable_join(ping, set);
+  runner_event_t event;
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == ping);
+  assert(RUNNER_SUBTASK_STATE(event.code) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(event.code) == 0);
+  runner_waitable_join(ping, 0);
+  runner_subtask_drop(ping);
+
+  // Read the result from our future
+  status2 = test_future_string_read(ping_result, &string_tmp);
+  assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status2) == 1);
+  assert(memcmp(string_tmp.ptr, "helloworld", string_tmp.len) == 0);
+  test_future_string_close_readable(ping_result);
+
+  // Start the `pong` subtask
+  runner_string_t pong_result;
+  reader = test_future_string_new(&writer);
+  status = test_async_pong(&reader, &pong_result);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t pong = RUNNER_SUBTASK_HANDLE(status);
+
+  // Write our string to the "pong" subtask
+  status2 = test_future_string_write(writer, &string_tmp);
+  assert(RUNNER_WAITABLE_STATE(status2) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status2) == 1);
+  runner_string_free(&string_tmp);
+  test_future_string_close_writable(writer);
+
+  // Wait for "pong" to complete
+  runner_waitable_join(pong, set);
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == pong);
+  assert(RUNNER_SUBTASK_STATE(event.code) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(event.code) == 0);
+  runner_waitable_join(pong, 0);
+  runner_subtask_drop(pong);
+
+  // Assert the result of "pong"
+  assert(memcmp(pong_result.ptr, "helloworld", pong_result.len) == 0);
+  runner_string_free(&pong_result);
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/ping-pong/test.c
+++ b/tests/runtime-async/async/ping-pong/test.c
@@ -1,0 +1,156 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <test.h>
+
+#define PING_S1 0
+#define PING_S2 1
+
+struct ping_task {
+  int state;
+  test_string_t arg;
+  test_string_t read_result;
+  exports_test_future_string_t future;
+  test_waitable_set_t set;
+  exports_test_future_string_writer_t writer;
+};
+
+test_callback_code_t exports_test_async_ping(exports_test_future_string_t x, test_string_t *y) {
+  // Initialize a new task
+  struct ping_task *task = malloc(sizeof(struct ping_task));
+  assert(task != NULL);
+  memset(task, 0, sizeof(struct ping_task));
+  task->state = PING_S1;
+  task->arg = *y;
+  task->future = x;
+  task->set = test_waitable_set_new();
+
+  // Start reading the future provided
+  test_waitable_status_t status = exports_test_future_string_read(x, &task->read_result);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+  // Register ourselves as waiting on the future, then block our task.
+  test_waitable_join(task->future, task->set);
+  test_context_set(task);
+  return TEST_CALLBACK_CODE_WAIT(task->set);
+}
+
+test_callback_code_t exports_test_async_ping_callback(test_event_t *event) {
+  struct ping_task *task = test_context_get();
+  switch (task->state) {
+    case PING_S1:
+      // Assert that our future read completed and discard the read end of the
+      // future.
+      assert(event->event == TEST_EVENT_FUTURE_READ);
+      assert(event->waitable == task->future);
+      assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+      assert(TEST_WAITABLE_COUNT(event->code) == 1);
+      test_waitable_join(task->future, 0);
+      exports_test_future_string_close_readable(task->future);
+      task->future = 0;
+
+      // Create a new future and start the return of our task with this future.
+      exports_test_future_string_writer_t writer;
+      exports_test_future_string_t reader = exports_test_future_string_new(&writer);
+      exports_test_async_ping_return(reader);
+      task->writer = writer;
+
+      // Concatenate `task->read_result` and `task->arg`.
+      test_string_t concatenated;
+      concatenated.len = task->arg.len + task->read_result.len;
+      concatenated.ptr = malloc(concatenated.len);
+      assert(concatenated.ptr != NULL);
+      memcpy(concatenated.ptr, task->read_result.ptr, task->read_result.len);
+      memcpy(concatenated.ptr + task->read_result.len, task->arg.ptr, task->arg.len);
+      test_string_free(&task->arg);
+      test_string_free(&task->read_result);
+      task->arg = concatenated;
+
+      // Send `task->arg`, now a concatenated string, along the future created
+      // prior.
+      test_waitable_status_t status = exports_test_future_string_write(writer, &task->arg);
+      assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+      // Block and wait on the future write completing.
+      task->state = PING_S2;
+      test_waitable_join(writer, task->set);
+      return TEST_CALLBACK_CODE_WAIT(task->set);
+
+    case PING_S2:
+      // Assert that our future write has completed, and discard the write end
+      // of the future.
+      assert(event->event == TEST_EVENT_FUTURE_WRITE);
+      assert(event->waitable == task->writer);
+      assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+      assert(TEST_WAITABLE_COUNT(event->code) == 1);
+      test_waitable_join(task->writer, 0);
+      exports_test_future_string_close_writable(task->writer);
+      task->writer = 0;
+
+      // Drop our waitable set, it's no longer needed.
+      test_waitable_set_drop(task->set);
+      task->set = 0;
+
+      // Deallocate the string that we were sending.
+      test_string_free(&task->arg);
+
+      // And finally deallocate the task, exiting afterwards.
+      free(task);
+      return TEST_CALLBACK_CODE_EXIT;
+
+    default:
+      assert(0);
+  }
+
+}
+
+struct pong_task {
+  test_string_t read_result;
+  exports_test_future_string_t future;
+  test_waitable_set_t set;
+};
+
+test_callback_code_t exports_test_async_pong(exports_test_future_string_t x) {
+  struct pong_task *task = malloc(sizeof(struct pong_task));
+  assert(task != NULL);
+  task->future = x;
+  task->set = test_waitable_set_new();
+
+  // Start our future read, assert it's blocked, then add this to our waitable
+  // set.
+  test_waitable_status_t status = exports_test_future_string_read(x, &task->read_result);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+  test_waitable_join(task->future, task->set);
+
+  test_context_set(task);
+  return TEST_CALLBACK_CODE_WAIT(task->set);
+}
+
+test_callback_code_t exports_test_async_pong_callback(test_event_t *event) {
+  struct pong_task *task = test_context_get();
+
+  // assert this event is a future read completion
+  assert(event->event == TEST_EVENT_FUTURE_READ);
+  assert(event->waitable == task->future);
+  assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(event->code) == 1);
+
+  // deallocate/destroy our future
+  test_waitable_join(task->future, 0);
+  exports_test_future_string_close_readable(task->future);
+  task->future = 0;
+
+  // deallocate/destroy our waitable set
+  test_waitable_set_drop(task->set);
+  task->set = 0;
+
+  // return our string
+  exports_test_async_pong_return(task->read_result);
+  test_string_free(&task->read_result);
+
+  free(task);
+
+  return TEST_CALLBACK_CODE_EXIT;
+}

--- a/tests/runtime-async/async/simple-call-import/runner.c
+++ b/tests/runtime-async/async/simple-call-import/runner.c
@@ -1,0 +1,9 @@
+//@ args = '--rename a:b/i=test'
+#include <assert.h>
+#include <runner.h>
+
+int main() {
+  runner_subtask_status_t status = test_async_f();
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+}

--- a/tests/runtime-async/async/simple-call-import/runner.rs
+++ b/tests/runtime-async/async/simple-call-import/runner.rs
@@ -1,0 +1,7 @@
+include!(env!("BINDINGS"));
+
+fn main() {
+    wit_bindgen::block_on(async {
+        crate::a::b::i::f().await;
+    });
+}

--- a/tests/runtime-async/async/simple-call-import/test.c
+++ b/tests/runtime-async/async/simple-call-import/test.c
@@ -1,0 +1,13 @@
+//@ args = '--rename a:b/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+test_subtask_status_t exports_test_async_f() {
+  exports_test_async_f_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_f_callback(test_event_t *event) {
+  assert(0);
+}

--- a/tests/runtime-async/async/simple-call-import/test.rs
+++ b/tests/runtime-async/async/simple-call-import/test.rs
@@ -1,0 +1,9 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::a::b::i::Guest for Component {
+    async fn f() {}
+}

--- a/tests/runtime-async/async/simple-call-import/test.wit
+++ b/tests/runtime-async/async/simple-call-import/test.wit
@@ -1,0 +1,13 @@
+package a:b;
+
+interface i {
+  f: async func();
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/simple-future/runner.c
+++ b/tests/runtime-async/async/simple-future/runner.c
@@ -1,0 +1,69 @@
+//@ args = '--rename my:test/i=test'
+
+#include <runner.h>
+#include <assert.h>
+
+/* include!(env!("BINDINGS")); */
+
+/* use crate::my::test::i::*; */
+
+/* fn main() { */
+/*     wit_bindgen::block_on(async { */
+/*         let (tx, rx) = wit_future::new(); */
+/*         let (res, ()) = futures::join!(tx.write(()), read_future(rx)); */
+/*         assert!(res.is_ok()); */
+
+/*         let (tx, rx) = wit_future::new(); */
+/*         let (res, ()) = futures::join!(tx.write(()), close_future(rx)); */
+/*         assert!(res.is_err()); */
+/*     }); */
+/* } */
+
+
+int main() {
+  {
+    test_future_void_writer_t writer;
+    test_future_void_t reader = test_future_void_new(&writer);
+
+    runner_waitable_status_t status = test_future_void_write(writer);
+    assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+    runner_subtask_status_t subtask = test_async_read_future(&reader);
+    assert(RUNNER_SUBTASK_STATE(subtask) == RUNNER_SUBTASK_RETURNED);
+
+    runner_waitable_set_t set = runner_waitable_set_new();
+    runner_waitable_join(writer, set);
+    runner_event_t event;
+    runner_waitable_set_wait(set, &event);
+    assert(event.event == RUNNER_EVENT_FUTURE_WRITE);
+    assert(event.waitable == writer);
+    assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_COMPLETED);
+    assert(RUNNER_WAITABLE_COUNT(event.code) == 1);
+
+    test_future_void_close_writable(writer);
+    runner_waitable_set_drop(set);
+  }
+
+  {
+    test_future_void_writer_t writer;
+    test_future_void_t reader = test_future_void_new(&writer);
+
+    runner_waitable_status_t status = test_future_void_write(writer);
+    assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+    runner_subtask_status_t subtask = test_async_close_future(&reader);
+    assert(RUNNER_SUBTASK_STATE(subtask) == RUNNER_SUBTASK_RETURNED);
+
+    runner_waitable_set_t set = runner_waitable_set_new();
+    runner_waitable_join(writer, set);
+    runner_event_t event;
+    runner_waitable_set_wait(set, &event);
+    assert(event.event == RUNNER_EVENT_FUTURE_WRITE);
+    assert(event.waitable == writer);
+    assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(event.code) == 0);
+
+    test_future_void_close_writable(writer);
+    runner_waitable_set_drop(set);
+  }
+}

--- a/tests/runtime-async/async/simple-future/runner.rs
+++ b/tests/runtime-async/async/simple-future/runner.rs
@@ -1,0 +1,15 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::*;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new();
+        let (res, ()) = futures::join!(tx.write(()), read_future(rx));
+        assert!(res.is_ok());
+
+        let (tx, rx) = wit_future::new();
+        let (res, ()) = futures::join!(tx.write(()), close_future(rx));
+        assert!(res.is_err());
+    });
+}

--- a/tests/runtime-async/async/simple-future/test.c
+++ b/tests/runtime-async/async/simple-future/test.c
@@ -1,0 +1,27 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+test_subtask_status_t exports_test_async_read_future(exports_test_future_void_t future) {
+  test_waitable_status_t status = exports_test_future_void_read(future);
+  assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(status) == 1);
+  exports_test_future_void_close_readable(future);
+  exports_test_async_read_future_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_read_future_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_subtask_status_t exports_test_async_close_future(exports_test_future_void_t future) {
+  exports_test_future_void_close_readable(future);
+  exports_test_async_close_future_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_close_future_callback(test_event_t *event) {
+  assert(0);
+}

--- a/tests/runtime-async/async/simple-future/test.rs
+++ b/tests/runtime-async/async/simple-future/test.rs
@@ -1,0 +1,17 @@
+use wit_bindgen::FutureReader;
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn read_future(x: FutureReader<()>) {
+        x.await.unwrap();
+    }
+
+    async fn close_future(x: FutureReader<()>) {
+        drop(x);
+    }
+}

--- a/tests/runtime-async/async/simple-future/test.wit
+++ b/tests/runtime-async/async/simple-future/test.wit
@@ -1,0 +1,14 @@
+package my:test;
+
+interface i {
+  read-future: async func(x: future);
+  close-future: async func(x: future);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/simple-import-params-results/runner.c
+++ b/tests/runtime-async/async/simple-import-params-results/runner.c
@@ -1,0 +1,40 @@
+//@ args = '--rename a:b/i=test'
+
+#include <assert.h>
+#include <runner.h>
+
+int main() {
+  uint32_t argument = 1;
+  runner_subtask_status_t status = test_async_one_argument(&argument);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+
+  uint32_t result = 0xffffffff;
+  status = test_async_one_result(&result);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+  assert(result == 2);
+
+  argument = 3;
+  result = 0xffffffff;
+  status = test_async_one_argument_and_result(&argument, &result);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+  assert(result == 4);
+
+  test_async_two_arguments_args_t arguments;
+  arguments.x = 5;
+  arguments.y = 6;
+  status = test_async_two_arguments(&arguments);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+
+  test_async_two_arguments_and_result_args_t arguments2;
+  arguments2.x = 7;
+  arguments2.y = 8;
+  result = 0xffffffff;
+  status = test_async_two_arguments_and_result(&arguments2, &result);
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
+  assert(RUNNER_SUBTASK_HANDLE(status) == 0);
+  assert(result == 9);
+}

--- a/tests/runtime-async/async/simple-import-params-results/runner.rs
+++ b/tests/runtime-async/async/simple-import-params-results/runner.rs
@@ -1,0 +1,13 @@
+include!(env!("BINDINGS"));
+
+use crate::a::b::i::*;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        one_argument(1).await;
+        assert_eq!(one_result().await, 2);
+        assert_eq!(one_argument_and_result(3).await, 4);
+        two_arguments(5, 6).await;
+        assert_eq!(two_arguments_and_result(7, 8).await, 9);
+    });
+}

--- a/tests/runtime-async/async/simple-import-params-results/test.c
+++ b/tests/runtime-async/async/simple-import-params-results/test.c
@@ -1,0 +1,55 @@
+//@ args = '--rename a:b/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+test_subtask_status_t exports_test_async_one_argument(uint32_t x) {
+  assert(x == 1);
+  exports_test_async_one_argument_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_one_argument_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_subtask_status_t exports_test_async_one_result() {
+  exports_test_async_one_result_return(2);
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_one_result_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_subtask_status_t exports_test_async_one_argument_and_result(uint32_t x) {
+  assert(x == 3);
+  exports_test_async_one_argument_and_result_return(4);
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_one_argument_and_result_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_subtask_status_t exports_test_async_two_arguments(uint32_t x, uint32_t y) {
+  assert(x == 5);
+  assert(y == 6);
+  exports_test_async_two_arguments_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_two_arguments_callback(test_event_t *event) {
+  assert(0);
+}
+
+test_subtask_status_t exports_test_async_two_arguments_and_result(uint32_t x, uint32_t y) {
+  assert(x == 7);
+  assert(y == 8);
+  exports_test_async_two_arguments_and_result_return(9);
+  return TEST_CALLBACK_CODE_EXIT;
+}
+
+test_subtask_status_t exports_test_async_two_arguments_and_result_callback(test_event_t *event) {
+  assert(0);
+}

--- a/tests/runtime-async/async/simple-import-params-results/test.rs
+++ b/tests/runtime-async/async/simple-import-params-results/test.rs
@@ -1,0 +1,27 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::a::b::i::Guest for Component {
+    async fn one_argument(x: u32) {
+        assert_eq!(x, 1);
+    }
+    async fn one_result() -> u32 {
+        2
+    }
+    async fn one_argument_and_result(x: u32) -> u32 {
+        assert_eq!(x, 3);
+        4
+    }
+    async fn two_arguments(x: u32, y: u32) {
+        assert_eq!(x, 5);
+        assert_eq!(y, 6);
+    }
+    async fn two_arguments_and_result(x: u32, y: u32) -> u32 {
+        assert_eq!(x, 7);
+        assert_eq!(y, 8);
+        9
+    }
+}

--- a/tests/runtime-async/async/simple-import-params-results/test.wit
+++ b/tests/runtime-async/async/simple-import-params-results/test.wit
@@ -1,0 +1,17 @@
+package a:b;
+
+interface i {
+  one-argument: async func(x: u32);
+  one-result: async func() -> u32;
+  one-argument-and-result: async func(x: u32) -> u32;
+  two-arguments: async func(x: u32, y: u32);
+  two-arguments-and-result: async func(x: u32, y: u32) -> u32;
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/simple-pending-import/runner.c
+++ b/tests/runtime-async/async/simple-pending-import/runner.c
@@ -1,0 +1,29 @@
+//@ args = '--rename a:b/i=test'
+#include <assert.h>
+#include <runner.h>
+
+int main() {
+  runner_subtask_status_t status = test_async_f();
+  assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t handle = RUNNER_SUBTASK_HANDLE(status);
+  assert(handle != 0);
+
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_waitable_join(handle, set);
+
+  runner_event_t event;
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == handle);
+  assert(event.code == RUNNER_SUBTASK_RETURNED);
+
+  runner_waitable_join(handle, 0);
+  runner_subtask_drop(handle);
+
+  runner_waitable_set_poll(set, &event);
+  assert(event.event == RUNNER_EVENT_NONE);
+  assert(event.waitable == 0);
+  assert(event.code == 0);
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/simple-pending-import/runner.rs
+++ b/tests/runtime-async/async/simple-pending-import/runner.rs
@@ -1,0 +1,7 @@
+include!(env!("BINDINGS"));
+
+fn main() {
+    wit_bindgen::block_on(async {
+        crate::a::b::i::f().await;
+    });
+}

--- a/tests/runtime-async/async/simple-pending-import/test.c
+++ b/tests/runtime-async/async/simple-pending-import/test.c
@@ -1,0 +1,16 @@
+//@ args = '--rename a:b/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+test_subtask_status_t exports_test_async_f() {
+  return TEST_CALLBACK_CODE_YIELD;
+}
+
+test_subtask_status_t exports_test_async_f_callback(test_event_t *event) {
+  assert(event->event == TEST_EVENT_NONE);
+  assert(event->waitable == 0);
+  assert(event->code == 0);
+  exports_test_async_f_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}

--- a/tests/runtime-async/async/simple-pending-import/test.rs
+++ b/tests/runtime-async/async/simple-pending-import/test.rs
@@ -1,0 +1,40 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::a::b::i::Guest for Component {
+    async fn f() {
+        for _ in 0..10 {
+            yield_().await;
+        }
+    }
+}
+
+async fn yield_() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    #[derive(Default)]
+    struct Yield {
+        yielded: bool,
+    }
+
+    impl Future for Yield {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<()> {
+            if self.yielded {
+                Poll::Ready(())
+            } else {
+                self.yielded = true;
+                context.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    Yield::default().await;
+}

--- a/tests/runtime-async/async/simple-pending-import/test.wit
+++ b/tests/runtime-async/async/simple-pending-import/test.wit
@@ -1,0 +1,13 @@
+package a:b;
+
+interface i {
+  f: async func();
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/simple-stream-payload/runner.c
+++ b/tests/runtime-async/async/simple-stream-payload/runner.c
@@ -1,0 +1,68 @@
+//@ args = '--rename my:test/i=test'
+
+#include <runner.h>
+#include <assert.h>
+
+int main() {
+  test_stream_u8_writer_t writer;
+  test_stream_u8_t reader = test_stream_u8_new(&writer);
+  uint8_t buf[2];
+
+  // write 1 item
+  buf[0] = 0;
+  runner_waitable_status_t status = test_stream_u8_write(writer, buf, 1);
+  assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+  // Start the subtask
+  runner_subtask_status_t subtask_status = test_async_read_stream(&reader);
+  assert(RUNNER_SUBTASK_STATE(subtask_status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t subtask = RUNNER_SUBTASK_HANDLE(subtask_status);
+
+  // wait for the write to complete
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_waitable_join(writer, set);
+  runner_event_t event;
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_STREAM_WRITE);
+  assert(event.waitable == writer);
+  assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(event.code) == 1);
+
+  // write 2 items
+  buf[0] = 1;
+  buf[1] = 2;
+  status = test_stream_u8_write(writer, buf, 2);
+  assert(RUNNER_WAITABLE_STATE(status) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status) == 2);
+
+  // write 1/2 items
+  buf[0] = 3;
+  buf[1] = 4;
+  status = test_stream_u8_write(writer, buf, 2);
+  assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_STREAM_WRITE);
+  assert(event.waitable == writer);
+  assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(event.code) == 1);
+
+  // write the second item
+  status = test_stream_u8_write(writer, buf + 1, 1);
+  assert(RUNNER_WAITABLE_STATE(status) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status) == 1);
+
+  // clean up the writer
+  runner_waitable_join(writer, 0);
+  test_stream_u8_close_writable(writer);
+
+  // wait for the subtask to complete
+  runner_waitable_join(subtask, set);
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == subtask);
+  assert(RUNNER_SUBTASK_STATE(event.code) == RUNNER_SUBTASK_RETURNED);
+  runner_waitable_join(subtask, 0);
+  runner_subtask_drop(subtask);
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/simple-stream-payload/runner.rs
+++ b/tests/runtime-async/async/simple-stream-payload/runner.rs
@@ -1,0 +1,37 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::*;
+use wit_bindgen::StreamResult;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        let (mut tx, rx) = wit_stream::new();
+        let test = async {
+            // write one item
+            let (result, ret) = tx.write(vec![0]).await;
+            assert_eq!(result, StreamResult::Complete(1));
+            assert_eq!(ret.remaining(), 0);
+
+            // write two items
+            let (result, ret) = tx.write(vec![1, 2]).await;
+            assert_eq!(result, StreamResult::Complete(2));
+            assert_eq!(ret.remaining(), 0);
+
+            // write 1/2 items again
+            let (result, ret) = tx.write(vec![3, 4]).await;
+            assert_eq!(result, StreamResult::Complete(1));
+            assert_eq!(ret.remaining(), 1);
+
+            // resume the write
+            let (result, ret) = tx.write_buf(ret).await;
+            assert_eq!(result, StreamResult::Complete(1));
+            assert_eq!(ret.remaining(), 0);
+
+            // write to a closed stream
+            let (result, ret) = tx.write(vec![0]).await;
+            assert_eq!(result, StreamResult::Closed);
+            assert_eq!(ret.remaining(), 1);
+        };
+        let ((), ()) = futures::join!(test, read_stream(rx));
+    });
+}

--- a/tests/runtime-async/async/simple-stream-payload/test.c
+++ b/tests/runtime-async/async/simple-stream-payload/test.c
@@ -1,0 +1,70 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+static test_waitable_set_t SET = 0;
+static exports_test_stream_u8_t STREAM = 0;
+static uint8_t BUF[2];
+static uint8_t STATE = 0;
+
+test_subtask_status_t exports_test_async_read_stream(exports_test_stream_u8_t stream) {
+  test_waitable_status_t status = exports_test_stream_u8_read(stream, BUF, 1);
+  assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(status) == 1);
+  assert(BUF[0] == 0);
+
+  status = exports_test_stream_u8_read(stream, BUF, 2);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+  SET = test_waitable_set_new();
+  STREAM = stream;
+  test_waitable_join(STREAM, SET);
+
+  return TEST_CALLBACK_CODE_WAIT(SET);
+}
+
+test_subtask_status_t exports_test_async_read_stream_callback(test_event_t *event) {
+  switch (STATE++) {
+    case 0:
+      assert(event->event == TEST_EVENT_STREAM_READ);
+      assert(event->waitable == STREAM);
+      assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+      assert(TEST_WAITABLE_COUNT(event->code) == 2);
+
+      assert(BUF[0] == 1);
+      assert(BUF[1] == 2);
+
+      // read 1/2 items
+      test_waitable_status_t status = exports_test_stream_u8_read(STREAM, BUF, 1);
+      assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_COMPLETED);
+      assert(TEST_WAITABLE_COUNT(status) == 1);
+      assert(BUF[0] == 3);
+
+      // start the read of item 2/2
+      status = exports_test_stream_u8_read(STREAM, BUF + 1, 1);
+      assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+      return TEST_CALLBACK_CODE_WAIT(SET);
+
+    case 1:
+      // complete the read of item 2/2
+      assert(event->event == TEST_EVENT_STREAM_READ);
+      assert(event->waitable == STREAM);
+      assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+      assert(TEST_WAITABLE_COUNT(event->code) == 1);
+      assert(BUF[1] == 4);
+
+      // clean up resources
+      test_waitable_join(STREAM, 0);
+      exports_test_stream_u8_close_readable(STREAM);
+
+      test_waitable_set_drop(SET);
+
+      exports_test_async_read_stream_return();
+      return TEST_CALLBACK_CODE_EXIT;
+
+    default:
+      assert(0);
+  }
+}

--- a/tests/runtime-async/async/simple-stream-payload/test.rs
+++ b/tests/runtime-async/async/simple-stream-payload/test.rs
@@ -1,0 +1,34 @@
+use wit_bindgen::{StreamReader, StreamResult};
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn read_stream(mut x: StreamReader<u8>) {
+        // read one item
+        let (result, buf) = x.read(Vec::with_capacity(1)).await;
+        assert_eq!(result, StreamResult::Complete(1));
+        assert_eq!(buf, [0]);
+
+        // read two items
+        let (result, buf) = x.read(Vec::with_capacity(2)).await;
+        assert_eq!(result, StreamResult::Complete(2));
+        assert_eq!(buf, [1, 2]);
+
+        // read 1/2 items
+        let (result, buf) = x.read(Vec::with_capacity(1)).await;
+        assert_eq!(result, StreamResult::Complete(1));
+        assert_eq!(buf, [3]);
+
+        // read the next buffered item
+        let (result, buf) = x.read(Vec::with_capacity(1)).await;
+        assert_eq!(result, StreamResult::Complete(1));
+        assert_eq!(buf, [4]);
+
+        // close
+        drop(x);
+    }
+}

--- a/tests/runtime-async/async/simple-stream-payload/test.wit
+++ b/tests/runtime-async/async/simple-stream-payload/test.wit
@@ -1,0 +1,13 @@
+package my:test;
+
+interface i {
+  read-stream: async func(x: stream<u8>);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}

--- a/tests/runtime-async/async/simple-stream/runner.c
+++ b/tests/runtime-async/async/simple-stream/runner.c
@@ -1,0 +1,57 @@
+//@ args = '--rename my:test/i=test'
+
+#include <runner.h>
+#include <assert.h>
+
+int main() {
+  test_stream_void_writer_t writer;
+  test_stream_void_t reader = test_stream_void_new(&writer);
+
+  // write 1 item
+  runner_waitable_status_t status = test_stream_void_write(writer, 1);
+  assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+
+  // Start the subtask
+  runner_subtask_status_t subtask_status = test_async_read_stream(&reader);
+  assert(RUNNER_SUBTASK_STATE(subtask_status) == RUNNER_SUBTASK_STARTED);
+  runner_subtask_t subtask = RUNNER_SUBTASK_HANDLE(subtask_status);
+
+  // wait for the write to complete
+  runner_waitable_set_t set = runner_waitable_set_new();
+  runner_waitable_join(writer, set);
+  runner_event_t event;
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_STREAM_WRITE);
+  assert(event.waitable == writer);
+  assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(event.code) == 1);
+
+  // write 2 items
+  status = test_stream_void_write(writer, 2);
+  assert(RUNNER_WAITABLE_STATE(status) == RUNNER_WAITABLE_COMPLETED);
+  assert(RUNNER_WAITABLE_COUNT(status) == 2);
+
+  // write, but see it closed
+  status = test_stream_void_write(writer, 2);
+  assert(status == RUNNER_WAITABLE_STATUS_BLOCKED);
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_STREAM_WRITE);
+  assert(event.waitable == writer);
+  assert(RUNNER_WAITABLE_STATE(event.code) == RUNNER_WAITABLE_CLOSED);
+  assert(RUNNER_WAITABLE_COUNT(event.code) == 0);
+
+  // clean up the writer
+  runner_waitable_join(writer, 0);
+  test_stream_void_close_writable(writer);
+
+  // wait for the subtask to complete
+  runner_waitable_join(subtask, set);
+  runner_waitable_set_wait(set, &event);
+  assert(event.event == RUNNER_EVENT_SUBTASK);
+  assert(event.waitable == subtask);
+  assert(RUNNER_SUBTASK_STATE(event.code) == RUNNER_SUBTASK_RETURNED);
+  runner_waitable_join(subtask, 0);
+  runner_subtask_drop(subtask);
+
+  runner_waitable_set_drop(set);
+}

--- a/tests/runtime-async/async/simple-stream/runner.rs
+++ b/tests/runtime-async/async/simple-stream/runner.rs
@@ -1,0 +1,27 @@
+include!(env!("BINDINGS"));
+
+use crate::my::test::i::*;
+use wit_bindgen::StreamResult;
+
+fn main() {
+    wit_bindgen::block_on(async {
+        let (mut tx, rx) = wit_stream::new();
+        let test = async {
+            // write one item
+            let (result, ret) = tx.write(vec![()]).await;
+            assert_eq!(result, StreamResult::Complete(1));
+            assert_eq!(ret.remaining(), 0);
+
+            // write two items
+            let (result, ret) = tx.write(vec![(), ()]).await;
+            assert_eq!(result, StreamResult::Complete(2));
+            assert_eq!(ret.remaining(), 0);
+
+            // write two items again
+            let (result, ret) = tx.write(vec![(), ()]).await;
+            assert_eq!(result, StreamResult::Closed);
+            assert_eq!(ret.remaining(), 2);
+        };
+        let ((), ()) = futures::join!(test, read_stream(rx));
+    });
+}

--- a/tests/runtime-async/async/simple-stream/test.c
+++ b/tests/runtime-async/async/simple-stream/test.c
@@ -1,0 +1,37 @@
+//@ args = '--rename my:test/i=test'
+
+#include <assert.h>
+#include <test.h>
+
+test_waitable_set_t SET = 0;
+exports_test_stream_void_t STREAM = 0;
+
+test_subtask_status_t exports_test_async_read_stream(exports_test_stream_void_t stream) {
+  test_waitable_status_t status = exports_test_stream_void_read(stream, 1);
+  assert(TEST_WAITABLE_STATE(status) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(status) == 1);
+
+  status = exports_test_stream_void_read(stream, 2);
+  assert(status == TEST_WAITABLE_STATUS_BLOCKED);
+
+  SET = test_waitable_set_new();
+  STREAM = stream;
+  test_waitable_join(STREAM, SET);
+
+  return TEST_CALLBACK_CODE_WAIT(SET);
+}
+
+test_subtask_status_t exports_test_async_read_stream_callback(test_event_t *event) {
+  assert(event->event == TEST_EVENT_STREAM_READ);
+  assert(event->waitable == STREAM);
+  assert(TEST_WAITABLE_STATE(event->code) == TEST_WAITABLE_COMPLETED);
+  assert(TEST_WAITABLE_COUNT(event->code) == 2);
+
+  test_waitable_join(STREAM, 0);
+  exports_test_stream_void_close_readable(STREAM);
+
+  test_waitable_set_drop(SET);
+
+  exports_test_async_read_stream_return();
+  return TEST_CALLBACK_CODE_EXIT;
+}

--- a/tests/runtime-async/async/simple-stream/test.rs
+++ b/tests/runtime-async/async/simple-stream/test.rs
@@ -1,0 +1,24 @@
+use wit_bindgen::{StreamReader, StreamResult};
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::my::test::i::Guest for Component {
+    async fn read_stream(mut x: StreamReader<()>) {
+        // read one item
+        let (result, buf) = x.read(Vec::with_capacity(1)).await;
+        assert_eq!(result, StreamResult::Complete(1));
+        assert_eq!(buf.len(), 1);
+
+        // read two items
+        let (result, buf) = x.read(Vec::with_capacity(2)).await;
+        assert_eq!(result, StreamResult::Complete(2));
+        assert_eq!(buf.len(), 2);
+
+        // close
+        drop(x);
+    }
+}

--- a/tests/runtime-async/async/simple-stream/test.wit
+++ b/tests/runtime-async/async/simple-stream/test.wit
@@ -1,0 +1,13 @@
+package my:test;
+
+interface i {
+  read-stream: async func(x: stream);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}


### PR DESCRIPTION
This PR is a staging ground for now for developing support for component model async APIs in the C bindings generator. I'm opening this up with intermediate progress in case folks are interested but otherwise I plan on continuing to work on this before merging to ensure some more features are supported. What I hope to accomplish here is:

* [x] Calling async imports
* [x] Defining async exports
* [x] Bindings to `waitable-set`
* [x] Bindings to `subtask.*`
* [x] cancellation
* [x] futures
* [x] streams
* [x] cancelling reads/writes
* [x] tests via `wit-bindgen test`
* [x] all codegen tests enabled

