### PR TITLE
Support "linear writes" in Rust `future` bindings

### DIFF
--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -452,8 +452,11 @@ pub mod wit_future {{
             self.src.push_str(&format!(
                 "\
     /// Creates a new Component Model `future` with the specified payload type.
-    pub fn new<T: FuturePayload>() -> ({async_support}::FutureWriter<T>, {async_support}::FutureReader<T>) {{
-        unsafe {{ {async_support}::future_new::<T>(T::VTABLE) }}
+    ///
+    /// The `default` function provided computes the default value to be sent in
+    /// this future if no other value was otherwise sent.
+    pub fn new<T: FuturePayload>(default: fn() -> T) -> ({async_support}::FutureWriter<T>, {async_support}::FutureReader<T>) {{
+        unsafe {{ {async_support}::future_new::<T>(default, T::VTABLE) }}
     }}
 }}
                 ",

--- a/tests/runtime-async/async/cancel-import/runner.rs
+++ b/tests/runtime-async/async/cancel-import/runner.rs
@@ -9,7 +9,7 @@ use wit_bindgen::yield_async;
 fn main() {
     println!("test cancelling an import in progress");
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let mut import = Box::pin(pending_import(rx));
         assert!(import
             .as_mut()
@@ -21,7 +21,7 @@ fn main() {
 
     println!("test cancelling an import before it starts");
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let import = Box::pin(pending_import(rx));
         drop(import);
         tx.write(()).await.unwrap_err();
@@ -29,8 +29,8 @@ fn main() {
 
     println!("test cancelling an import in the started state");
     wit_bindgen::block_on(async {
-        let (tx1, rx1) = wit_future::new();
-        let (tx2, rx2) = wit_future::new();
+        let (tx1, rx1) = wit_future::new(|| unreachable!());
+        let (tx2, rx2) = wit_future::new(|| unreachable!());
 
         // create a task in the "started" state, but don't complete it yet
         let mut started_import = Box::pin(pending_import(rx1));
@@ -66,7 +66,7 @@ fn main() {
     println!("test cancellation with a status code saying it's done");
     wit_bindgen::block_on(async {
         // Start a subtask and get it into the "started" state
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let mut import = Box::pin(pending_import(rx));
         assert!(import
             .as_mut()
@@ -92,7 +92,7 @@ fn main() {
     println!("race cancellation with pending status code");
     wit_bindgen::block_on(async {
         // Start a subtask and get it into the "started" state
-        let (tx1, rx1) = wit_future::new();
+        let (tx1, rx1) = wit_future::new(|| unreachable!());
         let mut started_import = Box::pin(pending_import(rx1));
         assert!(started_import
             .as_mut()
@@ -102,7 +102,7 @@ fn main() {
         // force the next subtask to start out in the "starting" state, not the
         // "started" state.
         backpressure_set(true);
-        let (tx2, rx2) = wit_future::new();
+        let (tx2, rx2) = wit_future::new(|| unreachable!());
         let mut starting_import = Box::pin(pending_import(rx2));
         assert!(starting_import
             .as_mut()

--- a/tests/runtime-async/async/cancel-import/test.rs
+++ b/tests/runtime-async/async/cancel-import/test.rs
@@ -8,7 +8,7 @@ export!(Component);
 
 impl crate::exports::my::test::i::Guest for Component {
     async fn pending_import(x: FutureReader<()>) {
-        x.await.unwrap();
+        x.await
     }
 
     fn backpressure_set(x: bool) {

--- a/tests/runtime-async/async/future-cancel-read/runner.c
+++ b/tests/runtime-async/async/future-cancel-read/runner.c
@@ -3,10 +3,6 @@
 #include <assert.h>
 #include <runner.h>
 
-/* extern runner_subtask_status_t test_async_cancel_before_read(test_future_u32_t *arg); */
-/* extern runner_subtask_status_t test_async_cancel_after_read(test_future_u32_t *arg); */
-/* extern runner_subtask_status_t test_async_start_read_then_cancel(void); */
-
 int main() {
   {
     test_future_u32_writer_t writer;
@@ -27,7 +23,37 @@ int main() {
   }
 
   {
-    runner_subtask_status_t status = test_async_start_read_then_cancel();
-    assert(status == RUNNER_SUBTASK_RETURNED);
+    test_future_u32_writer_t data_writer;
+    test_future_u32_t data_reader = test_future_u32_new(&data_writer);
+    test_future_void_writer_t signal_writer;
+    test_future_void_t signal_reader = test_future_void_new(&signal_writer);
+    test_async_start_read_then_cancel_args_t args;
+    args.data = data_reader;
+    args.signal = signal_reader;
+    runner_subtask_status_t status = test_async_start_read_then_cancel(&args);
+    assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
+    runner_subtask_t task = RUNNER_SUBTASK_HANDLE(status);
+
+    uint32_t to_write = 4;
+    runner_waitable_status_t wstatus = test_future_u32_write(data_writer, &to_write);
+    assert(RUNNER_WAITABLE_STATE(wstatus) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(wstatus) == 1);
+
+    wstatus = test_future_void_write(signal_writer);
+    assert(RUNNER_WAITABLE_STATE(wstatus) == RUNNER_WAITABLE_CLOSED);
+    assert(RUNNER_WAITABLE_COUNT(wstatus) == 1);
+
+    runner_waitable_set_t set = runner_waitable_set_new();
+    runner_waitable_join(task, set);
+
+    runner_event_t event;
+    runner_waitable_set_wait(set, &event);
+    assert(event.event == RUNNER_EVENT_SUBTASK);
+    assert(event.waitable == task);
+    assert(event.code == RUNNER_SUBTASK_RETURNED);
+
+    runner_waitable_join(task, 0);
+    runner_subtask_drop(task);
+    runner_waitable_set_drop(set);
   }
 }

--- a/tests/runtime-async/async/future-cancel-read/runner.rs
+++ b/tests/runtime-async/async/future-cancel-read/runner.rs
@@ -4,14 +4,19 @@ use crate::my::test::i::*;
 
 fn main() {
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| 0);
         cancel_before_read(rx).await;
         drop(tx);
 
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| 0);
         cancel_after_read(rx).await;
         drop(tx);
 
-        start_read_then_cancel().await;
+        let (data_tx, data_rx) = wit_future::new(|| unreachable!());
+        let (signal_tx, signal_rx) = wit_future::new(|| unreachable!());
+        let ((), ()) = futures::join!(start_read_then_cancel(data_rx, signal_rx), async {
+            signal_tx.write(()).await.unwrap();
+            data_tx.write(4).await.unwrap();
+        });
     });
 }

--- a/tests/runtime-async/async/future-cancel-read/test.rs
+++ b/tests/runtime-async/async/future-cancel-read/test.rs
@@ -27,14 +27,14 @@ impl crate::exports::my::test::i::Guest for Component {
         drop(reader);
     }
 
-    async fn start_read_then_cancel() {
-        let (tx, rx) = wit_future::new::<u32>();
-        let mut read = Box::pin(rx.into_future());
+    async fn start_read_then_cancel(data: FutureReader<u32>, signal: FutureReader<()>) {
+        let mut read = Box::pin(data.into_future());
         assert!(read
             .as_mut()
             .poll(&mut Context::from_waker(noop_waker_ref()))
             .is_pending());
-        drop(tx);
-        assert!(read.as_mut().cancel().unwrap().is_none());
+
+        signal.await;
+        assert_eq!(read.as_mut().cancel().unwrap(), 4);
     }
 }

--- a/tests/runtime-async/async/future-cancel-read/test.wit
+++ b/tests/runtime-async/async/future-cancel-read/test.wit
@@ -3,7 +3,10 @@ package my:test;
 interface i {
   cancel-before-read: async func(x: future<u32>);
   cancel-after-read: async func(x: future<u32>);
-  start-read-then-cancel: async func();
+  start-read-then-cancel: async func(
+    data: future<u32>,
+    signal: future,
+  );
 }
 
 world test {

--- a/tests/runtime-async/async/future-cancel-write-then-read/runner.rs
+++ b/tests/runtime-async/async/future-cancel-write-then-read/runner.rs
@@ -1,13 +1,13 @@
-//@ args = '--async=-all'
-
 include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::f;
 
 fn main() {
-    let (tx, rx) = wit_future::new();
+    wit_bindgen::block_on(async move {
+        let (tx, rx) = wit_future::new(|| 0);
 
-    drop(tx.write(()));
+        drop(tx.write(4));
 
-    f(rx);
+        f(rx).await;
+    });
 }

--- a/tests/runtime-async/async/future-cancel-write-then-read/test.rs
+++ b/tests/runtime-async/async/future-cancel-write-then-read/test.rs
@@ -9,7 +9,7 @@ use crate::exports::a::b::the_test::Guest;
 use wit_bindgen::rt::async_support::FutureReader;
 
 impl Guest for Component {
-    async fn f(future: FutureReader<()>) {
-        assert!(future.await.is_none());
+    async fn f(future: FutureReader<u8>) {
+        assert_eq!(future.await, 0);
     }
 }

--- a/tests/runtime-async/async/future-cancel-write-then-read/test.wit
+++ b/tests/runtime-async/async/future-cancel-write-then-read/test.wit
@@ -1,7 +1,7 @@
 package a:b;
 
 interface the-test {
-  f: async func(param: future);
+  f: async func(param: future<u8>);
 }
 
 world test {

--- a/tests/runtime-async/async/future-cancel-write/test.rs
+++ b/tests/runtime-async/async/future-cancel-write/test.rs
@@ -11,6 +11,6 @@ impl crate::exports::my::test::i::Guest for Component {
         drop(x)
     }
     async fn read_and_drop(x: FutureReader<String>) {
-        x.await.unwrap();
+        let _ = x.await;
     }
 }

--- a/tests/runtime-async/async/future-close-after-coming-back/runner.rs
+++ b/tests/runtime-async/async/future-close-after-coming-back/runner.rs
@@ -3,7 +3,7 @@ include!(env!("BINDINGS"));
 use crate::a::b::the_test::f;
 
 fn main() {
-    let (tx, rx) = wit_future::new();
+    let (tx, rx) = wit_future::new(|| unreachable!());
 
     let rx = f(rx);
     drop(tx);

--- a/tests/runtime-async/async/future-close-then-receive-read/runner.rs
+++ b/tests/runtime-async/async/future-close-then-receive-read/runner.rs
@@ -3,12 +3,12 @@ include!(env!("BINDINGS"));
 use crate::a::b::the_test::{get, set};
 
 fn main() {
-    let (tx, rx) = wit_future::new();
+    let (tx, rx) = wit_future::new(|| unreachable!());
 
     set(rx);
     let rx = get();
     drop(tx);
     drop(rx);
 
-    wit_future::new::<()>();
+    wit_future::new::<()>(|| unreachable!());
 }

--- a/tests/runtime-async/async/future-closes-with-error/runner.rs
+++ b/tests/runtime-async/async/future-closes-with-error/runner.rs
@@ -1,12 +1,13 @@
-//@ args = '--async=-all'
 include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::f;
 
 fn main() {
-    let (tx, rx) = wit_future::new();
+    wit_bindgen::block_on(async {
+        let (tx, rx) = wit_future::new(|| ());
 
-    drop(tx);
+        drop(tx);
 
-    f(rx);
+        f(rx).await;
+    });
 }

--- a/tests/runtime-async/async/future-closes-with-error/test.rs
+++ b/tests/runtime-async/async/future-closes-with-error/test.rs
@@ -9,6 +9,6 @@ use wit_bindgen::rt::async_support::FutureReader;
 
 impl Guest for Component {
     async fn f(future: FutureReader<()>) {
-        assert!(future.await.is_none());
+        future.await
     }
 }

--- a/tests/runtime-async/async/future-write-then-read-comes-back/runner.rs
+++ b/tests/runtime-async/async/future-write-then-read-comes-back/runner.rs
@@ -6,10 +6,10 @@ use crate::a::b::the_test::f;
 
 fn main() {
     async_support::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
 
         let a = async { tx.write(()).await };
-        let b = async { f(rx).await.unwrap() };
+        let b = async { f(rx).await };
         let (a_result, ()) = futures::join!(a, b);
         a_result.unwrap()
     });

--- a/tests/runtime-async/async/future-write-then-read-remote/runner.rs
+++ b/tests/runtime-async/async/future-write-then-read-remote/runner.rs
@@ -8,7 +8,7 @@ use crate::a::b::the_test::f;
 
 fn main() {
     async_support::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
 
         let a = async { tx.write(()).await };
         let b = async { f(rx) };

--- a/tests/runtime-async/async/future-write-then-read-remote/runner2.rs
+++ b/tests/runtime-async/async/future-write-then-read-remote/runner2.rs
@@ -8,7 +8,7 @@ use crate::a::b::the_test::f;
 
 fn main() {
     async_support::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
 
         let a = tx.write(());
         let b = async { f(rx) };

--- a/tests/runtime-async/async/future-write-then-read-remote/test.rs
+++ b/tests/runtime-async/async/future-write-then-read-remote/test.rs
@@ -11,7 +11,7 @@ use wit_bindgen::rt::async_support::FutureReader;
 impl Guest for Component {
     async fn f(future: FutureReader<()>) {
         eprintln!("e1");
-        future.await.unwrap();
+        future.await;
         eprintln!("e2");
     }
 }

--- a/tests/runtime-async/async/pending-import/runner.rs
+++ b/tests/runtime-async/async/pending-import/runner.rs
@@ -9,7 +9,7 @@ use wit_bindgen::yield_async;
 fn main() {
     // Test that Rust-level polling twice works.
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let mut import = Box::pin(pending_import(rx));
         assert!(import
             .as_mut()
@@ -28,7 +28,7 @@ fn main() {
     // the completion of the task-at-hand, and then drop it without completing
     // it.
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let mut import = Box::pin(pending_import(rx));
         assert!(import
             .as_mut()

--- a/tests/runtime-async/async/pending-import/test.rs
+++ b/tests/runtime-async/async/pending-import/test.rs
@@ -8,6 +8,6 @@ export!(Component);
 
 impl crate::exports::my::test::i::Guest for Component {
     async fn pending_import(x: FutureReader<()>) {
-        x.await.unwrap();
+        x.await
     }
 }

--- a/tests/runtime-async/async/ping-pong/runner.rs
+++ b/tests/runtime-async/async/ping-pong/runner.rs
@@ -4,14 +4,14 @@ use crate::my::test::i::{ping, pong};
 
 fn main() {
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let f1 = ping(rx, "world".into());
         let f2 = async { tx.write("hello".into()).await.unwrap() };
         let (rx2, ()) = futures::join!(f1, f2);
-        let m2 = rx2.await.unwrap();
+        let m2 = rx2.await;
         assert_eq!(m2, "helloworld");
 
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let f1 = async move {
             let m3 = pong(rx).await;
             assert_eq!(m3, "helloworld");

--- a/tests/runtime-async/async/ping-pong/test.rs
+++ b/tests/runtime-async/async/ping-pong/test.rs
@@ -8,8 +8,8 @@ export!(Component);
 
 impl crate::exports::my::test::i::Guest for Component {
     async fn ping(x: FutureReader<String>, y: String) -> FutureReader<String> {
-        let msg = x.await.unwrap() + y.as_str();
-        let (tx, rx) = wit_future::new();
+        let msg = x.await + y.as_str();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         wit_bindgen::spawn(async move {
             tx.write(msg).await.unwrap();
         });
@@ -17,6 +17,6 @@ impl crate::exports::my::test::i::Guest for Component {
     }
 
     async fn pong(x: FutureReader<String>) -> String {
-        x.await.unwrap()
+        x.await
     }
 }

--- a/tests/runtime-async/async/simple-future/runner.rs
+++ b/tests/runtime-async/async/simple-future/runner.rs
@@ -4,11 +4,11 @@ use crate::my::test::i::*;
 
 fn main() {
     wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let (res, ()) = futures::join!(tx.write(()), read_future(rx));
         assert!(res.is_ok());
 
-        let (tx, rx) = wit_future::new();
+        let (tx, rx) = wit_future::new(|| unreachable!());
         let (res, ()) = futures::join!(tx.write(()), close_future(rx));
         assert!(res.is_err());
     });

--- a/tests/runtime-async/async/simple-future/test.rs
+++ b/tests/runtime-async/async/simple-future/test.rs
@@ -8,7 +8,7 @@ export!(Component);
 
 impl crate::exports::my::test::i::Guest for Component {
     async fn read_future(x: FutureReader<()>) {
-        x.await.unwrap();
+        x.await
     }
 
     async fn close_future(x: FutureReader<()>) {


### PR DESCRIPTION
To account for WebAssembly/wasip3-prototyping#172 and WebAssembly/component-model#521 the Rust bindings need to take into account that a future writer cannot be dropped without actually writing something. To model this futures now must be created with a thunk that creates the default value to be sent. This value is only used if another value was not otherwise written.

Closes #1304