### PR TITLE
Disallow the value 0 in `from_handle` methods in the Rust bindings.

### DIFF
--- a/crates/guest-rust/src/pre_wit_bindgen_0_20_0.rs
+++ b/crates/guest-rust/src/pre_wit_bindgen_0_20_0.rs
@@ -147,7 +147,7 @@ pub unsafe trait RustResource: WasmResource {
 impl<T: WasmResource> Resource<T> {
     #[doc(hidden)]
     pub unsafe fn from_handle(handle: u32) -> Self {
-        debug_assert!(handle != u32::MAX);
+        debug_assert!(handle != 0 && handle != u32::MAX);
         Self {
             handle: AtomicU32::new(handle),
             _marker: marker::PhantomData,

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -664,7 +664,7 @@ pub unsafe trait WasmResource {
 impl<T: WasmResource> Resource<T> {
     #[doc(hidden)]
     pub unsafe fn from_handle(handle: u32) -> Self {
-        debug_assert!(handle != u32::MAX);
+        debug_assert!(handle != 0 && handle != u32::MAX);
         Self {
             handle: AtomicU32::new(handle),
             _marker: marker::PhantomData,


### PR DESCRIPTION
The canonical ABI for its part [guarantees] the value 0 will not be used as a table index. Should users of the Rust bindings be able to construct handle types with the value 0?

If we say yes, then handle types act as if they have an internal `Option` type that gets implicitly unwrapped when passed to an import.

However, in this PR I propose to say no, and prohibit zero in handle types. It seems tidier to say that code depending on optionality should explicitly use `Option` for itself, which will then help avoid traping, by construction. And even if we can't do niche optimizations today due to the `AtomicU32`, it is theoretically possible we could do something with `NonZeroU32` in the future.

[guarantees]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#table-state