### PR TITLE
[C] Generate explicit borrow dropping functions when autodrop borrows is disabled

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1295,7 +1295,8 @@ void {ns}_{snake}_drop_own({own} handle) {{
                 "\ntypedef struct {borrow} {{\nint32_t __handle;\n}} {borrow};\n"
             ));
 
-            if self.autodrop_enabled() {
+            // Explicit borrow dropping is not required if autodrop is enabled.
+            if !self.autodrop_enabled() {
                 // As we have two different types for owned vs borrowed resources,
                 // but owns and borrows are dropped using the same intrinsic we
                 // also generate a version of the drop function for borrows that we

--- a/tests/runtime/c/autodrop-borrows/autodropper.c
+++ b/tests/runtime/c/autodrop-borrows/autodropper.c
@@ -1,0 +1,11 @@
+//@ args = '--autodrop-borrows=yes'
+
+#include "autodropper.h"
+#include <assert.h>
+
+void exports_test_resource_borrow_imported_autodrop_borrow_thing_do_borrow(
+    test_resource_borrow_imported_test_borrow_thing_t thing) {
+    uint32_t result = test_resource_borrow_imported_test_method_thing_get_int(thing);
+    assert(result == 42);
+    // Intentionally do not drop the borrow, as it will be done automatically
+}

--- a/tests/runtime/c/autodrop-borrows/borrower.c
+++ b/tests/runtime/c/autodrop-borrows/borrower.c
@@ -1,0 +1,12 @@
+//@ args = '--autodrop-borrows=no'
+
+#include "borrower.h"
+#include <assert.h>
+
+void exports_test_resource_borrow_imported_borrow_thing_do_borrow(
+    test_resource_borrow_imported_test_borrow_thing_t thing) {
+    uint32_t result = test_resource_borrow_imported_test_method_thing_get_int(thing);
+    assert(result == 42);
+    // We must explicitly drop the borrow, because autodrop borrows is turned off
+    test_resource_borrow_imported_test_thing_drop_borrow(thing);
+}

--- a/tests/runtime/c/autodrop-borrows/compose.wac
+++ b/tests/runtime/c/autodrop-borrows/compose.wac
@@ -1,0 +1,19 @@
+package example:composition;
+
+let exporter = new test:exporter { ... };
+let borrower = new test:borrower {
+  test: exporter.test,
+  ...
+};
+let autodropper = new test:autodropper {
+  test: exporter.test,
+  ...
+};
+let runner = new test:runner { 
+  test: exporter.test,
+  borrow-thing: borrower.borrow-thing,
+  autodrop-borrow-thing: autodropper.autodrop-borrow-thing,
+  ...
+};
+
+export runner...;

--- a/tests/runtime/c/autodrop-borrows/exporter.c
+++ b/tests/runtime/c/autodrop-borrows/exporter.c
@@ -1,0 +1,22 @@
+#include "exporter.h"
+#include <stdlib.h>
+
+struct exports_test_resource_borrow_imported_test_thing_t {
+  uint32_t my_state;
+};
+
+uint32_t exports_test_resource_borrow_imported_test_method_thing_get_int(
+    exports_test_resource_borrow_imported_test_borrow_thing_t thing) {
+  return thing->my_state;
+}
+
+void exports_test_resource_borrow_imported_test_thing_destructor(
+    exports_test_resource_borrow_imported_test_thing_t *rep) {
+  free(rep);
+}
+
+exports_test_resource_borrow_imported_test_own_thing_t exports_test_resource_borrow_imported_test_constructor_thing(void) {
+    exports_test_resource_borrow_imported_test_thing_t *rep = malloc(sizeof(exports_test_resource_borrow_imported_test_thing_t));
+    rep->my_state = 42;
+    return exports_test_resource_borrow_imported_test_thing_new(rep);
+}

--- a/tests/runtime/c/autodrop-borrows/runner.c
+++ b/tests/runtime/c/autodrop-borrows/runner.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include "runner.h"
+
+int main() {
+    test_resource_borrow_imported_test_own_thing_t thing = test_resource_borrow_imported_test_constructor_thing();
+    assert(thing.__handle != 0);
+
+    test_resource_borrow_imported_borrow_thing_do_borrow(
+        test_resource_borrow_imported_test_borrow_thing(thing)
+    );
+
+    test_resource_borrow_imported_autodrop_borrow_thing_do_borrow(
+        test_resource_borrow_imported_test_borrow_thing(thing)
+    );
+
+    test_resource_borrow_imported_test_thing_drop_own(thing);
+}

--- a/tests/runtime/c/autodrop-borrows/test.wit
+++ b/tests/runtime/c/autodrop-borrows/test.wit
@@ -1,0 +1,39 @@
+//@ dependencies = ['exporter', 'borrower', 'autodropper']
+//@ wac = 'compose.wac'
+
+package test:resource-borrow-imported;
+
+interface test {
+  resource thing {
+    constructor();
+    get-int: func() -> u32;
+  }
+}
+
+interface borrow-thing {
+    use test.{thing};
+    do-borrow: func(handle: borrow<thing>);
+}
+
+interface autodrop-borrow-thing {
+    use test.{thing};
+    do-borrow: func(handle: borrow<thing>);
+}
+
+world exporter {
+  export test;
+}
+
+world borrower {
+  export borrow-thing;
+}
+
+world autodropper {
+    export autodrop-borrow-thing;
+}
+
+world runner {
+  import test;
+  import autodrop-borrow-thing;
+  import borrow-thing;
+}


### PR DESCRIPTION
Currently, the `*_drop_borrow` bindings are only generated when autodropping borrows is enabled, whereas it should be the other way around. This affects the case where a component exports a function that takes a borrowing handle to an imported reference. The explicit `*_drop_borrow` call is required when autodropping is disabled in order to not leak the handle.

Also adds a test to ensure that both autodrop modes work and do not leak the handle, which would result in a runtime error. 