### PR TITLE
[c,cpp] Fix link forcing symbol for component type information

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -316,6 +316,7 @@ impl WorldGenerator for C {
             self.src.c_adapters,
             "
                extern void {linking_symbol}(void);
+               __attribute__((used))
                void {linking_symbol}_public_use_in_this_compilation_unit(void) {{
                    {linking_symbol}();
                }}

--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -625,7 +625,8 @@ impl WorldGenerator for Cpp {
         uwrite!(
             c_str.src,
             "#ifdef __wasm32__
-                   extern void {linking_symbol}(void);
+                   extern \"C\" void {linking_symbol}(void);
+                   __attribute__((used))
                    void {linking_symbol}_public_use_in_this_compilation_unit(void) {{
                        {linking_symbol}();
                    }}


### PR DESCRIPTION
Fixes two issues with the current method of generating linker errors when `world_name_component_type.o` is not linked into the final component:

- **C & C++ generators**: The linker can, and does, discard the `__component_type_object_force_link_plugin_public_use_in_this_compilation_unit` function, which removes the unresolved symbol, resulting in no linker error if the type information is not linked against. This PR adds `__attribute__((used))` to ensure that this doesn't happen. This is a [GCC extension](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-used-function-attribute), but these extensions are already used to, for example, define weak symbols, so I think this is reasonable.
- **C++ generator**: The `__component_type_object_force_link_plugin` symbol is mangled in `.o` files generated from the bindings, so it will fail to link against the type information object file. This PR declares it `extern "C"` to disable mangling.

Initially discussed [here](https://github.com/bytecodealliance/wit-bindgen/pull/1322#issuecomment-3005571728)