### PR TITLE
[cpp] sharing types between import and export

### DIFF
--- a/tests/runtime/common-types/compose.wac
+++ b/tests/runtime/common-types/compose.wac
@@ -1,0 +1,15 @@
+package example:composition;
+
+let leaf = new test:leaf {
+  ... 
+};
+let middle = new test:middle {
+  to-test: leaf.to-test,
+  ...
+};
+let runner = new test:runner {
+  to-test: middle.to-test,
+  ...
+};
+
+export runner...;

--- a/tests/runtime/common-types/leaf.cpp
+++ b/tests/runtime/common-types/leaf.cpp
@@ -1,0 +1,11 @@
+#include <leaf_cpp.h>
+
+using namespace test::common::test_types;
+
+R1 exports::test::common::to_test::Wrap(F1 flag) {
+    if (flag == F1::kA) {
+        return R1{ 1, flag };
+    } else {
+        return R1{ 2, flag };
+    }
+}

--- a/tests/runtime/common-types/middle.cpp
+++ b/tests/runtime/common-types/middle.cpp
@@ -1,0 +1,7 @@
+#include <middle_cpp.h>
+
+using namespace test::common::test_types;
+
+R1 exports::test::common::to_test::Wrap(F1 flag) {
+    return ::test::common::to_test::Wrap(flag);
+}

--- a/tests/runtime/common-types/runner.cpp
+++ b/tests/runtime/common-types/runner.cpp
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <runner_cpp.h>
+
+int main() {
+    using namespace ::test::common::test_types;
+    
+    R1 res = test::common::to_test::Wrap(F1::kA);
+    assert(res.b == F1::kA);
+    assert(res.a == 1);
+
+    R1 res2 = test::common::to_test::Wrap(F1::kB);
+    assert(res2.b == F1::kB);
+    assert(res2.a == 2);
+
+    return 0;
+}

--- a/tests/runtime/common-types/test.wit
+++ b/tests/runtime/common-types/test.wit
@@ -1,0 +1,28 @@
+//@ dependencies = ['middle', 'leaf']
+//@ wac = 'compose.wac'
+
+package test:common;
+
+interface test-types {
+    flags f1 { a, b }
+    record r1 { a: u8, b: f1 }
+}
+
+interface to-test {
+    use test-types.{f1, r1};
+
+    wrap: func(flag: f1) -> r1;
+}
+
+world leaf {
+    export to-test;
+}
+
+world middle {
+    import to-test;
+    export to-test;
+}
+
+world runner {
+    import to-test;
+}


### PR DESCRIPTION
This adds a test which illustrates that types need to be compatible between import and export. 

(The same test can be written for Rust, this isn't included in here)

Related to discussion at https://github.com/bytecodealliance/wit-bindgen/pull/1327