### PR TITLE
Test the C++ generator in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # moonbit removed from language matrix for now - causing CI failures
-        lang: [c, rust, csharp]
+        lang: [c, rust, csharp, cpp]
         exclude:
           # For now csharp doesn't work on macos, so exclude it from testing.
           - os: macos-latest

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -177,6 +177,13 @@ impl LanguageMethods for Cpp {
     }
 
     fn verify(&self, runner: &crate::Runner<'_>, verify: &crate::Verify) -> anyhow::Result<()> {
+        // for expected
+        let cwd = std::env::current_dir()?;
+        let mut helper_dir2 = cwd;
+        helper_dir2.push("crates");
+        helper_dir2.push("cpp");
+        helper_dir2.push("test_headers");
+
         let compiler = clangpp(runner);
         let mut cmd = Command::new(compiler);
         cmd.arg(
@@ -186,11 +193,14 @@ impl LanguageMethods for Cpp {
         )
         .arg("-I")
         .arg(&verify.bindings_dir)
+        .arg("-I")
+        .arg(helper_dir2.to_str().unwrap().to_string())
         .arg("-Wall")
         .arg("-Wextra")
         .arg("-Werror")
         .arg("-Wc++-compat")
         .arg("-Wno-unused-parameter")
+        .arg("-std=c++20")
         .arg("-c")
         .arg("-o")
         .arg(verify.artifacts_dir.join("tmp.o"));

--- a/tests/runtime/lists/test.cpp
+++ b/tests/runtime/lists/test.cpp
@@ -33,7 +33,7 @@ static bool equal(std::span<const R> const&a, std::vector<R> const& b) {
 }
 template<class R>
 static bool equal(wit::vector<R> const&a, std::vector<R> const& b) {
-    return equal(a.get_view(), std::span<R>(b));
+    return equal(a.get_view(), std::span<const R>(b.begin(), b.end()));
 }
 template<class R,class S, class T, class U>
 static bool equal(std::tuple<R,S> const&a, std::tuple<T,U> const& b) {


### PR DESCRIPTION
Updating CI configuration to ensure that `cpp` is listed under the languages tested.