### PR TITLE
Fix spacing between subsequent headings for markdown generation

### DIFF
--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -428,7 +428,7 @@ impl InterfaceGenerator<'_> {
     fn docs(&mut self, docs: &Docs) {
         let docs = match &docs.contents {
             Some(docs) => docs,
-            None => return,
+            None => "\n",
         };
         for line in docs.lines() {
             self.push_str(line.trim());
@@ -511,6 +511,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             self.print_ty(ty);
             self.push_str("\n");
         }
+        self.push_str("\n");
     }
 
     fn type_flags(&mut self, _id: TypeId, name: &str, flags: &Flags, docs: &Docs) {

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -484,6 +484,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             }
             self.push_str("\n");
         }
+        self.push_str("\n");
     }
 
     fn type_resource(&mut self, _id: TypeId, name: &str, docs: &Docs) {
@@ -538,6 +539,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             }
             self.push_str("\n");
         }
+        self.push_str("\n");
     }
 
     fn type_variant(&mut self, _id: TypeId, name: &str, variant: &Variant, docs: &Docs) {
@@ -568,6 +570,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             }
             self.push_str("\n");
         }
+        self.push_str("\n");
     }
 
     fn type_enum(&mut self, _id: TypeId, name: &str, enum_: &Enum, docs: &Docs) {
@@ -594,6 +597,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
             }
             self.push_str("\n");
         }
+        self.push_str("\n");
     }
 
     fn type_option(&mut self, _id: TypeId, name: &str, payload: &Type, docs: &Docs) {


### PR DESCRIPTION
When `types` do not have documentation the succeeding heading can touch the previous paragraph, which prevents the markdown rendering correctly.

Also, lists of definitions, such as records, flags, variants, enums and tuple can collide with the subsequent heading, also causing markdown rendering issues.

This PR ensures appropriate spacing to allow these items to render correctly.