### PR TITLE
[cpp] Add move_if_necessary in C++ binding flush instruction

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -3063,7 +3063,7 @@ impl<'a, 'b> Bindgen for FunctionBindgen<'a, 'b> {
                 for i in operands.iter().take(*amt) {
                     let tmp = self.tmp();
                     let result = format!("result{}", tmp);
-                    uwriteln!(self.src, "auto {result} = {};", i);
+                    uwriteln!(self.src, "auto {result} = {};", move_if_necessary(i));
                     results.push(result);
                 }
             }

--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -2639,7 +2639,7 @@ impl<'a, 'b> Bindgen for FunctionBindgen<'a, 'b> {
                         let case = format!("{elem_ns}::{}", case.name.to_pascal_case());
                         uwriteln!(
                             self.src,
-                            "const {} &{} = std::get<{case}>({}.variants).value;",
+                            "{} &{} = std::get<{case}>({}.variants).value;",
                             ty,
                             payload,
                             operands[0],

--- a/tests/runtime/cpp/variant-with-data/runner.cpp
+++ b/tests/runtime/cpp/variant-with-data/runner.cpp
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <runner_cpp.h>
+
+template <class T>
+static bool equal(T const& a, T const& b) {
+    return a == b;
+}
+
+template <class T>
+static bool equal(wit::vector<T> const& a, wit::vector<T> const& b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!equal(a[i], b[i])) return false;
+    }
+    return true;
+}
+
+static bool equal(wit::string const& a, wit::string const& b) {
+    return a.get_view() == b.get_view();
+}
+
+static bool equal(::test::variant_with_data::to_test::DataVariant const& a, ::test::variant_with_data::to_test::DataVariant const& b) {
+    if (a.variants.index() != b.variants.index()) return false;
+    switch (a.variants.index()) {
+        case 0: return equal(std::get<::test::variant_with_data::to_test::DataVariant::Bytes>(a.variants).value, std::get<::test::variant_with_data::to_test::DataVariant::Bytes>(b.variants).value);
+        case 1: return equal(std::get<::test::variant_with_data::to_test::DataVariant::Number>(a.variants).value, std::get<::test::variant_with_data::to_test::DataVariant::Number>(b.variants).value);
+        case 2: return equal(std::get<::test::variant_with_data::to_test::DataVariant::Text>(a.variants).value, std::get<::test::variant_with_data::to_test::DataVariant::Text>(b.variants).value);
+    }
+    return false;
+}
+
+int main() {
+  using namespace ::test::variant_with_data::to_test;
+
+  // Test bytes variant
+  auto bytes_variant = GetData(0);
+  uint8_t expected_bytes[]{0x01, 0x02, 0x03, 0x04, 0x05};
+  DataVariant expected_bytes_variant;
+  expected_bytes_variant.variants = DataVariant::Bytes(wit::vector<uint8_t>::from_view(std::span<uint8_t>(expected_bytes)));
+  assert(equal(bytes_variant, expected_bytes_variant));
+
+  // Test number variant
+  auto number_variant = GetData(1);
+  DataVariant expected_number_variant;
+  expected_number_variant.variants = DataVariant::Number(42);
+  assert(equal(number_variant, expected_number_variant));
+
+  // Test text variant
+  auto text_variant = GetData(2);
+  DataVariant expected_text_variant;
+  expected_text_variant.variants = DataVariant::Text(wit::string::from_view("hello"));
+  assert(equal(text_variant, expected_text_variant));
+
+  return 0;
+}

--- a/tests/runtime/cpp/variant-with-data/test.cpp
+++ b/tests/runtime/cpp/variant-with-data/test.cpp
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <vector>
+#include <test_cpp.h>
+
+using ::test::variant_with_data::to_test::DataVariant;
+
+DataVariant exports::test::variant_with_data::to_test::GetData(uint8_t num) {
+  DataVariant variant;
+  switch (num) {
+    case 0: {
+      uint8_t bytes[]{0x01, 0x02, 0x03, 0x04, 0x05};
+      variant.variants = DataVariant::Bytes(wit::vector<uint8_t>::from_view(std::span<uint8_t>(bytes)));
+    }
+    case 1:
+      variant.variants = DataVariant::Number(42);
+    case 2:
+      variant.variants = DataVariant::Text(wit::string::from_view("hello"));
+    default:
+      variant.variants = DataVariant::Number(0);
+  }
+  auto result = std::move(variant);
+  return result;
+}

--- a/tests/runtime/cpp/variant-with-data/test.wit
+++ b/tests/runtime/cpp/variant-with-data/test.wit
@@ -1,0 +1,19 @@
+package test:variant-with-data;
+
+interface to-test {
+  variant data-variant {
+    bytes(list<u8>),
+    number(u32),
+    text(string)
+  }
+
+  get-data: func(num: u8) -> data-variant;
+}
+
+world runner {
+  import to-test;
+}
+
+world test {
+  export to-test;
+}


### PR DESCRIPTION
This addresses https://github.com/bytecodealliance/wit-bindgen/issues/1332.

Not completely sure this is the right way to do it, would appreciate a double check @cpetig or @TartanLlama when you get the chance.

Also not sure where I would add a test for this, some guidance would be helpful.