### PR TITLE
c/lib.rs: dtor symbols should use name, not snake

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -1382,7 +1382,7 @@ extern int32_t __wasm_import_{ns}_{snake}_rep(int32_t);
     return ({ns}_{snake}_t*) __wasm_import_{ns}_{snake}_rep(handle.__handle);
 }}
 
-__attribute__((__export_name__("{module}#[dtor]{snake}")))
+__attribute__((__export_name__("{module}#[dtor]{name}")))
 void __wasm_export_{ns}_{snake}_dtor({ns}_{snake}_t* arg) {{
     {ns}_{snake}_destructor(arg);
 }}


### PR DESCRIPTION
I noticed this discrepancy between the symbols generated by the rust and C binding generators - this change should (hopefully) make it so that rust and C/C++ implementers can build components that are compatible with eachother.