### PR TITLE
Migrate this workspace to using trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,10 +79,14 @@ jobs:
         files: "dist/*"
         tag_name: v${{ steps.tag.outputs.version }}
 
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+      if: steps.tag.outputs.push_tag == 'yes'
+
     - run: |
         rm -rf dist main.log
         rustc ci/publish.rs
         ./publish publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       if: steps.tag.outputs.push_tag == 'yes'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,13 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   create_tag:
     name: Publish artifacts of build
     runs-on: ubuntu-latest
+    environment: release
     if: |
       github.repository_owner == 'bytecodealliance'
       && github.event_name == 'push'

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -334,42 +334,6 @@ fn publish(krate: &Crate) -> bool {
         return false;
     }
 
-    // After we've published then make sure that the `wasmtime-publish` group is
-    // added to this crate for future publications. If it's already present
-    // though we can skip the `cargo owner` modification.
-    match curl(&format!(
-        "https://crates.io/api/v1/crates/{}/owners",
-        krate.name
-    )) {
-        Some(output) => {
-            if output.contains("wasmtime-publish") {
-                println!(
-                    "wasmtime-publish already listed as an owner of {}",
-                    krate.name
-                );
-                return true;
-            }
-        }
-        None => return false,
-    }
-
-    // Note that the status is ignored here. This fails most of the time because
-    // the owner is already set and present, so we only want to add this to
-    // crates which haven't previously been published.
-    let status = Command::new("cargo")
-        .arg("owner")
-        .arg("-a")
-        .arg("github:bytecodealliance:wasmtime-publish")
-        .arg(&krate.name)
-        .status()
-        .expect("failed to run cargo");
-    if !status.success() {
-        panic!(
-            "FAIL: failed to add wasmtime-publish as owner `{}`: {}",
-            krate.name, status
-        );
-    }
-
     true
 }
 
@@ -410,6 +374,7 @@ fn verify(crates: &[Crate]) {
         if !krate.publish {
             continue;
         }
+        verify_crates_io(krate);
         verify_and_vendor(&krate);
     }
 
@@ -440,6 +405,46 @@ fn verify(crates: &[Crate]) {
             "{\"files\":{}}",
         )
         .unwrap();
+    }
+
+    fn verify_crates_io(krate: &Crate) {
+        let name = &krate.name;
+        let Some(owners) = curl(&format!("https://crates.io/api/v1/crates/{name}/owners")) else {
+            println!(
+                "
+failed to get owners for {name}
+
+If this crate does not exist on crates.io yet please ping wasm-tools maintainers
+to add the crate on crates.io as a small shim. When doing so please remind them
+that the trusted publishing workflow must be configured as well.
+",
+                name = name,
+            );
+        };
+
+        // This is the id of the `wasmtime-publish` user on crates.io
+        if !owners.contains("\"id\":73222,") {
+            println!(
+                "
+crate {name} is not owned by wasmtime-publish, please run:
+
+    cargo owner -a wasmtime-publish {name}
+",
+                name = name,
+            );
+        }
+
+        if owners.split("\"id\"").count() != 2 {
+            println!(
+                "
+crate {name} is not exclusively owned by wasmtime-publish
+
+Please contact wasm-tools maintainers to ensure that `wasmtime-publish` is the
+only listed owner of the crate.
+",
+                name = name,
+            );
+        }
     }
 }
 

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -410,7 +410,7 @@ fn verify(crates: &[Crate]) {
     fn verify_crates_io(krate: &Crate) {
         let name = &krate.name;
         let Some(owners) = curl(&format!("https://crates.io/api/v1/crates/{name}/owners")) else {
-            println!(
+            panic!(
                 "
 failed to get owners for {name}
 
@@ -424,7 +424,7 @@ that the trusted publishing workflow must be configured as well.
 
         // This is the id of the `wasmtime-publish` user on crates.io
         if !owners.contains("\"id\":73222,") {
-            println!(
+            panic!(
                 "
 crate {name} is not owned by wasmtime-publish, please run:
 
@@ -435,7 +435,7 @@ crate {name} is not owned by wasmtime-publish, please run:
         }
 
         if owners.split("\"id\"").count() != 2 {
-            println!(
+            panic!(
                 "
 crate {name} is not exclusively owned by wasmtime-publish
 


### PR DESCRIPTION
Similar to bytecodealliance/wasm-tools#2281 but for this repository. The main benefit is removal of a long-lived token, and the main consequence is that crates will need to be published to crates.io with a placeholder before being merged in here.