### PR TITLE
Parse `wit` folder in `generate!` with `inline`

### DIFF
--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -262,14 +262,14 @@ fn parse_source(
                 // whether it exists and only if there is it parsed.
                 None => {
                     if default.exists() {
-                        parse(default)?;
+                        parse(&[default])?;
                     }
                 }
             }
             pkgs.push(resolve.push_group(UnresolvedPackageGroup::parse("macro-input", s)?)?);
         }
         Some(Source::Paths(p)) => parse(p)?,
-        None => parse(&vec![default])?,
+        None => parse(&[default])?,
     };
 
     Ok((resolve, pkgs, files))


### PR DESCRIPTION
This commit updates handling of the `inline` attribute in the `generate!` macro of the Rust bindings generator. Previously if `inline` was specified it would by default lookup nothing on the filesystem unless `path` was specified. This contradicts the documentation though that `./wit` is the default lookup path. To resolve this this commit adds a check to see if `./wit` exists, and if so parses it. This keeps the default search path behavior without requiring its existence when using `inline`.