### PR TITLE
Prioritize `inline` worlds, not external ones

### DIFF
--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -266,6 +266,7 @@ fn parse_source(
                     }
                 }
             }
+            pkgs.truncate(0);
             pkgs.push(resolve.push_group(UnresolvedPackageGroup::parse("macro-input", s)?)?);
         }
         Some(Source::Paths(p)) => parse(p)?,

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -16,3 +16,18 @@ mod multiple_paths {
         generate_all,
     });
 }
+
+#[allow(unused)]
+mod inline_and_path {
+    wit_bindgen::generate!({
+        inline: r#"
+        package test:paths;
+
+        world test {
+            import test:inline-and-path/bar;
+        }
+        "#,
+        path: ["tests/wit/path3"],
+        generate_all,
+    });
+}


### PR DESCRIPTION
When multiple `path`s are used the `generate!` macro will fail if they all contain a `world` and no world is otherwise specified. This then additionally affected when using `inline` plus loading auxiliary WIT from a `paths` directory (either explicitly or the default `wit`). This commit switches the logic to prioritizing worlds in the `inline` block because if that's being specified it's pretty likely the exact one that wants to be used.