### PR TITLE
Support fallible constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ name = "test-helpers"
 version = "0.0.0"
 dependencies = [
  "codegen-macro",
- "wasm-encoder 0.236.0",
+ "wasm-encoder 0.237.0",
  "wit-bindgen-core",
  "wit-component",
  "wit-parser",
@@ -999,9 +999,9 @@ checksum = "ddbd7f2a9e3635abe5d4df93b12cadc8d6818079785ee4fab3719ae3c85a064e"
 
 [[package]]
 name = "wasm-compose"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b5290a0aca685aab16c936f682b85e8e4e3a0bfe1843afd43372eb82e34f47"
+checksum = "4691ea85473e81ea13f91088854186eb792710d7c1af8b07bc1ad1ab3a02404f"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -1013,8 +1013,8 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasmparser 0.237.0",
  "wat",
 ]
 
@@ -1029,12 +1029,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3108979166ab0d3c7262d2e16a2190ffe784b2a5beb963edef154b5e8e07680b"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.236.0",
+ "wasmparser 0.237.0",
 ]
 
 [[package]]
@@ -1055,14 +1055,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac1c212d9a151aefa45403315d8eb5c81d64dd06103e2d5e0f351034f20169"
+checksum = "4cc0b0a0c4f35ca6efa7a797671372915d4e9659dba2d59edc6fafc931d19997"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasmparser 0.237.0",
 ]
 
 [[package]]
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d1eee846a705f6f3cb9d7b9f79b54583810f1fb57a1e3aea76d1742db2e3d2"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -1091,22 +1091,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "236.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d6b6faeab519ba6fbf9b26add41617ca6f5553f99ebc33d876e591d2f4f3c6"
+checksum = "fcf66f545acbd55082485cb9a6daab54579cb8628a027162253e8e9f5963c767"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.1",
- "wasm-encoder 0.236.0",
+ "wasm-encoder 0.237.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.236.0"
+version = "1.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc31704322400f461f7f31a5f9190d5488aaeafb63ae69ad2b5888d2704dcb08"
+checksum = "27975186f549e4b8d6878b627be732863883c72f7bf4dcf8f96e5f8242f73da9"
 dependencies = [
  "wast",
 ]
@@ -1282,8 +1282,8 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "indexmap",
- "wasm-encoder 0.236.0",
- "wasm-metadata 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasm-metadata 0.237.0",
  "wit-bindgen-core",
  "wit-component",
 ]
@@ -1295,7 +1295,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
- "wasm-encoder 0.236.0",
+ "wasm-encoder 0.237.0",
  "wit-bindgen-c",
  "wit-bindgen-core",
  "wit-bindgen-cpp",
@@ -1326,8 +1326,8 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "test-helpers",
- "wasm-encoder 0.236.0",
- "wasm-metadata 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasm-metadata 0.237.0",
  "wit-bindgen-c",
  "wit-bindgen-core",
  "wit-component",
@@ -1341,7 +1341,7 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "indexmap",
- "wasm-metadata 0.236.0",
+ "wasm-metadata 0.237.0",
  "wit-bindgen-core",
  "wit-component",
  "wit-parser",
@@ -1391,7 +1391,7 @@ dependencies = [
  "serde_json",
  "syn",
  "test-helpers",
- "wasm-metadata 0.236.0",
+ "wasm-metadata 0.237.0",
  "wit-bindgen",
  "wit-bindgen-core",
  "wit-bindgen-rt",
@@ -1429,8 +1429,8 @@ dependencies = [
  "wac-types",
  "wasi-preview1-component-adapter-provider",
  "wasm-compose",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasmparser 0.237.0",
  "wat",
  "wit-bindgen-csharp",
  "wit-component",
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1404fddf6cdadb06a0812faa433c03208f444b867543814aa36a6322f33684"
+checksum = "bfb7674f76c10e82fe00b256a9d4ffb2b8d037d42ab8e9a83ebb3be35c9d0bf6"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1450,18 +1450,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.236.0",
- "wasm-metadata 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder 0.237.0",
+ "wasm-metadata 0.237.0",
+ "wasmparser 0.237.0",
  "wat",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c643fd8e1a5c25a6d50299f8047e9a61e31cb486f8e230e944408da9b63a859"
+checksum = "ce2596a5bc7c24cc965b56ad6ff9e32394c4e401764f89620a888519c6e849ab"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -1472,5 +1472,5 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.236.0",
+ "wasmparser 0.237.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ prettyplease = "0.2.20"
 syn = { version = "2.0.89", features = ["printing"] }
 futures = "0.3.31"
 
-wat = "1.236.0"
-wasmparser = "0.236.0"
-wasm-encoder = "0.236.0"
-wasm-metadata = { version = "0.236.0", default-features = false }
-wit-parser = "0.236.0"
-wit-component = "0.236.0"
-wasm-compose = "0.236.0"
+wat = "1.237.0"
+wasmparser = "0.237.0"
+wasm-encoder = "0.237.0"
+wasm-metadata = { version = "0.237.0", default-features = false }
+wit-parser = "0.237.0"
+wit-component = "0.237.0"
+wasm-compose = "0.237.0"
 
 wit-bindgen-core = { path = 'crates/core', version = '0.44.0' }
 wit-bindgen-c = { path = 'crates/c', version = '0.44.0' }

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -59,6 +59,7 @@ impl LanguageMethods for Cpp {
             | "multiversion"
             | "resource-alias.wit"
             | "resource-borrow-in-record.wit"
+            | "resource-fallible-constructor.wit"
             | "resources.wit"
             | "resources-in-aggregates.wit"
             | "resources-with-futures.wit"

--- a/crates/test/src/csharp.rs
+++ b/crates/test/src/csharp.rs
@@ -36,11 +36,14 @@ impl LanguageMethods for Csharp {
 
     fn should_fail_verify(
         &self,
-        _name: &str,
+        name: &str,
         config: &crate::config::WitConfig,
         _args: &[String],
     ) -> bool {
-        config.async_
+        match name {
+            "resource-fallible-constructor.wit" => true,
+            _ => config.async_,
+        }
     }
 
     fn prepare(&self, runner: &mut Runner<'_>) -> Result<()> {

--- a/tests/codegen/resource-fallible-constructor.wit
+++ b/tests/codegen/resource-fallible-constructor.wit
@@ -1,0 +1,12 @@
+package my:resources;
+
+interface fallible-constructor {
+  resource x {
+    constructor(s: string) -> result<x, string>;
+  }
+}
+
+world resources {
+  import fallible-constructor;
+  export fallible-constructor;
+}


### PR DESCRIPTION
This implements https://github.com/WebAssembly/component-model/pull/550 for the Rust generator. C worked out of the box without additional changes. Support for other language generators needs more thought (see below).

What's the best way to proceed with this PR from here on?
Get all languages working first? I'll need help with that then.
Or merge with this initial set of languages, and leave the rest for future PRs?

### C++
AFAICS, there isn't any exception throwing/handling support in the cpp generator today and everything uses `std::expected`. I have near-zero experience with C++, though I've heard exception handling is a bit of a contentious topic in the C++ community. So I suppose this was done for a reason?

If the cpp generator wants to continue using C++'s native constructor syntax it'll require exceptions.
Alternatively, it'll need to switch to a static factory method. But, at least for _exported_ resources, there already exists a static `New` method. Not sure why this is needed when there's already a constructor too.

### C#
The csharp generator has exception support already. But it also has a `with_wit_results` mode. What should happen in that case?
- Ignore the flag and generate a throwing constructor anyway? Not very intuitive.
- Leave the native constructor syntax behind and generate a static factory method?
- Generate both versions? Similar to the common [`Parse`](https://learn.microsoft.com/en-us/dotnet/api/system.int32.parse?view=net-9.0)+[`TryParse`](https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse?view=net-9.0) pattern.

Maybe worth noting: [properties](https://github.com/WebAssembly/component-model/issues/235) will likely end up in the same boat.

### Moonbit
No experience with this language.