### PR TITLE
Disable C# in CI testing for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # moonbit removed from language matrix for now - causing CI failures
-        lang: [c, rust, csharp, cpp]
+        # csharp removed from language matrix for now - causing CI failures
+        lang: [c, rust, cpp]
         exclude:
           # For now csharp doesn't work on macos, so exclude it from testing.
           - os: macos-latest


### PR DESCRIPTION
It's causing failures on CI, so temporarily remove it while those are sorted out.