### PR TITLE
fix(msrv): add rust-version based on ground truth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 CLI tool to generate bindings for WIT documents and the component model.
@@ -18,6 +19,7 @@ edition = "2021"
 version = "0.44.0"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/bytecodealliance/wit-bindgen"
+rust-version = "1.82.0"
 
 [workspace.dependencies]
 anyhow = "1.0.72"

--- a/crates/c/Cargo.toml
+++ b/crates/c/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 C bindings generator for WIT and the component model, typically used through the

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 Low-level support for bindings generation based on WIT files for use with

--- a/crates/cpp/Cargo.toml
+++ b/crates/cpp/Cargo.toml
@@ -3,6 +3,7 @@ name = "wit-bindgen-cpp"
 authors = ["Christof Petig <christof.petig@arcor.de>"]
 version = "0.44.0"
 edition.workspace = true
+rust-version.workspace = true
 repository = 'https://github.com/cpetig/wit-bindgen'
 license = "Apache-2.0 WITH LLVM-exception"
 description = """

--- a/crates/csharp/Cargo.toml
+++ b/crates/csharp/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 C# bindings generator for WIT and the component model, typically used

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 Rust bindings generator and runtime support for WIT and the component model.

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 Markdown generator for WIT and the component model, typically used

--- a/crates/moonbit/Cargo.toml
+++ b/crates/moonbit/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 MoonBit bindings generator for WIT and the component model, typically used

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
 Rust bindings generator for WIT and the component model, typically used through

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -4,9 +4,10 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 homepage = 'https://github.com/bytecodealliance/wit-bindgen'
 description = """
-Backend of the `wit-bindgne test` subcommand
+Backend of the `wit-bindgen test` subcommand
 """
 readme = "README.md"
 


### PR DESCRIPTION
use of `iter::repeat_n` (and `Cargo.lock` version 4?) cause these
packages to depend on Rust 1.82.0 at minimum
