### PR TITLE
C#: reenable csharp in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # moonbit removed from language matrix for now - causing CI failures
-        # csharp removed from language matrix for now - causing CI failures
-        lang: [c, rust, cpp]
+        lang: [c, rust, csharp, cpp]
         exclude:
           # For now csharp doesn't work on macos, so exclude it from testing.
           - os: macos-latest


### PR DESCRIPTION
Reenables c# in CI as we have new compiler packages.