### PR TITLE
Redefine `with` in the Rust generator to only apply to imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
     - run: cargo test
     - run: cargo test -p wit-bindgen-core
     - run: cargo test -p wit-bindgen
+    - run: cargo test -p wit-bindgen-rust
     - run: cargo test --workspace --exclude 'wit-bindgen*'
     - run: cargo test -p wit-bindgen-rt --all-features
     - run: rustup update nightly --no-self-update

--- a/crates/rust/tests/wit/path3/package.wit
+++ b/crates/rust/tests/wit/path3/package.wit
@@ -1,0 +1,3 @@
+package test:inline-and-path;
+
+interface bar {}

--- a/crates/test/src/c.rs
+++ b/crates/test/src/c.rs
@@ -21,8 +21,6 @@ pub struct COpts {
 
 pub struct C;
 
-pub struct Cpp;
-
 /// C/C++-specific configuration of component files
 #[derive(Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -37,14 +35,6 @@ fn clang(runner: &Runner<'_>) -> PathBuf {
     match &runner.opts.c.wasi_sdk_path {
         Some(path) => path.join(format!("bin/{target}-clang")),
         None => format!("{target}-clang").into(),
-    }
-}
-
-fn clangpp(runner: &Runner<'_>) -> PathBuf {
-    let target = &runner.opts.c.c_target;
-    match &runner.opts.c.wasi_sdk_path {
-        Some(path) => path.join(format!("bin/{target}-clang++")),
-        None => format!("{target}-clang++").into(),
     }
 }
 
@@ -84,41 +74,6 @@ impl LanguageMethods for C {
 
     fn verify(&self, runner: &Runner<'_>, v: &Verify<'_>) -> Result<()> {
         verify(runner, v, clang(runner))
-    }
-}
-
-impl LanguageMethods for Cpp {
-    fn display(&self) -> &str {
-        "cpp"
-    }
-
-    fn bindgen_name(&self) -> Option<&str> {
-        Some("c")
-    }
-
-    fn comment_prefix_for_test_config(&self) -> Option<&str> {
-        Some("//@")
-    }
-
-    fn should_fail_verify(
-        &self,
-        name: &str,
-        config: &crate::config::WitConfig,
-        args: &[String],
-    ) -> bool {
-        C.should_fail_verify(name, config, args)
-    }
-
-    fn prepare(&self, runner: &mut Runner<'_>) -> Result<()> {
-        prepare(runner, clangpp(runner))
-    }
-
-    fn compile(&self, runner: &Runner<'_>, c: &Compile<'_>) -> Result<()> {
-        compile(runner, c, clangpp(runner))
-    }
-
-    fn verify(&self, runner: &Runner<'_>, v: &Verify<'_>) -> Result<()> {
-        verify(runner, v, clangpp(runner))
     }
 }
 

--- a/tests/runtime/rust/with-only-affects-imports/compose.wac
+++ b/tests/runtime/rust/with-only-affects-imports/compose.wac
@@ -1,0 +1,13 @@
+package example:composition;
+
+let leaf = new test:leaf { ... };
+let intermediate = new test:test {
+  foo: leaf.foo,
+  ...
+};
+let runner = new test:runner {
+  foo: intermediate.foo,
+  ...
+};
+
+export runner...;

--- a/tests/runtime/rust/with-only-affects-imports/leaf.rs
+++ b/tests/runtime/rust/with-only-affects-imports/leaf.rs
@@ -1,0 +1,13 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+use crate::exports::my::inline::foo::{Guest, A};
+
+impl Guest for Component {
+    fn bar(a: A) {
+        assert_eq!(a.b, 2);
+    }
+}

--- a/tests/runtime/rust/with-only-affects-imports/runner.rs
+++ b/tests/runtime/rust/with-only-affects-imports/runner.rs
@@ -1,0 +1,5 @@
+include!(env!("BINDINGS"));
+
+fn main() {
+    my::inline::foo::bar(my::inline::foo::A { b: 2 });
+}

--- a/tests/runtime/rust/with-only-affects-imports/test.rs
+++ b/tests/runtime/rust/with-only-affects-imports/test.rs
@@ -1,0 +1,40 @@
+//@ args = '--with my:inline/foo=other::my::inline::foo'
+
+#![expect(
+    unused_imports,
+    reason = "using `with` is known to produce possibly dead imports"
+)]
+
+include!(env!("BINDINGS"));
+
+mod other {
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline;
+
+            interface foo {
+                record a { b: u8 }
+
+                bar: func(a: a);
+            }
+
+            world gen {
+                import foo;
+            }
+        ",
+    });
+}
+
+struct Component;
+
+export!(Component);
+
+use crate::exports::my::inline::foo::{Guest, A};
+use std::any::TypeId;
+
+impl Guest for Component {
+    fn bar(a: A) {
+        assert!(TypeId::of::<A>() != TypeId::of::<other::my::inline::foo::A>());
+        other::my::inline::foo::bar(other::my::inline::foo::A { b: a.b })
+    }
+}

--- a/tests/runtime/rust/with-only-affects-imports/test.wit
+++ b/tests/runtime/rust/with-only-affects-imports/test.wit
@@ -1,0 +1,25 @@
+//@ dependencies = ['test', 'leaf']
+//@ wac = 'compose.wac'
+
+package my:inline;
+
+interface foo {
+    record a {
+      b: u8,
+    }
+
+    bar: func(a: a);
+}
+
+world leaf {
+    export foo;
+}
+
+world test {
+    import foo;
+    export foo;
+}
+
+world runner {
+    import foo;
+}


### PR DESCRIPTION
This commit avoids looking at `--with` for exports, for example, to fix situations where an interface is imported and exported and only the import types should be reused from elsewhere. I'm not aware of any cases where exports want to be reused, so there's effectively no more support for that.