### PR TITLE
feat(moonbit): set default target

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -572,7 +572,10 @@ impl WorldGenerator for MoonBit {
         // Export project files
         if !self.opts.ignore_stub && !self.opts.ignore_module_file {
             let mut body = Source::default();
-            uwriteln!(&mut body, "{{ \"name\": \"{project_name}\" }}");
+            uwriteln!(
+                &mut body,
+                "{{ \"name\": \"{project_name}\", \"preferred-target\": \"wasm\" }}"
+            );
             files.push(&format!("moon.mod.json"), body.as_bytes());
         }
 

--- a/crates/test/src/moonbit.rs
+++ b/crates/test/src/moonbit.rs
@@ -49,8 +49,6 @@ impl LanguageMethods for MoonBit {
         let mut cmd = Command::new("moon");
         cmd.arg("build")
             .arg("--no-strip") // for debugging
-            .arg("--target")
-            .arg("wasm")
             .arg("-C")
             .arg(compile.bindings_dir);
         runner.run_command(&mut cmd)?;
@@ -91,8 +89,6 @@ impl LanguageMethods for MoonBit {
     fn verify(&self, runner: &crate::Runner<'_>, verify: &crate::Verify) -> anyhow::Result<()> {
         let mut cmd = Command::new("moon");
         cmd.arg("check")
-            .arg("--target")
-            .arg("wasm")
             .arg("--warn-list")
             .arg("-28")
             .arg("--deny-warn")
@@ -102,8 +98,6 @@ impl LanguageMethods for MoonBit {
         runner.run_command(&mut cmd)?;
         let mut cmd = Command::new("moon");
         cmd.arg("build")
-            .arg("--target")
-            .arg("wasm")
             .arg("--source-dir")
             .arg(verify.bindings_dir);
 


### PR DESCRIPTION
A small improvement : set the default target for the generated project to Wasm 1 so that users don't need to add `--target wasm` any more.