### PR TITLE
[C#] Change class to readonly struct for records

### DIFF
--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -995,7 +995,7 @@ impl<'a> CoreInterfaceGenerator<'a> for InterfaceGenerator<'a> {
         uwrite!(
             self.src,
             "
-            {access} class {name} {{
+            {access} readonly struct {name} {{
                 {fields}
 
                 {access} {name}({parameters}) {{


### PR DESCRIPTION
By design the `record` wit type is just a set of fields (https://component-model.bytecodealliance.org/design/wit.html#records) This PR aims to reduce the GC work changing from a `class` to a `readonly struct`.