### PR TITLE
fix(core): results for async task generation

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -1247,7 +1247,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         if async_ =>
                     {
                         let name = &format!("[task-return]{}", func.name);
-                        let params = results.as_deref().unwrap_or(&[WasmType::I32]);
+                        let params = results.as_deref().unwrap_or_default();
                         self.emit(&Instruction::AsyncTaskReturn { name, params });
                     }
 


### PR DESCRIPTION
This commit fixes the parameter generation when emitting the `AsyncTaskReturn` instruction -- in the past the "default" was expeted to be a single I32, but this was a misreading of the spec, it is possible for an task.return to return nothing if there are no results to return.