### PR TITLE
Fill out missing `StreamRead::cancel` implementation

### DIFF
--- a/crates/guest-rust/src/rt/async_support/stream_support.rs
+++ b/crates/guest-rust/src/rt/async_support/stream_support.rs
@@ -599,6 +599,6 @@ impl<'a, T> StreamRead<'a, T> {
     /// Panics if the operation has already been completed via `Future::poll`,
     /// or if this method is called twice.
     pub fn cancel(self: Pin<&mut Self>) -> (StreamResult, Vec<T>) {
-        todo!()
+        self.pin_project().cancel()
     }
 }


### PR DESCRIPTION
Just a typo from when this was originally scaffolded.