### PR TITLE
Re-enable C# in CI testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # moonbit removed from language matrix for now - causing CI failures
-        # csharp removed from language matrix for now - causing CI failures
-        lang: [c, rust, cpp]
+        lang: [c, rust, csharp, cpp]
         exclude:
           # For now csharp doesn't work on macos, so exclude it from testing.
           - os: macos-latest


### PR DESCRIPTION
Reverts #1362
Fixes #1363

Support for WASI SDK 27 has been added in https://github.com/dotnet/runtimelab/pull/3162 and is available in the NuGet feed.