### PR TITLE
fix(async): rust-rt async depends on std

### DIFF
--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -30,7 +30,7 @@ default = ["macros", "realloc", "async", "std", "bitflags"]
 macros = ["dep:wit-bindgen-rust-macro"]
 realloc = []
 std = []
-async = ["macros", "dep:futures", "dep:once_cell", "wit-bindgen-rust-macro/async"]
+async = ["macros", "std", "dep:futures", "dep:once_cell", "wit-bindgen-rust-macro/async"]
 bitflags = ["dep:bitflags"]
 
 # Unstable feature to support being a libstd dependency


### PR DESCRIPTION
presumably after #1369, the following build feature combo fails to build:

```bash
cargo build -p wit-bindgen --no-default-features --features async
```
