### PR TITLE
[C#] Fixes mem leak: https://github.com/bytecodealliance/wit-bindgen/issues/1377

### DIFF
--- a/crates/csharp/src/function.rs
+++ b/crates/csharp/src/function.rs
@@ -838,10 +838,23 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             }
 
             Instruction::StringLift { .. } => {
-                results.push(format!(
+                let str = self.locals.tmp("str");
+                let op0 = &operands[0];
+
+                let get_str = format!(
                     "global::System.Text.Encoding.UTF8.GetString((byte*){}, {})",
-                    operands[0], operands[1]
-                ));
+                    op0, operands[1]
+                );
+
+                uwriteln!(
+                    self.src,
+                    "
+                    var {str} = {get_str};
+                    global::System.Runtime.InteropServices.NativeMemory.Free((void*){op0});
+                    "
+                );
+
+                results.push(str);
             }
 
             Instruction::ListLower { element, realloc } => {


### PR DESCRIPTION
The PR aims to fix https://github.com/bytecodealliance/wit-bindgen/issues/1377
Beside that other languages still leaking because of missing `free` calls in this case.

wit file:
```wit
package tests:component@0.1.0;

world test {
    export accept-string: func(s: string, b: string);
}
````

Generated code:

```csharp
// Generated by `wit-bindgen` 0.46.0. DO NOT EDIT!
// <auto-generated />
#nullable enable

namespace TestWorld {

    public interface ITestWorld {
        static abstract void AcceptString(string s, string b);

    }

    namespace exports {
        public static class TestWorld
        {

            [global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute(EntryPoint = "accept-string")]
            public static unsafe void wasmExportAcceptString(nint p0, int p1, nint p2, int p3) {

                var str = global::System.Text.Encoding.UTF8.GetString((byte*)p0, p1);
                global::System.Runtime.InteropServices.NativeMemory.Free((void*)p0);

                var str0 = global::System.Text.Encoding.UTF8.GetString((byte*)p2, p3);
                global::System.Runtime.InteropServices.NativeMemory.Free((void*)p2);

                TestWorldImpl.AcceptString((str), (str0));

            }

        }
    }

}

```