### PR TITLE
Switch `Subtask` trait to taking `&self`

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -873,9 +873,11 @@ pub mod examples;
 pub mod rt;
 
 #[cfg(feature = "async")]
+#[allow(deprecated)]
+pub use rt::async_support::backpressure_set;
+#[cfg(feature = "async")]
 pub use rt::async_support::{
-    backpressure_dec, backpressure_inc, backpressure_set, block_on, spawn, yield_async,
-    yield_blocking, AbiBuffer, FutureRead, FutureReader, FutureWrite, FutureWriteCancel,
-    FutureWriteError, FutureWriter, StreamRead, StreamReader, StreamResult, StreamWrite,
-    StreamWriter,
+    backpressure_dec, backpressure_inc, block_on, spawn, yield_async, yield_blocking, AbiBuffer,
+    FutureRead, FutureReader, FutureWrite, FutureWriteCancel, FutureWriteError, FutureWriter,
+    StreamRead, StreamReader, StreamResult, StreamWrite, StreamWriter,
 };


### PR DESCRIPTION
This enables having a subtask dispatched based on in-memory variable information as opposed to requiring static information up-front. I'm intending to use this for `wit-dylib` over in wasm-tools to prove out some async bits. This'll eventually happen for futures/streams most likely as well, but for now it's just subtasks.

This also shouldn't affect runtime code generated for this crate from before since the types used are all zero-sized and will get elided at runtime. Thus this is intended to enable more use cases without altering existing ones.