### PR TITLE
Emit deallocation instructions for all supported languages

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -1236,16 +1236,25 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 }
 
                 // Free things
-                let mut offset = 0;
-                for (_, ty) in func.params.iter() {
-                    let types = flat_types(self.resolve, ty, Some(max_flat_params))
-                        .expect(&format!("direct parameter load failed to produce types during generation of fn call (func name: '{}')", func.name));
-                    for _ in 0..types.len() {
-                        self.emit(&Instruction::GetArg { nth: offset });
-                        offset += 1;
-                    }
+                if sig.indirect_params {
+                    // self.emit(&Instruction::GetArg { nth: 0 });
+                    // let ElementInfo { size, align } = self
+                    //     .bindgen
+                    //     .sizes()
+                    //     .record(func.params.iter().map(|t| &t.1));
+                    // self.emit(&Instruction::GuestDeallocate { size, align });
+                } else {
+                    let mut offset = 0;
+                    for (_, ty) in func.params.iter() {
+                        let types = flat_types(self.resolve, ty, Some(max_flat_params))
+                            .expect(&format!("direct parameter load failed to produce types during generation of fn call (func name: '{}')", func.name));
+                        for _ in 0..types.len() {
+                            self.emit(&Instruction::GetArg { nth: offset });
+                            offset += 1;
+                        }
 
-                    self.deallocate(ty, Deallocate::Lists);
+                        self.deallocate(ty, Deallocate::Lists);
+                    }
                 }
 
                 // Build and emit the appropriate return


### PR DESCRIPTION
I'm not very satisfied with https://github.com/bytecodealliance/wit-bindgen/pull/1389 because as I wrote, other languages still leaking.
I saw the existence of the following instructions which seems to be not used (or at least I didn't find a way to trigger them).
https://github.com/bytecodealliance/wit-bindgen/blob/545dc8d2281c7cfed1d2b3b9e2b8857f03f46de3/crates/core/src/abi.rs#L525-L557

My proposal is quite simple: parse all sign parameters, push them to the stack and deallocate. This should solve all memory leaks for all languages (a revert of https://github.com/bytecodealliance/wit-bindgen/pull/1389 is necessary btw).

I'm not sure about that `Deallocate::Lists` parameter.
Also the generation fails when the sign is marked as `indirect_params`, not sure how to do procede yet.

Appreciate a feedback!

@jsturtevant @yowl @pavelsavara 