### PR TITLE
Make generated rust async futures Send

### DIFF
--- a/tests/runtime-async/async/rust-lowered-send/runner.rs
+++ b/tests/runtime-async/async/rust-lowered-send/runner.rs
@@ -1,0 +1,21 @@
+include!(env!("BINDINGS"));
+
+use std::future::Future;
+
+use crate::a::b::i::*;
+
+// Explicitly require Send.
+#[allow(dead_code)]
+fn require_send<T: Send>(_t: &T) {}
+
+// This is the type of block_on with a Send requirement added.
+pub fn block_on_require_send<T: 'static>(future: impl Future<Output = T> + Send + 'static) -> T {
+    require_send(&future);
+    wit_bindgen::block_on(future)
+}
+
+fn main() {
+    block_on_require_send(async {
+        one_argument("hello".into()).await;
+    });
+}

--- a/tests/runtime-async/async/rust-lowered-send/test.rs
+++ b/tests/runtime-async/async/rust-lowered-send/test.rs
@@ -1,0 +1,11 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::a::b::i::Guest for Component {
+    async fn one_argument(x: String) {
+        assert_eq!(&x, "hello");
+    }
+}

--- a/tests/runtime-async/async/rust-lowered-send/test.wit
+++ b/tests/runtime-async/async/rust-lowered-send/test.wit
@@ -1,0 +1,13 @@
+package a:b;
+
+interface i {
+  one-argument: async func(x: string);
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+}


### PR DESCRIPTION
The futures for generated rust async bindings were not always Send, because the LoweredParams held a non-Send `*mut u8`. To fix this, explicitly implement Send for LoweredParams. This makes the futures compatible with more of the Rust ecosystem, eg. an axum webserver where all handlers must be Send. This is safe, at least for now, because the generated code is single threaded.

To make LoweredParams Send, change the type from a tuple to a struct which we can explicitly mark as Send. This also requires moving it up a little bit in the generated code outside of the trait impl.

Add a test that asserts the generated binding is Send.