### PR TITLE
Don't enable `macros` feature with `async`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,7 @@ jobs:
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features macros,realloc
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features async
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features async-spawn
+    - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features async,macros
 
     # Verity that documentation can be generated for the rust bindings crate.
     - run: rustup update nightly --no-self-update

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -29,7 +29,7 @@ default = ["macros", "realloc", "async", "std", "bitflags"]
 macros = ["dep:wit-bindgen-rust-macro"]
 realloc = []
 std = []
-async = ["macros", "std", "wit-bindgen-rust-macro/async"]
+async = ["std", "wit-bindgen-rust-macro?/async"]
 bitflags = ["dep:bitflags"]
 async-spawn = ['async', 'dep:futures']
 


### PR DESCRIPTION
That can stay turned off which can help slim down the dependency tree here.