### PR TITLE
fix(cpp): multiversion package support

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -12,7 +12,7 @@ use symbol_name::{make_external_component, make_external_symbol};
 use wit_bindgen_c::to_c_ident;
 use wit_bindgen_core::{
     abi::{self, AbiVariant, Bindgen, Bitcast, LiftLower, WasmSignature, WasmType},
-    uwrite, uwriteln,
+    name_package_module, uwrite, uwriteln,
     wit_parser::{
         Alignment, ArchitectureSize, Docs, Function, FunctionKind, Handle, Int, InterfaceId,
         Resolve, SizeAlign, Stability, Type, TypeDef, TypeDefKind, TypeId, TypeOwner, WorldId,
@@ -741,9 +741,11 @@ fn namespace(resolve: &Resolve, owner: &TypeOwner, guest_export: bool, opts: &Op
         TypeOwner::World(w) => result.push(to_c_ident(&resolve.worlds[*w].name)),
         TypeOwner::Interface(i) => {
             let iface = &resolve.interfaces[*i];
-            let pkg = &resolve.packages[iface.package.unwrap()];
+            let pkg_id = iface.package.unwrap();
+            let pkg = &resolve.packages[pkg_id];
             result.push(to_c_ident(&pkg.name.namespace));
-            result.push(to_c_ident(&pkg.name.name));
+            // Use name_package_module to get version-specific package names
+            result.push(to_c_ident(&name_package_module(resolve, pkg_id)));
             if let Some(name) = &iface.name {
                 result.push(to_c_ident(name));
             }

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -49,7 +49,6 @@ impl LanguageMethods for Cpp {
             "async-trait-function.wit"
             | "error-context.wit"
             | "futures.wit"
-            | "multiversion"
             | "resources-with-futures.wit"
             | "resources-with-streams.wit"
             | "streams.wit" => true,


### PR DESCRIPTION
This fixes the last remaining non-async codegen test case for `cpp`.

@cpetig since you already have a wip on async, I think this will be my last cpp fix for a bit unless of course I run into problems while exercising it. I think we're feature complete for WASIP2.
