### PR TITLE
Relax a trait bound for futures

### DIFF
--- a/crates/guest-rust/src/rt/async_support/future_support.rs
+++ b/crates/guest-rust/src/rt/async_support/future_support.rs
@@ -209,7 +209,7 @@ pub struct FutureVtable<T> {
     pub new: unsafe extern "C" fn() -> u64,
 }
 
-impl<T> FutureOps for &'static FutureVtable<T> {
+impl<T> FutureOps for &FutureVtable<T> {
     type Payload = T;
 
     fn new(&mut self) -> u64 {


### PR DESCRIPTION
Required to update wit-bindgen in the `wasip3` crate. Seems like a possible rustc bug? Unsure...