### PR TITLE
rust: Fix receiving async events in busy yield loops

### DIFF
--- a/crates/guest-rust/src/rt/async_support/waitable_set.rs
+++ b/crates/guest-rust/src/rt/async_support/waitable_set.rs
@@ -17,13 +17,14 @@ impl WaitableSet {
     }
 
     pub fn remove_waitable_from_all_sets(waitable: u32) {
-        rtdebug!("waitable-set.join({waitable}, 0)");
+        rtdebug!("waitable.join({waitable}, 0)");
         unsafe { join(waitable, 0) }
     }
 
     pub fn wait(&self) -> (u32, u32, u32) {
         unsafe {
             let mut payload = [0; 2];
+            rtdebug!("waitable-set.wait({}) = ...", self.0.get());
             let event0 = wait(self.0.get(), &mut payload);
             rtdebug!(
                 "waitable-set.wait({}) = ({event0}, {:#x}, {:#x})",
@@ -38,6 +39,7 @@ impl WaitableSet {
     pub fn poll(&self) -> (u32, u32, u32) {
         unsafe {
             let mut payload = [0; 2];
+            rtdebug!("waitable-set.poll({}) = ...", self.0.get());
             let event0 = poll(self.0.get(), &mut payload);
             rtdebug!(
                 "waitable-set.poll({}) = ({event0}, {:#x}, {:#x})",

--- a/tests/runtime-async/async/yield-loop-receives-events/leaf.rs
+++ b/tests/runtime-async/async/yield-loop-receives-events/leaf.rs
@@ -1,0 +1,13 @@
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl crate::exports::test::common::i_middle::Guest for Component {
+    async fn f() {
+        for _ in 0..2 {
+            wit_bindgen::yield_async().await;
+        }
+    }
+}

--- a/tests/runtime-async/async/yield-loop-receives-events/middle.rs
+++ b/tests/runtime-async/async/yield-loop-receives-events/middle.rs
@@ -1,0 +1,34 @@
+include!(env!("BINDINGS"));
+
+use crate::test::common::i_middle::f;
+use std::task::Poll;
+
+pub struct Component;
+
+export!(Component);
+
+static mut HIT: bool = false;
+
+impl crate::exports::test::common::i_runner::Guest for Component {
+    async fn f() {
+        wit_bindgen::spawn(async move {
+            f().await;
+            unsafe {
+                HIT = true;
+            }
+        });
+
+        // This is an "infinite loop" but it's also effectively a yield which
+        // should enable not only making progress on sibling rust-level tasks
+        // but additionally async events should be deliverable.
+        std::future::poll_fn(|cx| unsafe {
+            if HIT {
+                Poll::Ready(())
+            } else {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+}

--- a/tests/runtime-async/async/yield-loop-receives-events/runner.rs
+++ b/tests/runtime-async/async/yield-loop-receives-events/runner.rs
@@ -1,0 +1,7 @@
+include!(env!("BINDINGS"));
+
+fn main() {
+    wit_bindgen::block_on(async {
+        crate::test::common::i_runner::f().await;
+    });
+}

--- a/tests/runtime-async/async/yield-loop-receives-events/test.wit
+++ b/tests/runtime-async/async/yield-loop-receives-events/test.wit
@@ -1,0 +1,24 @@
+//@ dependencies = ['middle', 'leaf']
+
+package test:common;
+
+world runner {
+    import i-runner;
+}
+
+interface i-runner {
+    f: async func();
+}
+
+world middle {
+    export i-runner;
+    import i-middle;
+}
+
+interface i-middle {
+    f: async func();
+}
+
+world leaf {
+    export i-middle;
+}


### PR DESCRIPTION
This commit fixes an issue with the rust async support where when a yield-loop was detected it suspended with `CALLBACK_CODE_YIELD` which meant that it wasn't possible to deliver async events for other async operations in progress. The fix is to instead return `CALLBACK_CODE_POLL` with the waitable-set that has all the waitables inside of it. This enables delivery of async events from that set to ensure that if the yielding task is waiting on something else that it gets delivered.

This also refactors a few things here and there, such as `CALLBACK_CODE_*`, to be less error prone. Support was added for composing 3+ components with `wasm-compose` since `wac` doesn't yet use the same `wasm-tools`.