### PR TITLE
Always build all tests as a "reactor"

### DIFF
--- a/crates/test/src/c.rs
+++ b/crates/test/src/c.rs
@@ -1,5 +1,5 @@
 use crate::config::StringList;
-use crate::{Compile, Kind, LanguageMethods, Runner, Verify};
+use crate::{Compile, LanguageMethods, Runner, Verify};
 use anyhow::{Context, Result};
 use clap::Parser;
 use heck::ToSnakeCase;
@@ -144,12 +144,7 @@ fn compile(runner: &Runner<'_>, compile: &Compile<'_>, compiler: PathBuf) -> Res
     for flag in Vec::from(config.cflags) {
         cmd.arg(flag);
     }
-    match compile.component.kind {
-        Kind::Runner => {}
-        Kind::Test => {
-            cmd.arg("-mexec-model=reactor");
-        }
-    }
+    cmd.arg("-mexec-model=reactor");
     if produces_component(runner) {
         cmd.arg("-Wl,--skip-wit-component");
     }

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -1,5 +1,5 @@
 use crate::config::StringList;
-use crate::{Kind, LanguageMethods, Runner};
+use crate::{LanguageMethods, Runner};
 use anyhow::Context;
 use heck::ToSnakeCase;
 use serde::Deserialize;
@@ -174,12 +174,7 @@ impl LanguageMethods for Cpp {
         for flag in Vec::from(config.cflags) {
             cmd.arg(flag);
         }
-        match compile.component.kind {
-            Kind::Runner => {}
-            Kind::Test => {
-                cmd.arg("-mexec-model=reactor");
-            }
-        }
+        cmd.arg("-mexec-model=reactor");
         runner.run_command(&mut cmd)?;
         Ok(())
     }

--- a/crates/test/src/csharp.rs
+++ b/crates/test/src/csharp.rs
@@ -1,4 +1,4 @@
-use crate::{Compile, Kind, LanguageMethods, Runner, Verify};
+use crate::{Compile, LanguageMethods, Runner, Verify};
 use anyhow::Result;
 use heck::*;
 use std::env;
@@ -75,9 +75,6 @@ impl LanguageMethods for Csharp {
         let mut csproj =
             wit_bindgen_csharp::CSProject::new(test_dir.to_path_buf(), &assembly_name, world_name);
         csproj.aot();
-        if let Kind::Runner = compile.component.kind {
-            csproj.binary();
-        }
         csproj.generate()?;
 
         let mut cmd = dotnet();

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -1030,14 +1030,8 @@ status: {}",
             section.encode(&mut module);
         }
 
-        let wasi_adapter = match compile.component.kind {
-            Kind::Runner => {
-                wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_COMMAND_ADAPTER
-            }
-            Kind::Test => {
-                wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER
-            }
-        };
+        let wasi_adapter =
+            wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER;
 
         let component = ComponentEncoder::default()
             .module(module.as_slice())

--- a/crates/test/src/runner.rs
+++ b/crates/test/src/runner.rs
@@ -45,6 +45,7 @@ impl TestRunner {
         for arg in self.args.iter() {
             ret.arg(arg);
         }
+        ret.arg("--invoke=run()");
         ret
     }
 }

--- a/crates/test/src/rust.rs
+++ b/crates/test/src/rust.rs
@@ -1,5 +1,5 @@
 use crate::config::StringList;
-use crate::{Compile, Kind, LanguageMethods, Runner, Verify};
+use crate::{Compile, LanguageMethods, Runner, Verify};
 use anyhow::{Context, Result};
 use clap::Parser;
 use heck::ToSnakeCase;
@@ -206,12 +206,7 @@ path = 'lib.rs'
             let arg = format!("--extern={name}={}", path.display());
             cmd.arg(arg);
         }
-        match compile.component.kind {
-            Kind::Runner => {}
-            Kind::Test => {
-                cmd.arg("--crate-type=cdylib");
-            }
-        }
+        cmd.arg("--crate-type=cdylib");
         if runner.produces_component() {
             cmd.arg("-Clink-arg=--skip-wit-component");
         }

--- a/tests/runtime-async/async/cancel-import/runner.c
+++ b/tests/runtime-async/async/cancel-import/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   // Call an import and cancel it.
   {
     test_future_void_writer_t writer;

--- a/tests/runtime-async/async/cancel-import/runner.rs
+++ b/tests/runtime-async/async/cancel-import/runner.rs
@@ -6,128 +6,134 @@ use std::future::Future;
 use std::task::Context;
 use wit_bindgen::yield_async;
 
-fn main() {
-    println!("test cancelling an import in progress");
-    wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
-        let mut import = Box::pin(pending_import(rx));
-        assert!(import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-        drop(import);
-        tx.write(()).await.unwrap_err();
-    });
+struct Component;
 
-    println!("test cancelling an import before it starts");
-    wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
-        let import = Box::pin(pending_import(rx));
-        drop(import);
-        tx.write(()).await.unwrap_err();
-    });
+export!(Component);
 
-    println!("test cancelling an import in the started state");
-    wit_bindgen::block_on(async {
-        let (tx1, rx1) = wit_future::new(|| unreachable!());
-        let (tx2, rx2) = wit_future::new(|| unreachable!());
-
-        // create a task in the "started" state, but don't complete it yet
-        let mut started_import = Box::pin(pending_import(rx1));
-        assert!(started_import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-
-        // request the other component sets its backpressure flag meaning we
-        // won't be able to create new tasks in the "started" state.
-        backpressure_set(true);
-        let mut starting_import = Box::pin(pending_import(rx2));
-        assert!(starting_import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-
-        // Now cancel the "starting" import. This should notably drop handles in
-        // arguments since they get re-acquired during cancellation
-        drop(starting_import);
-
-        // cancel our in-progress export
-        drop(started_import);
-
-        backpressure_set(false);
-
-        // both channels should be dropped
-        tx1.write(()).await.unwrap_err();
-        tx2.write(()).await.unwrap_err();
-    });
-
-    // Race an import's cancellation with a status code saying it's done.
-    println!("test cancellation with a status code saying it's done");
-    wit_bindgen::block_on(async {
-        // Start a subtask and get it into the "started" state
-        let (tx, rx) = wit_future::new(|| unreachable!());
-        let mut import = Box::pin(pending_import(rx));
-        assert!(import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-
-        // Complete the subtask, but don't see the completion in Rust yet.
-        tx.write(()).await.unwrap();
-
-        // Let the subtask's completion notification make its way to our task
-        // here.
-        for _ in 0..5 {
-            yield_async().await;
+impl Guest for Component {
+    async fn run() {
+        println!("test cancelling an import in progress");
+        {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+            let mut import = Box::pin(pending_import(rx));
+            assert!(import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            drop(import);
+            tx.write(()).await.unwrap_err();
         }
 
-        // Now cancel the import, despite it actually being done. This should
-        // realize that the cancellation is racing completion.
-        drop(import);
-    });
-
-    // Race an import's cancellation with a pending status code indicating that
-    // it's transitioning from started => returned.
-    println!("race cancellation with pending status code");
-    wit_bindgen::block_on(async {
-        // Start a subtask and get it into the "started" state
-        let (tx1, rx1) = wit_future::new(|| unreachable!());
-        let mut started_import = Box::pin(pending_import(rx1));
-        assert!(started_import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-
-        // force the next subtask to start out in the "starting" state, not the
-        // "started" state.
-        backpressure_set(true);
-        let (tx2, rx2) = wit_future::new(|| unreachable!());
-        let mut starting_import = Box::pin(pending_import(rx2));
-        assert!(starting_import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-
-        // Disable backpressure in the other component which will let the
-        // `starting_import`, previously in the "STARTING" state, get a queued up
-        // notification that it's entered the "STARTED" state.
-        backpressure_set(false);
-        for _ in 0..5 {
-            yield_async().await;
+        println!("test cancelling an import before it starts");
+        {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+            let import = Box::pin(pending_import(rx));
+            drop(import);
+            tx.write(()).await.unwrap_err();
         }
 
-        // Now cancel the `starting_import`. This should correctly pick up the
-        // STARTING => STARTED state transition and handle that correctly.
-        drop(starting_import);
+        println!("test cancelling an import in the started state");
+        {
+            let (tx1, rx1) = wit_future::new(|| unreachable!());
+            let (tx2, rx2) = wit_future::new(|| unreachable!());
 
-        // Our future to the import we cancelled shouldn't be able to complete
-        // its write.
-        tx2.write(()).await.unwrap_err();
+            // create a task in the "started" state, but don't complete it yet
+            let mut started_import = Box::pin(pending_import(rx1));
+            assert!(started_import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
 
-        // Complete the other import normally just to assert that it's not
-        // cancelled and able to proceed as usual.
-        tx1.write(()).await.unwrap();
-        started_import.await;
-    });
+            // request the other component sets its backpressure flag meaning we
+            // won't be able to create new tasks in the "started" state.
+            backpressure_set(true);
+            let mut starting_import = Box::pin(pending_import(rx2));
+            assert!(starting_import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+
+            // Now cancel the "starting" import. This should notably drop handles in
+            // arguments since they get re-acquired during cancellation
+            drop(starting_import);
+
+            // cancel our in-progress export
+            drop(started_import);
+
+            backpressure_set(false);
+
+            // both channels should be dropped
+            tx1.write(()).await.unwrap_err();
+            tx2.write(()).await.unwrap_err();
+        }
+
+        // Race an import's cancellation with a status code saying it's done.
+        println!("test cancellation with a status code saying it's done");
+        {
+            // Start a subtask and get it into the "started" state
+            let (tx, rx) = wit_future::new(|| unreachable!());
+            let mut import = Box::pin(pending_import(rx));
+            assert!(import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+
+            // Complete the subtask, but don't see the completion in Rust yet.
+            tx.write(()).await.unwrap();
+
+            // Let the subtask's completion notification make its way to our task
+            // here.
+            for _ in 0..5 {
+                yield_async().await;
+            }
+
+            // Now cancel the import, despite it actually being done. This should
+            // realize that the cancellation is racing completion.
+            drop(import);
+        }
+
+        // Race an import's cancellation with a pending status code indicating that
+        // it's transitioning from started => returned.
+        println!("race cancellation with pending status code");
+        {
+            // Start a subtask and get it into the "started" state
+            let (tx1, rx1) = wit_future::new(|| unreachable!());
+            let mut started_import = Box::pin(pending_import(rx1));
+            assert!(started_import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+
+            // force the next subtask to start out in the "starting" state, not the
+            // "started" state.
+            backpressure_set(true);
+            let (tx2, rx2) = wit_future::new(|| unreachable!());
+            let mut starting_import = Box::pin(pending_import(rx2));
+            assert!(starting_import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+
+            // Disable backpressure in the other component which will let the
+            // `starting_import`, previously in the "STARTING" state, get a queued up
+            // notification that it's entered the "STARTED" state.
+            backpressure_set(false);
+            for _ in 0..5 {
+                yield_async().await;
+            }
+
+            // Now cancel the `starting_import`. This should correctly pick up the
+            // STARTING => STARTED state transition and handle that correctly.
+            drop(starting_import);
+
+            // Our future to the import we cancelled shouldn't be able to complete
+            // its write.
+            tx2.write(()).await.unwrap_err();
+
+            // Complete the other import normally just to assert that it's not
+            // cancelled and able to proceed as usual.
+            tx1.write(()).await.unwrap();
+            started_import.await;
+        }
+    }
 }

--- a/tests/runtime-async/async/cancel-import/test.wit
+++ b/tests/runtime-async/async/cancel-import/test.wit
@@ -11,4 +11,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-cancel-read/runner.c
+++ b/tests/runtime-async/async/future-cancel-read/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   {
     test_future_u32_writer_t writer;
     test_future_u32_t reader = test_future_u32_new(&writer);

--- a/tests/runtime-async/async/future-cancel-read/runner.rs
+++ b/tests/runtime-async/async/future-cancel-read/runner.rs
@@ -2,8 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::my::test::i::*;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| 0);
         cancel_before_read(rx).await;
         drop(tx);
@@ -18,5 +22,5 @@ fn main() {
             signal_tx.write(()).await.unwrap();
             data_tx.write(4).await.unwrap();
         });
-    });
+    }
 }

--- a/tests/runtime-async/async/future-cancel-read/test.wit
+++ b/tests/runtime-async/async/future-cancel-read/test.wit
@@ -15,4 +15,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-cancel-write-then-read/runner.rs
+++ b/tests/runtime-async/async/future-cancel-write-then-read/runner.rs
@@ -2,12 +2,16 @@ include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::f;
 
-fn main() {
-    wit_bindgen::block_on(async move {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| 0);
 
         drop(tx.write(4));
 
         f(rx).await;
-    });
+    }
 }

--- a/tests/runtime-async/async/future-cancel-write-then-read/test.wit
+++ b/tests/runtime-async/async/future-cancel-write-then-read/test.wit
@@ -9,4 +9,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-cancel-write/runner.c
+++ b/tests/runtime-async/async/future-cancel-write/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   runner_event_t event;
   runner_waitable_set_t set = runner_waitable_set_new();
   runner_string_t string;

--- a/tests/runtime-async/async/future-cancel-write/runner.rs
+++ b/tests/runtime-async/async/future-cancel-write/runner.rs
@@ -6,8 +6,12 @@ use std::future::Future;
 use std::task::Context;
 use wit_bindgen::FutureWriteCancel;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         // cancel from the other end
         let (tx, rx) = wit_future::new(|| unreachable!());
         let f1 = async { tx.write("hello".into()).await };
@@ -66,5 +70,5 @@ fn main() {
             FutureWriteCancel::AlreadySent => {}
             other => panic!("expected sent, got: {other:?}"),
         };
-    });
+    }
 }

--- a/tests/runtime-async/async/future-cancel-write/test.wit
+++ b/tests/runtime-async/async/future-cancel-write/test.wit
@@ -11,4 +11,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-close-after-coming-back/runner.rs
+++ b/tests/runtime-async/async/future-close-after-coming-back/runner.rs
@@ -2,10 +2,16 @@ include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::f;
 
-fn main() {
-    let (tx, rx) = wit_future::new(|| ());
+struct Component;
 
-    let rx = f(rx);
-    drop(rx);
-    drop(tx);
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
+        let (tx, rx) = wit_future::new(|| ());
+
+        let rx = f(rx);
+        drop(rx);
+        drop(tx);
+    }
 }

--- a/tests/runtime-async/async/future-close-after-coming-back/test.wit
+++ b/tests/runtime-async/async/future-close-after-coming-back/test.wit
@@ -9,4 +9,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-close-then-receive-read/runner.rs
+++ b/tests/runtime-async/async/future-close-then-receive-read/runner.rs
@@ -2,14 +2,20 @@ include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::{get, set};
 
-fn main() {
-    let (tx, rx) = wit_future::new(|| ());
+struct Component;
 
-    set(rx);
-    let rx = get();
-    drop(rx);
-    drop(tx);
+export!(Component);
 
-    let (_tx, rx) = wit_future::new::<()>(|| ());
-    drop(rx);
+impl Guest for Component {
+    async fn run() {
+        let (tx, rx) = wit_future::new(|| ());
+
+        set(rx);
+        let rx = get();
+        drop(rx);
+        drop(tx);
+
+        let (_tx, rx) = wit_future::new::<()>(|| ());
+        drop(rx);
+    }
 }

--- a/tests/runtime-async/async/future-close-then-receive-read/test.wit
+++ b/tests/runtime-async/async/future-close-then-receive-read/test.wit
@@ -10,4 +10,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-closes-with-error/runner.rs
+++ b/tests/runtime-async/async/future-closes-with-error/runner.rs
@@ -2,12 +2,16 @@ include!(env!("BINDINGS"));
 
 use crate::a::b::the_test::f;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| ());
 
         drop(tx);
 
         f(rx).await;
-    });
+    }
 }

--- a/tests/runtime-async/async/future-closes-with-error/test.wit
+++ b/tests/runtime-async/async/future-closes-with-error/test.wit
@@ -9,4 +9,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-write-then-read-comes-back/runner.rs
+++ b/tests/runtime-async/async/future-write-then-read-comes-back/runner.rs
@@ -1,16 +1,18 @@
 include!(env!("BINDINGS"));
 
-use wit_bindgen::rt::async_support;
-
 use crate::a::b::the_test::f;
 
-fn main() {
-    async_support::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| unreachable!());
 
         let a = async { tx.write(()).await };
         let b = async { f(rx).await };
         let (a_result, ()) = futures::join!(a, b);
         a_result.unwrap()
-    });
+    }
 }

--- a/tests/runtime-async/async/future-write-then-read-comes-back/test.wit
+++ b/tests/runtime-async/async/future-write-then-read-comes-back/test.wit
@@ -9,4 +9,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/future-write-then-read-remote/runner.rs
+++ b/tests/runtime-async/async/future-write-then-read-remote/runner.rs
@@ -2,17 +2,21 @@
 
 include!(env!("BINDINGS"));
 
-use wit_bindgen::rt::async_support;
-
 use crate::a::b::the_test::f;
 
-fn main() {
-    async_support::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
+struct Component;
 
-        let a = async { tx.write(()).await };
-        let b = async { f(rx) };
-        let (a_result, ()) = futures::join!(a, b);
-        a_result.unwrap();
-    });
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        wit_bindgen::block_on(async {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+
+            let a = async { tx.write(()).await };
+            let b = async { f(rx) };
+            let (a_result, ()) = futures::join!(a, b);
+            a_result.unwrap();
+        });
+    }
 }

--- a/tests/runtime-async/async/future-write-then-read-remote/runner2.rs
+++ b/tests/runtime-async/async/future-write-then-read-remote/runner2.rs
@@ -2,17 +2,21 @@
 
 include!(env!("BINDINGS"));
 
-use wit_bindgen::rt::async_support;
-
 use crate::a::b::the_test::f;
 
-fn main() {
-    async_support::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
+struct Component;
 
-        let a = tx.write(());
-        let b = async { f(rx) };
-        let (a_result, ()) = futures::join!(a, b);
-        a_result.unwrap();
-    });
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        wit_bindgen::block_on(async {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+
+            let a = tx.write(());
+            let b = async { f(rx) };
+            let (a_result, ()) = futures::join!(a, b);
+            a_result.unwrap();
+        });
+    }
 }

--- a/tests/runtime-async/async/future-write-then-read-remote/test.wit
+++ b/tests/runtime-async/async/future-write-then-read-remote/test.wit
@@ -9,4 +9,6 @@ world test {
 }
 world runner {
   import the-test;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/pending-import/runner.c
+++ b/tests/runtime-async/async/pending-import/runner.c
@@ -1,10 +1,10 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <assert.h>
 #include <runner.h>
 #include <stdio.h>
 
-int main() {
+void exports_runner_run() {
   test_future_void_writer_t writer;
   test_future_void_t reader = test_future_void_new(&writer);
   runner_subtask_status_t status = test_pending_import(reader);

--- a/tests/runtime-async/async/pending-import/runner.rs
+++ b/tests/runtime-async/async/pending-import/runner.rs
@@ -6,39 +6,45 @@ use std::future::Future;
 use std::task::Context;
 use wit_bindgen::yield_async;
 
-fn main() {
-    // Test that Rust-level polling twice works.
-    wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
-        let mut import = Box::pin(pending_import(rx));
-        assert!(import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-        assert!(import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-        tx.write(()).await.unwrap();
-        import.await;
-    });
+struct Component;
 
-    // Start the imported function call, get it pending, then let it complete by
-    // finishing `tx`, then yield a few times to ensure that the runtime gets
-    // the completion of the task-at-hand, and then drop it without completing
-    // it.
-    wit_bindgen::block_on(async {
-        let (tx, rx) = wit_future::new(|| unreachable!());
-        let mut import = Box::pin(pending_import(rx));
-        assert!(import
-            .as_mut()
-            .poll(&mut Context::from_waker(noop_waker_ref()))
-            .is_pending());
-        tx.write(()).await.unwrap();
+export!(Component);
 
-        for _ in 0..5 {
-            yield_async().await;
+impl Guest for Component {
+    async fn run() {
+        // Test that Rust-level polling twice works.
+        {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+            let mut import = Box::pin(pending_import(rx));
+            assert!(import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            assert!(import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            tx.write(()).await.unwrap();
+            import.await;
         }
-        drop(import);
-    });
+
+        // Start the imported function call, get it pending, then let it complete by
+        // finishing `tx`, then yield a few times to ensure that the runtime gets
+        // the completion of the task-at-hand, and then drop it without completing
+        // it.
+        {
+            let (tx, rx) = wit_future::new(|| unreachable!());
+            let mut import = Box::pin(pending_import(rx));
+            assert!(import
+                .as_mut()
+                .poll(&mut Context::from_waker(noop_waker_ref()))
+                .is_pending());
+            tx.write(()).await.unwrap();
+
+            for _ in 0..5 {
+                yield_async().await;
+            }
+            drop(import);
+        }
+    }
 }

--- a/tests/runtime-async/async/pending-import/test.wit
+++ b/tests/runtime-async/async/pending-import/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/ping-pong/runner.c
+++ b/tests/runtime-async/async/ping-pong/runner.c
@@ -1,10 +1,10 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <assert.h>
 #include <string.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   test_future_string_writer_t writer;
   test_future_string_t reader = test_future_string_new(&writer);
 

--- a/tests/runtime-async/async/ping-pong/runner.rs
+++ b/tests/runtime-async/async/ping-pong/runner.rs
@@ -2,8 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::my::test::i::{ping, pong};
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| unreachable!());
         let f1 = ping(rx, "world".into());
         let f2 = async { tx.write("hello".into()).await.unwrap() };
@@ -18,5 +22,5 @@ fn main() {
         };
         let f2 = async { tx.write(m2).await.unwrap() };
         let ((), ()) = futures::join!(f1, f2);
-    });
+    }
 }

--- a/tests/runtime-async/async/ping-pong/test.wit
+++ b/tests/runtime-async/async/ping-pong/test.wit
@@ -11,4 +11,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/rust-cross-task-wakeup/runner.rs
+++ b/tests/runtime-async/async/rust-cross-task-wakeup/runner.rs
@@ -3,8 +3,12 @@ include!(env!("BINDINGS"));
 use crate::my::test::i::*;
 use wit_bindgen::yield_async;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         futures::join! {
             async {
                 pending_import().await;
@@ -18,6 +22,6 @@ fn main() {
                 }
                 resolve_pending_import();
             },
-        }
-    });
+        };
+    }
 }

--- a/tests/runtime-async/async/rust-cross-task-wakeup/test.wit
+++ b/tests/runtime-async/async/rust-cross-task-wakeup/test.wit
@@ -11,4 +11,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/rust-lowered-send/runner.rs
+++ b/tests/runtime-async/async/rust-lowered-send/runner.rs
@@ -1,21 +1,21 @@
 include!(env!("BINDINGS"));
 
-use std::future::Future;
-
 use crate::a::b::i::*;
 
 // Explicitly require Send.
-#[allow(dead_code)]
-fn require_send<T: Send>(_t: &T) {}
-
-// This is the type of block_on with a Send requirement added.
-pub fn block_on_require_send<T: 'static>(future: impl Future<Output = T> + Send + 'static) -> T {
-    require_send(&future);
-    wit_bindgen::block_on(future)
+fn require_send<T: Send>(t: T) -> T {
+    t
 }
 
-fn main() {
-    block_on_require_send(async {
-        one_argument("hello".into()).await;
-    });
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
+        require_send(async {
+            one_argument("hello".into()).await;
+        })
+        .await;
+    }
 }

--- a/tests/runtime-async/async/rust-lowered-send/test.wit
+++ b/tests/runtime-async/async/rust-lowered-send/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-call-import/runner.c
+++ b/tests/runtime-async/async/simple-call-import/runner.c
@@ -1,8 +1,8 @@
-//@ args = '--rename a:b/i=test'
+//@ args = '--rename a:b/i=test --async=-run'
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   runner_subtask_status_t status = test_f();
   assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
   assert(RUNNER_SUBTASK_HANDLE(status) == 0);

--- a/tests/runtime-async/async/simple-call-import/runner.rs
+++ b/tests/runtime-async/async/simple-call-import/runner.rs
@@ -1,7 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         crate::a::b::i::f().await;
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-call-import/test.wit
+++ b/tests/runtime-async/async/simple-call-import/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-future/runner.c
+++ b/tests/runtime-async/async/simple-future/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <runner.h>
 #include <assert.h>
 
-int main() {
+void exports_runner_run() {
   {
     test_future_void_writer_t writer;
     test_future_void_t reader = test_future_void_new(&writer);

--- a/tests/runtime-async/async/simple-future/runner.rs
+++ b/tests/runtime-async/async/simple-future/runner.rs
@@ -2,8 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::my::test::i::*;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (tx, rx) = wit_future::new(|| unreachable!());
         let (res, ()) = futures::join!(tx.write(()), read_future(rx));
         assert!(res.is_ok());
@@ -11,5 +15,5 @@ fn main() {
         let (tx, rx) = wit_future::new(|| unreachable!());
         let (res, ()) = futures::join!(tx.write(()), drop_future(rx));
         assert!(res.is_err());
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-future/test.wit
+++ b/tests/runtime-async/async/simple-future/test.wit
@@ -11,4 +11,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-import-params-results/runner.c
+++ b/tests/runtime-async/async/simple-import-params-results/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename a:b/i=test'
+//@ args = '--rename a:b/i=test --async=-run'
 
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   runner_subtask_status_t status = test_one_argument(1);
   assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_RETURNED);
   assert(RUNNER_SUBTASK_HANDLE(status) == 0);

--- a/tests/runtime-async/async/simple-import-params-results/runner.rs
+++ b/tests/runtime-async/async/simple-import-params-results/runner.rs
@@ -2,12 +2,16 @@ include!(env!("BINDINGS"));
 
 use crate::a::b::i::*;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         one_argument(1).await;
         assert_eq!(one_result().await, 2);
         assert_eq!(one_argument_and_result(3).await, 4);
         two_arguments(5, 6).await;
         assert_eq!(two_arguments_and_result(7, 8).await, 9);
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-import-params-results/test.wit
+++ b/tests/runtime-async/async/simple-import-params-results/test.wit
@@ -14,4 +14,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-pending-import/runner.c
+++ b/tests/runtime-async/async/simple-pending-import/runner.c
@@ -1,8 +1,8 @@
-//@ args = '--rename a:b/i=test'
+//@ args = '--rename a:b/i=test --async=-run'
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   runner_subtask_status_t status = test_f();
   assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
   runner_subtask_t handle = RUNNER_SUBTASK_HANDLE(status);

--- a/tests/runtime-async/async/simple-pending-import/runner.rs
+++ b/tests/runtime-async/async/simple-pending-import/runner.rs
@@ -1,7 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         crate::a::b::i::f().await;
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-pending-import/test.wit
+++ b/tests/runtime-async/async/simple-pending-import/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-stream-payload/runner.c
+++ b/tests/runtime-async/async/simple-stream-payload/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <runner.h>
 #include <assert.h>
 
-int main() {
+void exports_runner_run() {
   test_stream_u8_writer_t writer;
   test_stream_u8_t reader = test_stream_u8_new(&writer);
   uint8_t buf[2];

--- a/tests/runtime-async/async/simple-stream-payload/runner.rs
+++ b/tests/runtime-async/async/simple-stream-payload/runner.rs
@@ -3,8 +3,12 @@ include!(env!("BINDINGS"));
 use crate::my::test::i::*;
 use wit_bindgen::StreamResult;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (mut tx, rx) = wit_stream::new();
         let test = async {
             // write one item
@@ -28,5 +32,5 @@ fn main() {
             assert_eq!(ret.remaining(), 1);
         };
         let ((), ()) = futures::join!(test, read_stream(rx));
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-stream-payload/test.wit
+++ b/tests/runtime-async/async/simple-stream-payload/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-stream/runner.c
+++ b/tests/runtime-async/async/simple-stream/runner.c
@@ -1,9 +1,9 @@
-//@ args = '--rename my:test/i=test'
+//@ args = '--rename my:test/i=test --async=-run'
 
 #include <runner.h>
 #include <assert.h>
 
-int main() {
+void exports_runner_run() {
   test_stream_void_writer_t writer;
   test_stream_void_t reader = test_stream_void_new(&writer);
 

--- a/tests/runtime-async/async/simple-stream/runner.rs
+++ b/tests/runtime-async/async/simple-stream/runner.rs
@@ -3,8 +3,12 @@ include!(env!("BINDINGS"));
 use crate::my::test::i::*;
 use wit_bindgen::StreamResult;
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         let (mut tx, rx) = wit_stream::new();
         let test = async {
             // write one item
@@ -23,5 +27,5 @@ fn main() {
             assert_eq!(ret.remaining(), 2);
         };
         let ((), ()) = futures::join!(test, read_stream(rx));
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-stream/test.wit
+++ b/tests/runtime-async/async/simple-stream/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/simple-yield/runner.c
+++ b/tests/runtime-async/async/simple-yield/runner.c
@@ -1,8 +1,8 @@
-//@ args = '--rename a:b/i=test'
+//@ args = '--rename a:b/i=test --async=-run'
 #include <assert.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   runner_subtask_status_t status = test_f();
   assert(RUNNER_SUBTASK_STATE(status) == RUNNER_SUBTASK_STARTED);
   runner_subtask_t task = RUNNER_SUBTASK_HANDLE(status);

--- a/tests/runtime-async/async/simple-yield/runner.rs
+++ b/tests/runtime-async/async/simple-yield/runner.rs
@@ -1,7 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         crate::a::b::i::f().await;
-    });
+    }
 }

--- a/tests/runtime-async/async/simple-yield/test.wit
+++ b/tests/runtime-async/async/simple-yield/test.wit
@@ -10,4 +10,6 @@ world test {
 
 world runner {
   import i;
+
+  export run: async func();
 }

--- a/tests/runtime-async/async/yield-loop-receives-events/runner.rs
+++ b/tests/runtime-async/async/yield-loop-receives-events/runner.rs
@@ -1,7 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    wit_bindgen::block_on(async {
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn run() {
         crate::test::common::i_runner::f().await;
-    });
+    }
 }

--- a/tests/runtime-async/async/yield-loop-receives-events/test.wit
+++ b/tests/runtime-async/async/yield-loop-receives-events/test.wit
@@ -4,6 +4,8 @@ package test:common;
 
 world runner {
     import i-runner;
+
+    export run: async func();
 }
 
 interface i-runner {

--- a/tests/runtime/c/autodrop-borrows/runner.c
+++ b/tests/runtime/c/autodrop-borrows/runner.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include "runner.h"
 
-int main() {
+void exports_runner_run() {
     test_resource_borrow_imported_test_own_thing_t thing = test_resource_borrow_imported_test_constructor_thing();
     assert(thing.__handle != 0);
 

--- a/tests/runtime/c/autodrop-borrows/test.wit
+++ b/tests/runtime/c/autodrop-borrows/test.wit
@@ -36,4 +36,6 @@ world runner {
   import test;
   import autodrop-borrow-thing;
   import borrow-thing;
+
+  export run: func();
 }

--- a/tests/runtime/c/rename/runner.c
+++ b/tests/runtime/c/rename/runner.c
@@ -2,8 +2,7 @@
 
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
     rename3_f();
     rename4_f();
-    return 0;
 }

--- a/tests/runtime/c/rename/test.wit
+++ b/tests/runtime/c/rename/test.wit
@@ -9,6 +9,8 @@ world runner {
     f: func();
   }
   import b;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/common-types/runner.cpp
+++ b/tests/runtime/common-types/runner.cpp
@@ -1,9 +1,9 @@
 #include <assert.h>
 #include <runner_cpp.h>
 
-int main() {
+void exports::runner::Run() {
     using namespace ::test::common::test_types;
-    
+
     R1 res = test::common::to_test::Wrap(F1::kA);
     assert(res.b == F1::kA);
     assert(res.a == 1);
@@ -15,6 +15,4 @@ int main() {
     V1 res3 = test::common::to_test::VarF();
     assert(res3.variants.index() == 1);
     assert(std::get<1>(res3.variants).value == 42);
-
-    return 0;
 }

--- a/tests/runtime/common-types/test.wit
+++ b/tests/runtime/common-types/test.wit
@@ -27,4 +27,6 @@ world middle {
 
 world runner {
     import to-test;
+
+    export run: func();
 }

--- a/tests/runtime/cpp/param-ownership/runner-coarse-borrowing.cpp
+++ b/tests/runtime/cpp/param-ownership/runner-coarse-borrowing.cpp
@@ -2,7 +2,8 @@
 
 #include "runner_cpp.h"
 #include <array>
-int main() {
+
+void exports::runner::Run() {
   std::array<std::string_view, 2> a1 = {"value1", "value2"};
   std::array<std::string_view, 2> a2 = {"value3", "value4"};
   std::array<std::span<std::string_view const>, 2> as = {

--- a/tests/runtime/cpp/param-ownership/runner-fine-borrowing.cpp
+++ b/tests/runtime/cpp/param-ownership/runner-fine-borrowing.cpp
@@ -2,7 +2,8 @@
 
 #include "runner_cpp.h"
 #include <array>
-int main() {
+
+void exports::runner::Run() {
   std::array<std::string_view, 2> a1 = {"value1", "value2"};
   std::array<std::string_view, 2> a2 = {"value3", "value4"};
   std::array<std::span<std::string_view const>, 2> as = {

--- a/tests/runtime/cpp/param-ownership/runner-owning.cpp
+++ b/tests/runtime/cpp/param-ownership/runner-owning.cpp
@@ -2,7 +2,8 @@
 
 #include "runner_cpp.h"
 #include <array>
-int main() {
+
+void exports::runner::Run() {
   std::array<std::string_view, 2> a1 = {"value1", "value2"};
   std::array<std::string_view, 2> a2 = {"value3", "value4"};
   std::array<std::span<std::string_view const>, 2> as = {

--- a/tests/runtime/cpp/param-ownership/test.wit
+++ b/tests/runtime/cpp/param-ownership/test.wit
@@ -37,6 +37,8 @@ world runner {
     }
 
     import both-list-and-resource;
+
+    export run: func();
 }
 
 world test {

--- a/tests/runtime/cpp/variant-with-data/runner.cpp
+++ b/tests/runtime/cpp/variant-with-data/runner.cpp
@@ -31,7 +31,7 @@ static bool equal(DataVariant const& a, DataVariant const& b) {
     return false;
 }
 
-int main() {
+void exports::runner::Run() {
   using namespace ::test::variant_with_data::to_test;
 
   // Test bytes variant
@@ -52,6 +52,4 @@ int main() {
   DataVariant expected_text_variant;
   expected_text_variant.variants = DataVariant::Text(wit::string::from_view("hello"));
   assert(equal(text_variant, expected_text_variant));
-
-  return 0;
 }

--- a/tests/runtime/cpp/variant-with-data/test.wit
+++ b/tests/runtime/cpp/variant-with-data/test.wit
@@ -12,6 +12,8 @@ interface to-test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/demo/runner-component.wat
+++ b/tests/runtime/demo/runner-component.wat
@@ -6,9 +6,8 @@
   (core module $m
     (import "a:b/the-test" "x" (func $x))
 
-    (func (export "run") (result i32)
-      call $x
-      i32.const 0)
+    (func (export "run")
+      call $x)
   )
   (core func $x (canon lower (func $test "x")))
   (core instance $i (instantiate $m
@@ -17,7 +16,5 @@
     ))
   ))
 
-  (func $run (result (result)) (canon lift (core func $i "run")))
-  (instance $run (export "run" (func $run)))
-  (export "wasi:cli/run@0.2.0" (instance $run))
+  (func (export "run") (canon lift (core func $i "run")))
 )

--- a/tests/runtime/demo/runner-core.wat
+++ b/tests/runtime/demo/runner-core.wat
@@ -2,8 +2,7 @@
   (import "a:b/the-test" "x" (func $x))
   (memory (export "memory") 1)
 
-  (func (export "_start")
+  (func (export "run")
     call $x
   )
-
 )

--- a/tests/runtime/demo/runner-opt.c
+++ b/tests/runtime/demo/runner-opt.c
@@ -3,6 +3,6 @@
 
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   a_b_the_test_x();
 }

--- a/tests/runtime/demo/runner-opt.rs
+++ b/tests/runtime/demo/runner-opt.rs
@@ -3,6 +3,12 @@
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    a::b::the_test::x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        a::b::the_test::x();
+    }
 }

--- a/tests/runtime/demo/runner.c
+++ b/tests/runtime/demo/runner.c
@@ -1,5 +1,5 @@
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   a_b_the_test_x();
 }

--- a/tests/runtime/demo/runner.cpp
+++ b/tests/runtime/demo/runner.cpp
@@ -1,5 +1,5 @@
 #include <runner_cpp.h>
 
-int main() {
+void exports::runner::Run() {
   a::b::the_test::X();
 }

--- a/tests/runtime/demo/runner.cs
+++ b/tests/runtime/demo/runner.cs
@@ -3,9 +3,11 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using RunnerWorld.wit.imports.a.b;
 
-public class Program
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args)
+    public static void Run()
     {
         TheTestInterop.X();
     }

--- a/tests/runtime/demo/runner.rs
+++ b/tests/runtime/demo/runner.rs
@@ -1,5 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    a::b::the_test::x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        a::b::the_test::x();
+    }
 }

--- a/tests/runtime/demo/runner2.rs
+++ b/tests/runtime/demo/runner2.rs
@@ -1,5 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    a::b::the_test::x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        a::b::the_test::x();
+    }
 }

--- a/tests/runtime/demo/test.wit
+++ b/tests/runtime/demo/test.wit
@@ -6,6 +6,8 @@ interface the-test {
 
 world runner {
   import the-test;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/flavorful/runner.c
+++ b/tests/runtime/flavorful/runner.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main() {
+void exports_runner_run() {
   {
     test_list_in_record1_t a;
     runner_string_set(&a.a, "list_in_record1");

--- a/tests/runtime/flavorful/runner.rs
+++ b/tests/runtime/flavorful/runner.rs
@@ -5,10 +5,16 @@ use crate::test::flavorful::to_test::*;
 #[path = "../lists/alloc.rs"]
 mod alloc;
 
-fn main() {
-    let before = alloc::get();
-    run();
-    assert_eq!(before, alloc::get());
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let before = alloc::get();
+        run();
+        assert_eq!(before, alloc::get());
+    }
 }
 
 fn run() {

--- a/tests/runtime/flavorful/test.wit
+++ b/tests/runtime/flavorful/test.wit
@@ -40,4 +40,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/gated-features/runner.rs
+++ b/tests/runtime/gated-features/runner.rs
@@ -4,7 +4,13 @@ include!(env!("BINDINGS"));
 
 use crate::foo::bar::bindings::{y, z};
 
-fn main() {
-    y();
-    z();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        y();
+        z();
+    }
 }

--- a/tests/runtime/gated-features/test.wit
+++ b/tests/runtime/gated-features/test.wit
@@ -14,4 +14,6 @@ world test {
 }
 world runner {
   import bindings;
+
+  export run: func();
 }

--- a/tests/runtime/lists-alias/runner.rs
+++ b/tests/runtime/lists-alias/runner.rs
@@ -1,10 +1,16 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&[u8]`
-    cat::foo(b"hello");
+struct Component;
 
-    // Test the return type is `Vec<u8>`
-    let t: Vec<u8> = cat::bar();
-    assert_eq!(t, b"world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&[u8]`
+        cat::foo(b"hello");
+
+        // Test the return type is `Vec<u8>`
+        let t: Vec<u8> = cat::bar();
+        assert_eq!(t, b"world");
+    }
 }

--- a/tests/runtime/lists-alias/test.wit
+++ b/tests/runtime/lists-alias/test.wit
@@ -6,6 +6,8 @@ world runner {
     foo: func(x: my-list);
     bar: func() -> my-list;
   }
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/lists/runner.c
+++ b/tests/runtime/lists/runner.c
@@ -8,7 +8,7 @@
 
 #include "runner.h"
 
-int main() {
+void exports_runner_run() {
   {
     uint8_t list[] = {};
     runner_list_u8_t a;

--- a/tests/runtime/lists/runner.cpp
+++ b/tests/runtime/lists/runner.cpp
@@ -50,7 +50,7 @@ static bool equal(T const& a, T const& b) {
     return a==b;
 }
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::lists::to_test;
 

--- a/tests/runtime/lists/runner.cs
+++ b/tests/runtime/lists/runner.cs
@@ -4,10 +4,11 @@ using System.Diagnostics;
 using RunnerWorld.wit.imports.test.lists;
 using System.Text;
 
+namespace RunnerWorld;
 
-public class Program
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args)
+    public static void Run()
     {
         ToTestInterop.EmptyListParam(new byte[0]);
         ToTestInterop.EmptyStringParam("");

--- a/tests/runtime/lists/runner.rs
+++ b/tests/runtime/lists/runner.rs
@@ -25,136 +25,142 @@ impl Drop for Guard {
 
 mod alloc;
 
-fn main() {
-    let _guard_over_entire_function = Guard::new();
+struct Component;
 
-    {
-        let _guard = Guard::new();
-        empty_list_param(&[]);
-    }
-    {
-        let _guard = Guard::new();
-        empty_string_param("");
-    }
-    {
-        let _guard = Guard::new();
-        assert!(empty_list_result().is_empty());
-    }
-    {
-        let _guard = Guard::new();
-        assert!(empty_string_result().is_empty());
-    }
+export!(Component);
 
-    {
-        let _guard = Guard::new();
-        list_param(&[1, 2, 3, 4]);
-    }
-    {
-        let _guard = Guard::new();
-        list_param2("foo");
-    }
-    {
-        let _guard = Guard::new();
-        list_param3(&["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]);
-    }
-    {
-        let _guard = Guard::new();
-        list_param4(&[
-            vec!["foo".to_owned(), "bar".to_owned()],
-            vec!["baz".to_owned()],
-        ]);
-    }
-    {
-        let _guard = Guard::new();
-        list_param5(&[(1, 2, 3), (4, 5, 6)]);
-    }
-    {
-        let _guard = Guard::new();
-        let large_list: Vec<String> = (0..1000).map(|_| "string".to_string()).collect();
-        list_param_large(&large_list);
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_result(), [1, 2, 3, 4, 5]);
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_result2(), "hello!");
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_result3(), ["hello,", "world!"]);
-    }
+impl Guest for Component {
+    fn run() {
+        let _guard_over_entire_function = Guard::new();
 
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_roundtrip(&[]), []);
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_roundtrip(b"x"), b"x");
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(list_roundtrip(b"hello"), b"hello");
-    }
+        {
+            let _guard = Guard::new();
+            empty_list_param(&[]);
+        }
+        {
+            let _guard = Guard::new();
+            empty_string_param("");
+        }
+        {
+            let _guard = Guard::new();
+            assert!(empty_list_result().is_empty());
+        }
+        {
+            let _guard = Guard::new();
+            assert!(empty_string_result().is_empty());
+        }
 
-    {
-        let _guard = Guard::new();
-        assert_eq!(string_roundtrip("x"), "x");
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(string_roundtrip(""), "");
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(string_roundtrip("hello"), "hello");
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(string_roundtrip("hello ⚑ world"), "hello ⚑ world");
-    }
+        {
+            let _guard = Guard::new();
+            list_param(&[1, 2, 3, 4]);
+        }
+        {
+            let _guard = Guard::new();
+            list_param2("foo");
+        }
+        {
+            let _guard = Guard::new();
+            list_param3(&["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]);
+        }
+        {
+            let _guard = Guard::new();
+            list_param4(&[
+                vec!["foo".to_owned(), "bar".to_owned()],
+                vec!["baz".to_owned()],
+            ]);
+        }
+        {
+            let _guard = Guard::new();
+            list_param5(&[(1, 2, 3), (4, 5, 6)]);
+        }
+        {
+            let _guard = Guard::new();
+            let large_list: Vec<String> = (0..1000).map(|_| "string".to_string()).collect();
+            list_param_large(&large_list);
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_result(), [1, 2, 3, 4, 5]);
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_result2(), "hello!");
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_result3(), ["hello,", "world!"]);
+        }
 
-    {
-        let _guard = Guard::new();
-        assert_eq!(
-            list_minmax8(&[u8::MIN, u8::MAX], &[i8::MIN, i8::MAX]),
-            (vec![u8::MIN, u8::MAX], vec![i8::MIN, i8::MAX]),
-        );
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(
-            list_minmax16(&[u16::MIN, u16::MAX], &[i16::MIN, i16::MAX]),
-            (vec![u16::MIN, u16::MAX], vec![i16::MIN, i16::MAX]),
-        );
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(
-            list_minmax32(&[u32::MIN, u32::MAX], &[i32::MIN, i32::MAX]),
-            (vec![u32::MIN, u32::MAX], vec![i32::MIN, i32::MAX]),
-        );
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(
-            list_minmax64(&[u64::MIN, u64::MAX], &[i64::MIN, i64::MAX]),
-            (vec![u64::MIN, u64::MAX], vec![i64::MIN, i64::MAX]),
-        );
-    }
-    {
-        let _guard = Guard::new();
-        assert_eq!(
-            list_minmax_float(
-                &[f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
-                &[f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY]
-            ),
-            (
-                vec![f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
-                vec![f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY],
-            ),
-        );
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_roundtrip(&[]), []);
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_roundtrip(b"x"), b"x");
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(list_roundtrip(b"hello"), b"hello");
+        }
+
+        {
+            let _guard = Guard::new();
+            assert_eq!(string_roundtrip("x"), "x");
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(string_roundtrip(""), "");
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(string_roundtrip("hello"), "hello");
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(string_roundtrip("hello ⚑ world"), "hello ⚑ world");
+        }
+
+        {
+            let _guard = Guard::new();
+            assert_eq!(
+                list_minmax8(&[u8::MIN, u8::MAX], &[i8::MIN, i8::MAX]),
+                (vec![u8::MIN, u8::MAX], vec![i8::MIN, i8::MAX]),
+            );
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(
+                list_minmax16(&[u16::MIN, u16::MAX], &[i16::MIN, i16::MAX]),
+                (vec![u16::MIN, u16::MAX], vec![i16::MIN, i16::MAX]),
+            );
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(
+                list_minmax32(&[u32::MIN, u32::MAX], &[i32::MIN, i32::MAX]),
+                (vec![u32::MIN, u32::MAX], vec![i32::MIN, i32::MAX]),
+            );
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(
+                list_minmax64(&[u64::MIN, u64::MAX], &[i64::MIN, i64::MAX]),
+                (vec![u64::MIN, u64::MAX], vec![i64::MIN, i64::MAX]),
+            );
+        }
+        {
+            let _guard = Guard::new();
+            assert_eq!(
+                list_minmax_float(
+                    &[f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
+                    &[f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY]
+                ),
+                (
+                    vec![f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
+                    vec![f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY],
+                ),
+            );
+        }
     }
 }

--- a/tests/runtime/lists/test.wit
+++ b/tests/runtime/lists/test.wit
@@ -36,4 +36,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/many-arguments/runner.c
+++ b/tests/runtime/many-arguments/runner.c
@@ -2,7 +2,7 @@
 
 #include "runner.h"
 
-int main() {
+void exports_runner_run() {
   test_many_arguments_to_test_many_arguments(
       1,
       2,

--- a/tests/runtime/many-arguments/runner.cpp
+++ b/tests/runtime/many-arguments/runner.cpp
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <runner_cpp.h>
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::many_arguments::to_test;
 

--- a/tests/runtime/many-arguments/runner.cs
+++ b/tests/runtime/many-arguments/runner.cs
@@ -3,9 +3,11 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using RunnerWorld.wit.imports.test.manyArguments;
 
-public class Program
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args)
+    public static void Run()
     {
         ToTestInterop.ManyArguments(
             1,

--- a/tests/runtime/many-arguments/runner.rs
+++ b/tests/runtime/many-arguments/runner.rs
@@ -2,6 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::test::many_arguments::to_test::many_arguments;
 
-fn main() {
-    many_arguments(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        many_arguments(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    }
 }

--- a/tests/runtime/many-arguments/test.wit
+++ b/tests/runtime/many-arguments/test.wit
@@ -26,4 +26,6 @@ world test {
 }
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/numbers/runner.c
+++ b/tests/runtime/numbers/runner.c
@@ -3,7 +3,7 @@
 #include <math.h>
 #include <runner.h>
 
-int main() {
+void exports_runner_run() {
   assert(test_numbers_numbers_roundtrip_u8(1) == 1);
   assert(test_numbers_numbers_roundtrip_u8(0) == 0);
   assert(test_numbers_numbers_roundtrip_u8(UCHAR_MAX) == UCHAR_MAX);
@@ -54,6 +54,4 @@ int main() {
   assert(test_numbers_numbers_get_scalar() == 2);
   test_numbers_numbers_set_scalar(4);
   assert(test_numbers_numbers_get_scalar() == 4);
-
-  return 0;
 }

--- a/tests/runtime/numbers/runner.cpp
+++ b/tests/runtime/numbers/runner.cpp
@@ -2,7 +2,7 @@
 #include <limits.h>
 #include <runner_cpp.h>
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::numbers::numbers;
 

--- a/tests/runtime/numbers/runner.cs
+++ b/tests/runtime/numbers/runner.cs
@@ -3,9 +3,11 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using RunnerWorld.wit.imports.test.numbers;
 
-public class Program
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args)
+    public static void Run()
     {
         Debug.Assert(NumbersInterop.RoundtripU8(1) == 1);
         Debug.Assert(NumbersInterop.RoundtripU8(0) == 0);

--- a/tests/runtime/numbers/runner.rs
+++ b/tests/runtime/numbers/runner.rs
@@ -1,55 +1,61 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    use test::numbers::numbers::*;
-    assert_eq!(roundtrip_u8(1), 1);
-    assert_eq!(roundtrip_u8(u8::min_value()), u8::min_value());
-    assert_eq!(roundtrip_u8(u8::max_value()), u8::max_value());
+struct Component;
 
-    assert_eq!(roundtrip_s8(1), 1);
-    assert_eq!(roundtrip_s8(i8::min_value()), i8::min_value());
-    assert_eq!(roundtrip_s8(i8::max_value()), i8::max_value());
+export!(Component);
 
-    assert_eq!(roundtrip_u16(1), 1);
-    assert_eq!(roundtrip_u16(u16::min_value()), u16::min_value());
-    assert_eq!(roundtrip_u16(u16::max_value()), u16::max_value());
+impl Guest for Component {
+    fn run() {
+        use test::numbers::numbers::*;
+        assert_eq!(roundtrip_u8(1), 1);
+        assert_eq!(roundtrip_u8(u8::min_value()), u8::min_value());
+        assert_eq!(roundtrip_u8(u8::max_value()), u8::max_value());
 
-    assert_eq!(roundtrip_s16(1), 1);
-    assert_eq!(roundtrip_s16(i16::min_value()), i16::min_value());
-    assert_eq!(roundtrip_s16(i16::max_value()), i16::max_value());
+        assert_eq!(roundtrip_s8(1), 1);
+        assert_eq!(roundtrip_s8(i8::min_value()), i8::min_value());
+        assert_eq!(roundtrip_s8(i8::max_value()), i8::max_value());
 
-    assert_eq!(roundtrip_u32(1), 1);
-    assert_eq!(roundtrip_u32(u32::min_value()), u32::min_value());
-    assert_eq!(roundtrip_u32(u32::max_value()), u32::max_value());
+        assert_eq!(roundtrip_u16(1), 1);
+        assert_eq!(roundtrip_u16(u16::min_value()), u16::min_value());
+        assert_eq!(roundtrip_u16(u16::max_value()), u16::max_value());
 
-    assert_eq!(roundtrip_s32(1), 1);
-    assert_eq!(roundtrip_s32(i32::min_value()), i32::min_value());
-    assert_eq!(roundtrip_s32(i32::max_value()), i32::max_value());
+        assert_eq!(roundtrip_s16(1), 1);
+        assert_eq!(roundtrip_s16(i16::min_value()), i16::min_value());
+        assert_eq!(roundtrip_s16(i16::max_value()), i16::max_value());
 
-    assert_eq!(roundtrip_u64(1), 1);
-    assert_eq!(roundtrip_u64(u64::min_value()), u64::min_value());
-    assert_eq!(roundtrip_u64(u64::max_value()), u64::max_value());
+        assert_eq!(roundtrip_u32(1), 1);
+        assert_eq!(roundtrip_u32(u32::min_value()), u32::min_value());
+        assert_eq!(roundtrip_u32(u32::max_value()), u32::max_value());
 
-    assert_eq!(roundtrip_s64(1), 1);
-    assert_eq!(roundtrip_s64(i64::min_value()), i64::min_value());
-    assert_eq!(roundtrip_s64(i64::max_value()), i64::max_value());
+        assert_eq!(roundtrip_s32(1), 1);
+        assert_eq!(roundtrip_s32(i32::min_value()), i32::min_value());
+        assert_eq!(roundtrip_s32(i32::max_value()), i32::max_value());
 
-    assert_eq!(roundtrip_f32(1.0), 1.0);
-    assert_eq!(roundtrip_f32(f32::INFINITY), f32::INFINITY);
-    assert_eq!(roundtrip_f32(f32::NEG_INFINITY), f32::NEG_INFINITY);
-    assert!(roundtrip_f32(f32::NAN).is_nan());
+        assert_eq!(roundtrip_u64(1), 1);
+        assert_eq!(roundtrip_u64(u64::min_value()), u64::min_value());
+        assert_eq!(roundtrip_u64(u64::max_value()), u64::max_value());
 
-    assert_eq!(roundtrip_f64(1.0), 1.0);
-    assert_eq!(roundtrip_f64(f64::INFINITY), f64::INFINITY);
-    assert_eq!(roundtrip_f64(f64::NEG_INFINITY), f64::NEG_INFINITY);
-    assert!(roundtrip_f64(f64::NAN).is_nan());
+        assert_eq!(roundtrip_s64(1), 1);
+        assert_eq!(roundtrip_s64(i64::min_value()), i64::min_value());
+        assert_eq!(roundtrip_s64(i64::max_value()), i64::max_value());
 
-    assert_eq!(roundtrip_char('a'), 'a');
-    assert_eq!(roundtrip_char(' '), ' ');
-    assert_eq!(roundtrip_char('🚩'), '🚩');
+        assert_eq!(roundtrip_f32(1.0), 1.0);
+        assert_eq!(roundtrip_f32(f32::INFINITY), f32::INFINITY);
+        assert_eq!(roundtrip_f32(f32::NEG_INFINITY), f32::NEG_INFINITY);
+        assert!(roundtrip_f32(f32::NAN).is_nan());
 
-    set_scalar(2);
-    assert_eq!(get_scalar(), 2);
-    set_scalar(4);
-    assert_eq!(get_scalar(), 4);
+        assert_eq!(roundtrip_f64(1.0), 1.0);
+        assert_eq!(roundtrip_f64(f64::INFINITY), f64::INFINITY);
+        assert_eq!(roundtrip_f64(f64::NEG_INFINITY), f64::NEG_INFINITY);
+        assert!(roundtrip_f64(f64::NAN).is_nan());
+
+        assert_eq!(roundtrip_char('a'), 'a');
+        assert_eq!(roundtrip_char(' '), ' ');
+        assert_eq!(roundtrip_char('🚩'), '🚩');
+
+        set_scalar(2);
+        assert_eq!(get_scalar(), 2);
+        set_scalar(4);
+        assert_eq!(get_scalar(), 4);
+    }
 }

--- a/tests/runtime/numbers/test.wit
+++ b/tests/runtime/numbers/test.wit
@@ -23,4 +23,6 @@ world test {
 
 world runner {
   import numbers;
+
+  export run: func();
 }

--- a/tests/runtime/options/runner.cpp
+++ b/tests/runtime/options/runner.cpp
@@ -17,7 +17,7 @@ static bool equal(std::optional<wit::string> const& a, std::optional<std::string
     return true;
 }
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::options::to_test;
 

--- a/tests/runtime/options/runner.cs
+++ b/tests/runtime/options/runner.cs
@@ -1,12 +1,12 @@
 using System.Diagnostics;
 using RunnerWorld.wit.imports.test.options;
 
-namespace RunnerWorld
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public class Program
+    public static void Run()
     {
-        public static void Main()
-        {
             ToTestInterop.OptionNoneParam(null);
             ToTestInterop.OptionSomeParam("foo");
             Debug.Assert(ToTestInterop.OptionNoneResult() == null);
@@ -15,6 +15,5 @@ namespace RunnerWorld
             Debug.Assert(ToTestInterop.DoubleOptionRoundtrip(new Option<uint?>(42)).Value == 42);
             Debug.Assert(ToTestInterop.DoubleOptionRoundtrip(new Option<uint?>(null)).Value == null);
             Debug.Assert(!ToTestInterop.DoubleOptionRoundtrip(Option<uint?>.None).HasValue);
-        }
     }
 }

--- a/tests/runtime/options/runner.rs
+++ b/tests/runtime/options/runner.rs
@@ -2,13 +2,19 @@ include!(env!("BINDINGS"));
 
 use test::options::to_test::*;
 
-fn main() {
-    option_none_param(None);
-    option_some_param(Some("foo"));
-    assert!(option_none_result().is_none());
-    assert_eq!(option_some_result(), Some("foo".to_string()));
-    assert_eq!(option_roundtrip(Some("foo")), Some("foo".to_string()));
-    assert_eq!(double_option_roundtrip(Some(Some(42))), Some(Some(42)));
-    assert_eq!(double_option_roundtrip(Some(None)), Some(None));
-    assert_eq!(double_option_roundtrip(None), None);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        option_none_param(None);
+        option_some_param(Some("foo"));
+        assert!(option_none_result().is_none());
+        assert_eq!(option_some_result(), Some("foo".to_string()));
+        assert_eq!(option_roundtrip(Some("foo")), Some("foo".to_string()));
+        assert_eq!(double_option_roundtrip(Some(Some(42))), Some(Some(42)));
+        assert_eq!(double_option_roundtrip(Some(None)), Some(None));
+        assert_eq!(double_option_roundtrip(None), None);
+    }
 }

--- a/tests/runtime/options/test.wit
+++ b/tests/runtime/options/test.wit
@@ -17,4 +17,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/package-with-version/runner.rs
+++ b/tests/runtime/package-with-version/runner.rs
@@ -2,6 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::my::inline::foo::Bar;
 
-fn main() {
-    let _ = Bar::new();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let _ = Bar::new();
+    }
 }

--- a/tests/runtime/package-with-version/test.wit
+++ b/tests/runtime/package-with-version/test.wit
@@ -11,4 +11,6 @@ world test {
 }
 world runner {
     import foo;
+
+    export run: func();
 }

--- a/tests/runtime/records/runner.c
+++ b/tests/runtime/records/runner.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include "runner.h"
 
-int main()
+void exports_runner_run()
 {
     {
         runner_tuple2_u8_u16_t ret;

--- a/tests/runtime/records/runner.cpp
+++ b/tests/runtime/records/runner.cpp
@@ -6,7 +6,7 @@ bool equal(T const&a, T const&b) {
     return a==b;
 }
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::records::to_test;
 

--- a/tests/runtime/records/runner.cs
+++ b/tests/runtime/records/runner.cs
@@ -2,12 +2,14 @@ using System;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 using RunnerWorld.wit.imports.test.records;
-using RunnerWorld;
 
-public class Program {
-    public static void Main()
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
+{
+    public static void Run()
     {
-        {
+            {
                 var results = ToTestInterop.MultipleResults();
                 Debug.Assert(results.Item1 == 4);
                 Debug.Assert(results.Item2 == 5);

--- a/tests/runtime/records/runner.rs
+++ b/tests/runtime/records/runner.rs
@@ -2,38 +2,44 @@ include!(env!("BINDINGS"));
 
 use crate::test::records::to_test::*;
 
-fn main() {
-    assert_eq!(multiple_results(), (4, 5));
+struct Component;
 
-    assert_eq!(swap_tuple((1u8, 2u32)), (2u32, 1u8));
-    assert_eq!(roundtrip_flags1(F1::A), F1::A);
-    assert_eq!(roundtrip_flags1(F1::empty()), F1::empty());
-    assert_eq!(roundtrip_flags1(F1::B), F1::B);
-    assert_eq!(roundtrip_flags1(F1::A | F1::B), F1::A | F1::B);
+export!(Component);
 
-    assert_eq!(roundtrip_flags2(F2::C), F2::C);
-    assert_eq!(roundtrip_flags2(F2::empty()), F2::empty());
-    assert_eq!(roundtrip_flags2(F2::D), F2::D);
-    assert_eq!(roundtrip_flags2(F2::C | F2::E), F2::C | F2::E);
+impl Guest for Component {
+    fn run() {
+        assert_eq!(multiple_results(), (4, 5));
 
-    assert_eq!(
-        roundtrip_flags3(Flag8::B0, Flag16::B1, Flag32::B2),
-        (Flag8::B0, Flag16::B1, Flag32::B2)
-    );
+        assert_eq!(swap_tuple((1u8, 2u32)), (2u32, 1u8));
+        assert_eq!(roundtrip_flags1(F1::A), F1::A);
+        assert_eq!(roundtrip_flags1(F1::empty()), F1::empty());
+        assert_eq!(roundtrip_flags1(F1::B), F1::B);
+        assert_eq!(roundtrip_flags1(F1::A | F1::B), F1::A | F1::B);
 
-    let r = roundtrip_record1(R1 {
-        a: 8,
-        b: F1::empty(),
-    });
-    assert_eq!(r.a, 8);
-    assert_eq!(r.b, F1::empty());
+        assert_eq!(roundtrip_flags2(F2::C), F2::C);
+        assert_eq!(roundtrip_flags2(F2::empty()), F2::empty());
+        assert_eq!(roundtrip_flags2(F2::D), F2::D);
+        assert_eq!(roundtrip_flags2(F2::C | F2::E), F2::C | F2::E);
 
-    let r = roundtrip_record1(R1 {
-        a: 0,
-        b: F1::A | F1::B,
-    });
-    assert_eq!(r.a, 0);
-    assert_eq!(r.b, F1::A | F1::B);
+        assert_eq!(
+            roundtrip_flags3(Flag8::B0, Flag16::B1, Flag32::B2),
+            (Flag8::B0, Flag16::B1, Flag32::B2)
+        );
 
-    assert_eq!(tuple1((1,)), (1,));
+        let r = roundtrip_record1(R1 {
+            a: 8,
+            b: F1::empty(),
+        });
+        assert_eq!(r.a, 8);
+        assert_eq!(r.b, F1::empty());
+
+        let r = roundtrip_record1(R1 {
+            a: 0,
+            b: F1::A | F1::B,
+        });
+        assert_eq!(r.a, 0);
+        assert_eq!(r.b, F1::A | F1::B);
+
+        assert_eq!(tuple1((1,)), (1,));
+    }
 }

--- a/tests/runtime/records/test.wit
+++ b/tests/runtime/records/test.wit
@@ -43,4 +43,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/resource-borrow/runner.c
+++ b/tests/runtime/resource-borrow/runner.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include "runner.h"
 
-int main() {
+void exports_runner_run() {
   test_resource_borrow_to_test_own_thing_t thing;
   thing = test_resource_borrow_to_test_constructor_thing(42);
 

--- a/tests/runtime/resource-borrow/runner.cs
+++ b/tests/runtime/resource-borrow/runner.cs
@@ -1,8 +1,12 @@
 using RunnerWorld.wit.imports.test.resourceBorrow;
 using System.Diagnostics;
 
-public class RunnerWorldImpl {
-    public static void Main() {
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
+{
+    public static void Run()
+    {
         uint ret = ToTestInterop.Foo(new IToTest.Thing(42));
         Debug.Assert(ret == 42 + 1 + 2);
     }

--- a/tests/runtime/resource-borrow/runner.rs
+++ b/tests/runtime/resource-borrow/runner.rs
@@ -2,6 +2,12 @@ include!(env!("BINDINGS"));
 
 use crate::test::resource_borrow::to_test::{foo, Thing};
 
-fn main() {
-    assert_eq!(foo(&Thing::new(42)), 42 + 1 + 2);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        assert_eq!(foo(&Thing::new(42)), 42 + 1 + 2);
+    }
 }

--- a/tests/runtime/resource-borrow/test.wit
+++ b/tests/runtime/resource-borrow/test.wit
@@ -14,4 +14,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/resource-import-and-export/runner.rs
+++ b/tests/runtime/resource-import-and-export/runner.rs
@@ -2,20 +2,26 @@ use crate::test::resource_import_and_export::test::Thing;
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    let thing1 = Thing::new(42);
+struct Component;
 
-    // 42 + 1 (constructor) + 1 (constructor) + 2 (foo) + 2 (foo)
-    assert_eq!(thing1.foo(), 48);
+export!(Component);
 
-    // 33 + 3 (bar) + 3 (bar) + 2 (foo) + 2 (foo)
-    thing1.bar(33);
-    assert_eq!(thing1.foo(), 43);
+impl Guest for Component {
+    fn run() {
+        let thing1 = Thing::new(42);
 
-    let thing2 = Thing::new(81);
-    let thing3 = Thing::baz(thing1, thing2);
-    assert_eq!(
-        thing3.foo(),
-        33 + 3 + 3 + 81 + 1 + 1 + 2 + 2 + 4 + 1 + 2 + 4 + 1 + 1 + 2 + 2
-    );
+        // 42 + 1 (constructor) + 1 (constructor) + 2 (foo) + 2 (foo)
+        assert_eq!(thing1.foo(), 48);
+
+        // 33 + 3 (bar) + 3 (bar) + 2 (foo) + 2 (foo)
+        thing1.bar(33);
+        assert_eq!(thing1.foo(), 43);
+
+        let thing2 = Thing::new(81);
+        let thing3 = Thing::baz(thing1, thing2);
+        assert_eq!(
+            thing3.foo(),
+            33 + 3 + 3 + 81 + 1 + 1 + 2 + 2 + 4 + 1 + 2 + 4 + 1 + 1 + 2 + 2
+        );
+    }
 }

--- a/tests/runtime/resource-import-and-export/test.wit
+++ b/tests/runtime/resource-import-and-export/test.wit
@@ -35,4 +35,6 @@ world intermediate {
 
 world runner {
   import test;
+
+  export run: func();
 }

--- a/tests/runtime/resource_aggregates/runner.cs
+++ b/tests/runtime/resource_aggregates/runner.cs
@@ -4,8 +4,11 @@ using System.Diagnostics;
 using RunnerWorld.wit.imports.test.resourceAggregates;
 using RunnerWorld;
 
-public class Program {
-    public static void Main()
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
+{
+    public static void Run()
     {
         var il1 = new List<IToTest.Thing>();
         il1.Add(new IToTest.Thing(9));

--- a/tests/runtime/resource_aggregates/runner.rs
+++ b/tests/runtime/resource_aggregates/runner.rs
@@ -2,35 +2,41 @@ include!(env!("BINDINGS"));
 
 use crate::test::resource_aggregates::to_test::*;
 
-fn main() {
-    assert_eq!(
-        foo(
-            R1 {
-                thing: Thing::new(0)
-            },
-            &R2 {
-                thing: &Thing::new(1)
-            },
-            R3 {
-                thing1: &Thing::new(2),
-                thing2: Thing::new(3),
-            },
-            (
-                Thing::new(4),
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        assert_eq!(
+            foo(
                 R1 {
-                    thing: Thing::new(5)
-                }
+                    thing: Thing::new(0)
+                },
+                &R2 {
+                    thing: &Thing::new(1)
+                },
+                R3 {
+                    thing1: &Thing::new(2),
+                    thing2: Thing::new(3),
+                },
+                (
+                    Thing::new(4),
+                    R1 {
+                        thing: Thing::new(5)
+                    }
+                ),
+                &(&Thing::new(6),),
+                V1::Thing(Thing::new(7)),
+                &V2::Thing(&Thing::new(8)),
+                vec![Thing::new(9), Thing::new(10)],
+                &[&Thing::new(11), &Thing::new(12)],
+                Some(Thing::new(13)),
+                Some(&Thing::new(14)),
+                Ok(Thing::new(15)),
+                Ok(&Thing::new(16))
             ),
-            &(&Thing::new(6),),
-            V1::Thing(Thing::new(7)),
-            &V2::Thing(&Thing::new(8)),
-            vec![Thing::new(9), Thing::new(10)],
-            &[&Thing::new(11), &Thing::new(12)],
-            Some(Thing::new(13)),
-            Some(&Thing::new(14)),
-            Ok(Thing::new(15)),
-            Ok(&Thing::new(16))
-        ),
-        (0..17).map(|i| i + 1).sum::<u32>() + 3,
-    );
+            (0..17).map(|i| i + 1).sum::<u32>() + 3,
+        );
+    }
 }

--- a/tests/runtime/resource_aggregates/test.wit
+++ b/tests/runtime/resource_aggregates/test.wit
@@ -57,4 +57,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/resource_alias/runner.rs
+++ b/tests/runtime/resource_alias/runner.rs
@@ -3,12 +3,18 @@ include!(env!("BINDINGS"));
 use test::resource_alias::e1::{a as a1, Foo as Foo1, X};
 use test::resource_alias::e2::{a as a2, Foo as Foo2};
 
-fn main() {
-    let foo_e1 = Foo1 { x: X::new(42) };
-    a1(foo_e1);
+struct Component;
 
-    let foo_e2 = Foo2 { x: X::new(7) };
-    let bar_e2 = Foo1 { x: X::new(8) };
-    let y = X::new(8);
-    a2(foo_e2, bar_e2, &y);
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let foo_e1 = Foo1 { x: X::new(42) };
+        a1(foo_e1);
+
+        let foo_e2 = Foo2 { x: X::new(7) };
+        let bar_e2 = Foo1 { x: X::new(8) };
+        let y = X::new(8);
+        a2(foo_e2, bar_e2, &y);
+    }
 }

--- a/tests/runtime/resource_alias/test.wit
+++ b/tests/runtime/resource_alias/test.wit
@@ -26,4 +26,6 @@ world test {
 world runner {
   import e1;
   import e2;
+
+  export run: func();
 }

--- a/tests/runtime/resource_alias_redux/runner.cs
+++ b/tests/runtime/resource_alias_redux/runner.cs
@@ -5,8 +5,12 @@ using RunnerWorld.wit.imports.test.resourceAliasRedux;
 using RunnerWorld.wit.imports;
 using System.Text;
 
-public class Program {
-    public static void Main() {
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
+{
+    public static void Run()
+    {
         IResourceAlias1.Thing thing1 = new IResourceAlias1.Thing("Ni Hao");
         List<IResourceAlias1.Thing> myList = new List<IResourceAlias1.Thing>();
         myList.Add(thing1);

--- a/tests/runtime/resource_alias_redux/runner.rs
+++ b/tests/runtime/resource_alias_redux/runner.rs
@@ -4,22 +4,28 @@ use crate::test::resource_alias_redux::resource_alias1 as a1;
 use crate::test::resource_alias_redux::resource_alias2 as a2;
 use crate::the_test::test;
 
-fn main() {
-    let thing1 = crate::the_test::Thing::new("Ni Hao");
-    let result = test(vec![thing1]);
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].get(), "Ni Hao GuestThing GuestThing.get");
+struct Component;
 
-    let thing2 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Ciao");
-    let result = a1::a(a1::Foo { thing: thing2 });
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].get(), "Ciao GuestThing GuestThing.get");
+export!(Component);
 
-    let thing3 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Ciao");
-    let thing4 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Aloha");
+impl Guest for Component {
+    fn run() {
+        let thing1 = crate::the_test::Thing::new("Ni Hao");
+        let result = test(vec![thing1]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].get(), "Ni Hao GuestThing GuestThing.get");
 
-    let result = a2::b(a2::Foo { thing: thing3 }, a2::Bar { thing: thing4 });
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].get(), "Ciao GuestThing GuestThing.get");
-    assert_eq!(result[1].get(), "Aloha GuestThing GuestThing.get");
+        let thing2 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Ciao");
+        let result = a1::a(a1::Foo { thing: thing2 });
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].get(), "Ciao GuestThing GuestThing.get");
+
+        let thing3 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Ciao");
+        let thing4 = crate::test::resource_alias_redux::resource_alias1::Thing::new("Aloha");
+
+        let result = a2::b(a2::Foo { thing: thing3 }, a2::Bar { thing: thing4 });
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].get(), "Ciao GuestThing GuestThing.get");
+        assert_eq!(result[1].get(), "Aloha GuestThing GuestThing.get");
+    }
 }

--- a/tests/runtime/resource_alias_redux/test.wit
+++ b/tests/runtime/resource_alias_redux/test.wit
@@ -37,4 +37,6 @@ world runner {
     use resource-alias1.{thing};
     test: func(things: list<thing>) -> list<thing>;
   }
+
+  export run: func();
 }

--- a/tests/runtime/resource_borrow_in_record/runner.cpp
+++ b/tests/runtime/resource_borrow_in_record/runner.cpp
@@ -2,7 +2,8 @@
 
 namespace test_imports = ::test::resource_borrow_in_record::to_test;
 #include <iostream>
-int main() {
+
+void exports::runner::Run() {
     auto thing1 = test_imports::Thing("Bonjour");
     auto thing2 = test_imports::Thing("mon cher");
     std::cout << thing1.Get().to_string() << ' ' << thing1.get_handle() << std::endl;

--- a/tests/runtime/resource_borrow_in_record/runner.cs
+++ b/tests/runtime/resource_borrow_in_record/runner.cs
@@ -4,8 +4,12 @@ using System.Diagnostics;
 using RunnerWorld.wit.imports.test.resourceBorrowInRecord;
 using System.Text;
 
-public class Program {
-    public static void Main() {
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
+{
+    public static void Run()
+    {
         IToTest.Thing thing1 = new IToTest.Thing("Bonjour");
         IToTest.Thing thing2 = new IToTest.Thing("mon cher");
 

--- a/tests/runtime/resource_borrow_in_record/runner.rs
+++ b/tests/runtime/resource_borrow_in_record/runner.rs
@@ -2,12 +2,18 @@ include!(env!("BINDINGS"));
 
 use crate::test::resource_borrow_in_record::to_test::{test, Foo, Thing};
 
-fn main() {
-    let thing1 = Thing::new("Bonjour");
-    let thing2 = Thing::new("mon cher");
-    let result = test(&[Foo { thing: &thing1 }, Foo { thing: &thing2 }])
-        .into_iter()
-        .map(|x| x.get())
-        .collect::<Vec<_>>();
-    assert_eq!(result, ["Bonjour new test get", "mon cher new test get"]);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let thing1 = Thing::new("Bonjour");
+        let thing2 = Thing::new("mon cher");
+        let result = test(&[Foo { thing: &thing1 }, Foo { thing: &thing2 }])
+            .into_iter()
+            .map(|x| x.get())
+            .collect::<Vec<_>>();
+        assert_eq!(result, ["Bonjour new test get", "mon cher new test get"]);
+    }
 }

--- a/tests/runtime/resource_borrow_in_record/test.wit
+++ b/tests/runtime/resource_borrow_in_record/test.wit
@@ -19,4 +19,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/resource_floats/runner.rs
+++ b/tests/runtime/resource_floats/runner.rs
@@ -2,13 +2,19 @@ include!(env!("BINDINGS"));
 
 use exports::Float as Float2;
 
-fn main() {
-    let float3 = add(&Float::new(42.0), &Float::new(55.0));
-    assert_eq!(float3.get(), 114.0);
+struct Component;
 
-    let float3 = Float2::new(22.0);
-    assert_eq!(float3.get(), 22. + 1. + 2. + 4. + 3.);
+export!(Component);
 
-    let res = Float2::add(float3, 7.0);
-    assert_eq!(res.get(), 59.0);
+impl Guest for Component {
+    fn run() {
+        let float3 = add(&Float::new(42.0), &Float::new(55.0));
+        assert_eq!(float3.get(), 114.0);
+
+        let float3 = Float2::new(22.0);
+        assert_eq!(float3.get(), 22. + 1. + 2. + 4. + 3.);
+
+        let res = Float2::add(float3, 7.0);
+        assert_eq!(res.get(), 59.0);
+    }
 }

--- a/tests/runtime/resource_floats/test.wit
+++ b/tests/runtime/resource_floats/test.wit
@@ -56,4 +56,6 @@ world runner {
   }
 
   import add: func(a: borrow<float>, b: borrow<float>) -> own<float>;
+
+  export run: func();
 }

--- a/tests/runtime/resource_with_lists/runner.rs
+++ b/tests/runtime/resource_with_lists/runner.rs
@@ -2,23 +2,29 @@ include!(env!("BINDINGS"));
 
 use crate::test::resource_with_lists::test::Thing;
 
-fn main() {
-    let thing_instance = Thing::new(b"Hi");
+struct Component;
 
-    assert_eq!(
-        thing_instance.foo(),
-        b"Hi Thing HostThing HostThing.foo Thing.foo"
-    );
+export!(Component);
 
-    thing_instance.bar(b"Hola");
+impl Guest for Component {
+    fn run() {
+        let thing_instance = Thing::new(b"Hi");
 
-    assert_eq!(
-        thing_instance.foo(),
-        b"Hola Thing.bar HostThing.bar HostThing.foo Thing.foo"
-    );
+        assert_eq!(
+            thing_instance.foo(),
+            b"Hi Thing HostThing HostThing.foo Thing.foo"
+        );
 
-    assert_eq!(
-        Thing::baz(b"Ohayo Gozaimas"),
-        b"Ohayo Gozaimas Thing.baz HostThing.baz Thing.baz again"
-    );
+        thing_instance.bar(b"Hola");
+
+        assert_eq!(
+            thing_instance.foo(),
+            b"Hola Thing.bar HostThing.bar HostThing.foo Thing.foo"
+        );
+
+        assert_eq!(
+            Thing::baz(b"Ohayo Gozaimas"),
+            b"Ohayo Gozaimas Thing.baz HostThing.baz Thing.baz again"
+        );
+    }
 }

--- a/tests/runtime/resource_with_lists/test.wit
+++ b/tests/runtime/resource_with_lists/test.wit
@@ -23,4 +23,6 @@ world resource-with-lists {
 
 world runner {
   import test;
+
+  export run: func();
 }

--- a/tests/runtime/resources/runner.rs
+++ b/tests/runtime/resources/runner.rs
@@ -2,33 +2,39 @@ include!(env!("BINDINGS"));
 
 use crate::exports::*;
 
-fn main() {
-    test_imports().unwrap();
+struct Component;
 
-    let x = X::new(5);
-    assert_eq!(x.get_a(), 5);
-    x.set_a(10);
-    assert_eq!(x.get_a(), 10);
-    let z1 = Z::new(10);
-    assert_eq!(z1.get_a(), 10);
-    let z2 = Z::new(20);
-    assert_eq!(z2.get_a(), 20);
+export!(Component);
 
-    let xadd = X::add(x, 5);
-    assert_eq!(xadd.get_a(), 15);
+impl Guest for Component {
+    fn run() {
+        test_imports().unwrap();
 
-    let zadd = add(&z1, &z2);
-    assert_eq!(zadd.get_a(), 30);
+        let x = X::new(5);
+        assert_eq!(x.get_a(), 5);
+        x.set_a(10);
+        assert_eq!(x.get_a(), 10);
+        let z1 = Z::new(10);
+        assert_eq!(z1.get_a(), 10);
+        let z2 = Z::new(20);
+        assert_eq!(z2.get_a(), 20);
 
-    let dropped_zs_start = Z::num_dropped();
+        let xadd = X::add(x, 5);
+        assert_eq!(xadd.get_a(), 15);
 
-    drop(z1);
-    drop(z2);
+        let zadd = add(&z1, &z2);
+        assert_eq!(zadd.get_a(), 30);
 
-    consume(xadd);
+        let dropped_zs_start = Z::num_dropped();
 
-    let dropped_zs_end = Z::num_dropped();
-    if dropped_zs_start != 0 {
-        assert_eq!(dropped_zs_end, dropped_zs_start + 2);
+        drop(z1);
+        drop(z2);
+
+        consume(xadd);
+
+        let dropped_zs_end = Z::num_dropped();
+        if dropped_zs_start != 0 {
+            assert_eq!(dropped_zs_end, dropped_zs_start + 2);
+        }
     }
 }

--- a/tests/runtime/resources/test.wit
+++ b/tests/runtime/resources/test.wit
@@ -81,4 +81,6 @@ world runner {
 
     test-imports: func() -> result<_, string>;
   }
+
+  export run: func();
 }

--- a/tests/runtime/results/runner.cpp
+++ b/tests/runtime/results/runner.cpp
@@ -69,7 +69,7 @@ static bool equal(std::expected<std::expected<void, wit::string>, wit::string> c
     }
 }
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::results::test;
 

--- a/tests/runtime/results/runner.rs
+++ b/tests/runtime/results/runner.rs
@@ -2,44 +2,50 @@ include!(env!("BINDINGS"));
 
 use test::results::test::*;
 
-fn main() {
-    assert_eq!(string_error(0.0), Err("zero".to_owned()));
-    assert_eq!(string_error(1.0), Ok(1.0));
+struct Component;
 
-    assert_eq!(enum_error(0.0), Err(E::A));
-    assert_eq!(enum_error(1.0), Ok(1.0));
+export!(Component);
 
-    assert!(matches!(
-        record_error(0.0),
-        Err(E2 {
-            line: 420,
-            column: 0
-        })
-    ));
-    assert!(matches!(
-        record_error(1.0),
-        Err(E2 {
-            line: 77,
-            column: 2
-        })
-    ));
-    assert!(record_error(2.0).is_ok());
+impl Guest for Component {
+    fn run() {
+        assert_eq!(string_error(0.0), Err("zero".to_owned()));
+        assert_eq!(string_error(1.0), Ok(1.0));
 
-    assert!(matches!(
-        variant_error(0.0),
-        Err(E3::E2(E2 {
-            line: 420,
-            column: 0
-        }))
-    ));
-    assert!(matches!(variant_error(1.0), Err(E3::E1(E::B))));
-    assert!(matches!(variant_error(2.0), Err(E3::E1(E::C))));
+        assert_eq!(enum_error(0.0), Err(E::A));
+        assert_eq!(enum_error(1.0), Ok(1.0));
 
-    assert_eq!(empty_error(0), Err(()));
-    assert_eq!(empty_error(1), Ok(42));
-    assert_eq!(empty_error(2), Ok(2));
+        assert!(matches!(
+            record_error(0.0),
+            Err(E2 {
+                line: 420,
+                column: 0
+            })
+        ));
+        assert!(matches!(
+            record_error(1.0),
+            Err(E2 {
+                line: 77,
+                column: 2
+            })
+        ));
+        assert!(record_error(2.0).is_ok());
 
-    assert_eq!(double_error(0), Ok(Ok(())));
-    assert_eq!(double_error(1), Ok(Err("one".into())));
-    assert_eq!(double_error(2), Err("two".into()));
+        assert!(matches!(
+            variant_error(0.0),
+            Err(E3::E2(E2 {
+                line: 420,
+                column: 0
+            }))
+        ));
+        assert!(matches!(variant_error(1.0), Err(E3::E1(E::B))));
+        assert!(matches!(variant_error(2.0), Err(E3::E1(E::C))));
+
+        assert_eq!(empty_error(0), Err(()));
+        assert_eq!(empty_error(1), Ok(42));
+        assert_eq!(empty_error(2), Ok(2));
+
+        assert_eq!(double_error(0), Ok(Ok(())));
+        assert_eq!(double_error(1), Ok(Err("one".into())));
+        assert_eq!(double_error(2), Err("two".into()));
+    }
 }

--- a/tests/runtime/results/test.wit
+++ b/tests/runtime/results/test.wit
@@ -32,4 +32,6 @@ world intermediate {
 
 world runner {
   import test;
+
+  export run: func();
 }

--- a/tests/runtime/rust/alternative-bitflags/runner.rs
+++ b/tests/runtime/rust/alternative-bitflags/runner.rs
@@ -6,6 +6,12 @@ pub(crate) use wit_bindgen::rt::bitflags as my_bitflags;
 
 use crate::my::inline::t::{get_flag, Bar};
 
-fn main() {
-    assert_eq!(get_flag(), Bar::BAZ);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        assert_eq!(get_flag(), Bar::BAZ);
+    }
 }

--- a/tests/runtime/rust/alternative-bitflags/test.wit
+++ b/tests/runtime/rust/alternative-bitflags/test.wit
@@ -16,4 +16,6 @@ world test {
 
 world runner {
   import t;
+
+  export run: func();
 }

--- a/tests/runtime/rust/custom-derives/runner.rs
+++ b/tests/runtime/rust/custom-derives/runner.rs
@@ -2,9 +2,15 @@ include!(env!("BINDINGS"));
 
 use crate::my::inline::blah::{bar, Foo};
 
-fn main() {
-    bar(&Foo {
-        field1: "x".to_string(),
-        field2: vec![2, 3, 3, 4],
-    });
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        bar(&Foo {
+            field1: "x".to_string(),
+            field2: vec![2, 3, 3, 4],
+        });
+    }
 }

--- a/tests/runtime/rust/custom-derives/test.wit
+++ b/tests/runtime/rust/custom-derives/test.wit
@@ -28,4 +28,6 @@ world test {
 }
 world runner {
     import blah;
+
+    export run: func();
 }

--- a/tests/runtime/rust/disable-custom-section-link-helpers/runner.rs
+++ b/tests/runtime/rust/disable-custom-section-link-helpers/runner.rs
@@ -4,6 +4,12 @@ include!(env!("BINDINGS"));
 
 use crate::a::x;
 
-fn main() {
-    x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        x();
+    }
 }

--- a/tests/runtime/rust/disable-custom-section-link-helpers/test.wit
+++ b/tests/runtime/rust/disable-custom-section-link-helpers/test.wit
@@ -4,6 +4,8 @@ world runner {
     import a: interface {
         x: func();
     }
+
+    export run: func();
 }
 world test {
     export a: interface {

--- a/tests/runtime/rust/other-dependencies/runner.rs
+++ b/tests/runtime/rust/other-dependencies/runner.rs
@@ -4,6 +4,8 @@ wit_bindgen::generate!({
 
         world test {
             import other:test/test;
+
+            export run: func();
         }
     "#,
     path: "./other.wit",
@@ -12,6 +14,12 @@ wit_bindgen::generate!({
     }
 });
 
-fn main() {
-    other::test::test::f();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        other::test::test::f();
+    }
 }

--- a/tests/runtime/rust/owned-resource-deref-mut/runner.rs
+++ b/tests/runtime/rust/owned-resource-deref-mut/runner.rs
@@ -2,8 +2,14 @@ include!(env!("BINDINGS"));
 
 use crate::my::inline::foo::Bar;
 
-fn main() {
-    let data = Bar::new(3);
-    assert_eq!(data.get_data(), 3);
-    assert_eq!(Bar::consume(data), 4);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let data = Bar::new(3);
+        assert_eq!(data.get_data(), 3);
+        assert_eq!(Bar::consume(data), 4);
+    }
 }

--- a/tests/runtime/rust/owned-resource-deref-mut/test.wit
+++ b/tests/runtime/rust/owned-resource-deref-mut/test.wit
@@ -13,4 +13,6 @@ world test {
 }
 world runner {
     import foo;
+
+    export run: func();
 }

--- a/tests/runtime/rust/ownership/runner-borrowing-duplicate-if-necessary.rs
+++ b/tests/runtime/rust/ownership/runner-borrowing-duplicate-if-necessary.rs
@@ -8,36 +8,42 @@ impl PartialEq for thing_in_and_out::ThingResult {
     }
 }
 
-fn main() {
-    let value = &[&["foo", "bar"] as &[_]] as &[_];
-    assert_eq!(
-        vec![vec!["foo".to_owned(), "bar".to_owned()]],
-        lists::foo(value)
-    );
+struct Component;
 
-    thing_in::bar(thing_in::Thing {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    });
+export!(Component);
 
-    let value = thing_in_and_out::ThingParam {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    };
-    assert_eq!(
-        thing_in_and_out::ThingResult {
-            name: "thing 1".to_owned(),
-            value: vec!["some value".to_owned(), "another value".to_owned()],
-        },
-        thing_in_and_out::baz(value)
-    );
+impl Guest for Component {
+    fn run() {
+        let value = &[&["foo", "bar"] as &[_]] as &[_];
+        assert_eq!(
+            vec![vec!["foo".to_owned(), "bar".to_owned()]],
+            lists::foo(value)
+        );
 
-    let strings = vec!["foo", "bar", "baz"];
-    let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
-    test::ownership::both_list_and_resource::list_and_resource(
-        test::ownership::both_list_and_resource::Thing {
-            a: strings.iter().map(|s| s.to_string()).collect(),
-            b: resource,
-        },
-    );
+        thing_in::bar(thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        });
+
+        let value = thing_in_and_out::ThingParam {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        };
+        assert_eq!(
+            thing_in_and_out::ThingResult {
+                name: "thing 1".to_owned(),
+                value: vec!["some value".to_owned(), "another value".to_owned()],
+            },
+            thing_in_and_out::baz(value)
+        );
+
+        let strings = vec!["foo", "bar", "baz"];
+        let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
+        test::ownership::both_list_and_resource::list_and_resource(
+            test::ownership::both_list_and_resource::Thing {
+                a: strings.iter().map(|s| s.to_string()).collect(),
+                b: resource,
+            },
+        );
+    }
 }

--- a/tests/runtime/rust/ownership/runner-borrowing.rs
+++ b/tests/runtime/rust/ownership/runner-borrowing.rs
@@ -8,30 +8,36 @@ impl PartialEq for thing_in_and_out::Thing {
     }
 }
 
-fn main() {
-    let value = &[&["foo", "bar"] as &[_]] as &[_];
-    assert_eq!(
-        vec![vec!["foo".to_owned(), "bar".to_owned()]],
-        lists::foo(value)
-    );
+struct Component;
 
-    thing_in::bar(thing_in::Thing {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    });
+export!(Component);
 
-    let value = thing_in_and_out::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    };
-    assert_eq!(value, thing_in_and_out::baz(&value));
+impl Guest for Component {
+    fn run() {
+        let value = &[&["foo", "bar"] as &[_]] as &[_];
+        assert_eq!(
+            vec![vec!["foo".to_owned(), "bar".to_owned()]],
+            lists::foo(value)
+        );
 
-    let strings = vec!["foo", "bar", "baz"];
-    let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
-    test::ownership::both_list_and_resource::list_and_resource(
-        test::ownership::both_list_and_resource::Thing {
-            a: strings.iter().map(|s| s.to_string()).collect(),
-            b: resource,
-        },
-    );
+        thing_in::bar(thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        });
+
+        let value = thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, thing_in_and_out::baz(&value));
+
+        let strings = vec!["foo", "bar", "baz"];
+        let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
+        test::ownership::both_list_and_resource::list_and_resource(
+            test::ownership::both_list_and_resource::Thing {
+                a: strings.iter().map(|s| s.to_string()).collect(),
+                b: resource,
+            },
+        );
+    }
 }

--- a/tests/runtime/rust/ownership/runner-owning.rs
+++ b/tests/runtime/rust/ownership/runner-owning.rs
@@ -7,27 +7,33 @@ impl PartialEq for thing_in_and_out::Thing {
     }
 }
 
-fn main() {
-    let value = vec![vec!["foo".to_owned(), "bar".to_owned()]];
-    assert_eq!(value, lists::foo(&value));
+struct Component;
 
-    thing_in::bar(&thing_in::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    });
+export!(Component);
 
-    let value = thing_in_and_out::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    };
-    assert_eq!(value, thing_in_and_out::baz(&value));
+impl Guest for Component {
+    fn run() {
+        let value = vec![vec!["foo".to_owned(), "bar".to_owned()]];
+        assert_eq!(value, lists::foo(&value));
 
-    let strings = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];
-    let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
-    test::ownership::both_list_and_resource::list_and_resource(
-        test::ownership::both_list_and_resource::Thing {
-            a: strings,
-            b: resource,
-        },
-    );
+        thing_in::bar(&thing_in::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        });
+
+        let value = thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, thing_in_and_out::baz(&value));
+
+        let strings = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];
+        let resource = test::ownership::both_list_and_resource::TheResource::new(&strings);
+        test::ownership::both_list_and_resource::list_and_resource(
+            test::ownership::both_list_and_resource::Thing {
+                a: strings,
+                b: resource,
+            },
+        );
+    }
 }

--- a/tests/runtime/rust/ownership/test.wit
+++ b/tests/runtime/rust/ownership/test.wit
@@ -36,6 +36,8 @@ world runner {
     }
 
     import both-list-and-resource;
+
+    export run: func();
 }
 
 world test {

--- a/tests/runtime/rust/raw-strings/runner-nostd.rs
+++ b/tests/runtime/rust/raw-strings/runner-nostd.rs
@@ -8,11 +8,17 @@ use alloc::vec::Vec;
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&str`
-    cat::foo(b"hello");
+struct Component;
 
-    // Test the return type is `String`
-    let t: Vec<u8> = cat::bar();
-    assert_eq!(t, b"world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&str`
+        cat::foo(b"hello");
+
+        // Test the return type is `String`
+        let t: Vec<u8> = cat::bar();
+        assert_eq!(t, b"world");
+    }
 }

--- a/tests/runtime/rust/raw-strings/runner-std.rs
+++ b/tests/runtime/rust/raw-strings/runner-std.rs
@@ -2,11 +2,17 @@
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&[u8]`
-    cat::foo(b"hello");
+struct Component;
 
-    // Test the return type is `Vec<u8>`
-    let t: Vec<u8> = cat::bar();
-    assert_eq!(t, b"world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&[u8]`
+        cat::foo(b"hello");
+
+        // Test the return type is `Vec<u8>`
+        let t: Vec<u8> = cat::bar();
+        assert_eq!(t, b"world");
+    }
 }

--- a/tests/runtime/rust/raw-strings/test.wit
+++ b/tests/runtime/rust/raw-strings/test.wit
@@ -5,6 +5,8 @@ world runner {
     foo: func(x: string);
     bar: func() -> string;
   }
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/rust/resource_into_inner/runner.rs
+++ b/tests/runtime/rust/resource_into_inner/runner.rs
@@ -1,5 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    crate::test::resource_into_inner::to_test::test();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        crate::test::resource_into_inner::to_test::test();
+    }
 }

--- a/tests/runtime/rust/resource_into_inner/test.wit
+++ b/tests/runtime/rust/resource_into_inner/test.wit
@@ -14,4 +14,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/rust/run-ctors-once-workaround/runner.rs
+++ b/tests/runtime/rust/run-ctors-once-workaround/runner.rs
@@ -2,6 +2,12 @@
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    the::test::i::apply_the_workaround();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        the::test::i::apply_the_workaround();
+    }
 }

--- a/tests/runtime/rust/run-ctors-once-workaround/test.wit
+++ b/tests/runtime/rust/run-ctors-once-workaround/test.wit
@@ -6,6 +6,8 @@ interface i {
 
 world runner {
   import i;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/rust/skip/runner.rs
+++ b/tests/runtime/rust/skip/runner.rs
@@ -1,6 +1,12 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    exports::foo();
-    exports::bar();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        exports::foo();
+        exports::bar();
+    }
 }

--- a/tests/runtime/rust/skip/test.wit
+++ b/tests/runtime/rust/skip/test.wit
@@ -5,6 +5,8 @@ world runner {
     foo: func();
     bar: func();
   }
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/rust/type_section_suffix/runner.rs
+++ b/tests/runtime/rust/type_section_suffix/runner.rs
@@ -33,9 +33,15 @@ mod d {
     });
 }
 
-fn main() {
-    a::test::suffix::imports::foo();
-    b::test::suffix::imports::foo();
-    c::foo::f();
-    d::bar::f();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        a::test::suffix::imports::foo();
+        b::test::suffix::imports::foo();
+        c::foo::f();
+        d::bar::f();
+    }
 }

--- a/tests/runtime/rust/type_section_suffix/test.wit
+++ b/tests/runtime/rust/type_section_suffix/test.wit
@@ -12,6 +12,8 @@ world available-imports {
 
 world runner {
   include available-imports;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/rust/with-and-resources/runner.rs
+++ b/tests/runtime/rust/with-and-resources/runner.rs
@@ -20,7 +20,13 @@ mod other {
     });
 }
 
-fn main() {
-    let resource = other::my::inline::foo::bar();
-    my::inline::bar::bar(resource);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let resource = other::my::inline::foo::bar();
+        my::inline::bar::bar(resource);
+    }
 }

--- a/tests/runtime/rust/with-and-resources/test.wit
+++ b/tests/runtime/rust/with-and-resources/test.wit
@@ -19,4 +19,6 @@ world test {
 
 world runner {
     import bar;
+
+    export run: func();
 }

--- a/tests/runtime/rust/with-only-affects-imports/runner.rs
+++ b/tests/runtime/rust/with-only-affects-imports/runner.rs
@@ -1,5 +1,11 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    my::inline::foo::bar(my::inline::foo::A { b: 2 });
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        my::inline::foo::bar(my::inline::foo::A { b: 2 });
+    }
 }

--- a/tests/runtime/rust/with-only-affects-imports/test.wit
+++ b/tests/runtime/rust/with-only-affects-imports/test.wit
@@ -22,4 +22,6 @@ world test {
 
 world runner {
     import foo;
+
+    export run: func();
 }

--- a/tests/runtime/rust/with-option-generate/runner-generate-all.rs
+++ b/tests/runtime/rust/with-option-generate/runner-generate-all.rs
@@ -4,6 +4,12 @@ include!(env!("BINDINGS"));
 
 use crate::foo::baz::a::x;
 
-fn main() {
-    x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        x();
+    }
 }

--- a/tests/runtime/rust/with-option-generate/runner-generate-one.rs
+++ b/tests/runtime/rust/with-option-generate/runner-generate-one.rs
@@ -4,6 +4,12 @@ include!(env!("BINDINGS"));
 
 use crate::foo::baz::a::x;
 
-fn main() {
-    x();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        x();
+    }
 }

--- a/tests/runtime/rust/with-option-generate/test.wit
+++ b/tests/runtime/rust/with-option-generate/test.wit
@@ -10,6 +10,8 @@ world test {
 }
 world runner {
     import foo:baz/a;
+
+    export run: func();
 }
 
 package foo:baz {

--- a/tests/runtime/rust/with-types/runner.rs
+++ b/tests/runtime/rust/with-types/runner.rs
@@ -42,27 +42,33 @@ mod my_types {
     }
 }
 
-fn main() {
-    let a = my_types::MyA { inner: 0.0 };
-    let _ = my::inline::foo::func1(a);
+struct Component;
 
-    // can't actually succeed at runtime as this is faking a resource, so check
-    // that it compiles but dynamically skip it.
-    if false {
-        let b = my_types::MyB;
-        let _ = my::inline::foo::func2(b);
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let a = my_types::MyA { inner: 0.0 };
+        let _ = my::inline::foo::func1(a);
+
+        // can't actually succeed at runtime as this is faking a resource, so check
+        // that it compiles but dynamically skip it.
+        if false {
+            let b = my_types::MyB;
+            let _ = my::inline::foo::func2(b);
+        }
+
+        let c = my_types::MyC::A(a);
+        let _ = i::func7(c);
+
+        let a_list = vec![a, a];
+        let _ = my::inline::foo::func3(&a_list);
+
+        let _ = my::inline::foo::func4(Some(a));
+
+        let _ = my::inline::foo::func5();
+
+        let d = my_types::MyD { inner: 0 };
+        let _ = i::func8(d);
     }
-
-    let c = my_types::MyC::A(a);
-    let _ = i::func7(c);
-
-    let a_list = vec![a, a];
-    let _ = my::inline::foo::func3(&a_list);
-
-    let _ = my::inline::foo::func4(Some(a));
-
-    let _ = my::inline::foo::func5();
-
-    let d = my_types::MyD { inner: 0 };
-    let _ = i::func8(d);
 }

--- a/tests/runtime/rust/with-types/test.wit
+++ b/tests/runtime/rust/with-types/test.wit
@@ -73,4 +73,6 @@ world runner {
     }
 
     import bar;
+
+    export run: func();
 }

--- a/tests/runtime/rust/with/runner.rs
+++ b/tests/runtime/rust/with/runner.rs
@@ -21,9 +21,15 @@ mod other {
     });
 }
 
-fn main() {
-    let msg = other::my::inline::foo::Msg {
-        field: "hello".to_string(),
-    };
-    my::inline::bar::bar(&msg);
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let msg = other::my::inline::foo::Msg {
+            field: "hello".to_string(),
+        };
+        my::inline::bar::bar(&msg);
+    }
 }

--- a/tests/runtime/rust/with/test.wit
+++ b/tests/runtime/rust/with/test.wit
@@ -18,4 +18,6 @@ world test {
 
 world runner {
   import bar;
+
+  export run: func();
 }

--- a/tests/runtime/rust/xcrate/runner.rs
+++ b/tests/runtime/rust/xcrate/runner.rs
@@ -2,7 +2,13 @@ use crate::test::xcrate::b_exports::{b, X};
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    b();
-    X::new().foo();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        b();
+        X::new().foo();
+    }
 }

--- a/tests/runtime/rust/xcrate/test.wit
+++ b/tests/runtime/rust/xcrate/test.wit
@@ -62,6 +62,8 @@ world runner {
   import b-exports;
   import a-imports;
   import b-imports;
+
+  export run: func();
 }
 
 world intermediate {

--- a/tests/runtime/strings-alias/runner.rs
+++ b/tests/runtime/strings-alias/runner.rs
@@ -1,10 +1,16 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&str`
-    cat::foo("hello");
+struct Component;
 
-    // Test the return type is `String`
-    let t: String = cat::bar();
-    assert_eq!(t, "world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&str`
+        cat::foo("hello");
+
+        // Test the return type is `String`
+        let t: String = cat::bar();
+        assert_eq!(t, "world");
+    }
 }

--- a/tests/runtime/strings-alias/test.wit
+++ b/tests/runtime/strings-alias/test.wit
@@ -6,6 +6,8 @@ world runner {
     foo: func(x: my-string);
     bar: func() -> my-string;
   }
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/strings-simple/runner-nostd.rs
+++ b/tests/runtime/strings-simple/runner-nostd.rs
@@ -8,11 +8,17 @@ use alloc::string::String;
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&str`
-    cat::foo("hello");
+struct Component;
 
-    // Test the return type is `String`
-    let t: String = cat::bar();
-    assert_eq!(t, "world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&str`
+        cat::foo("hello");
+
+        // Test the return type is `String`
+        let t: String = cat::bar();
+        assert_eq!(t, "world");
+    }
 }

--- a/tests/runtime/strings-simple/runner-std.rs
+++ b/tests/runtime/strings-simple/runner-std.rs
@@ -1,10 +1,16 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    // Test the argument is `&str`
-    cat::foo("hello");
+struct Component;
 
-    // Test the return type is `String`
-    let t: String = cat::bar();
-    assert_eq!(t, "world");
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        // Test the argument is `&str`
+        cat::foo("hello");
+
+        // Test the return type is `String`
+        let t: String = cat::bar();
+        assert_eq!(t, "world");
+    }
 }

--- a/tests/runtime/strings-simple/test.wit
+++ b/tests/runtime/strings-simple/test.wit
@@ -5,6 +5,8 @@ world runner {
     foo: func(x: string);
     bar: func() -> string;
   }
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/strings/runner.c
+++ b/tests/runtime/strings/runner.c
@@ -19,7 +19,7 @@ void assert_str(runner_string_t* str, const char16_t* expected) {
     assert(memcmp(str->ptr, expected, expected_len * 2) == 0);
   }
 
-int main() {
+void exports_runner_run() {
     runner_string_t str1;
     runner_string_set(&str1, u"latin utf16");
     test_strings_to_test_take_basic(&str1);

--- a/tests/runtime/strings/runner.cpp
+++ b/tests/runtime/strings/runner.cpp
@@ -10,7 +10,7 @@ void assert_str(wit::string const& str, const char* expected) {
   assert(memcmp(str.data(), expected, expected_len) == 0);
 }
 
-int main() {
+void exports::runner::Run() {
     test::strings::to_test::TakeBasic("latin utf16");
 
     auto str2 = test::strings::to_test::ReturnUnicode();
@@ -21,6 +21,4 @@ int main() {
 
     auto str5 = test::strings::to_test::Roundtrip("🚀🚀🚀 𠈄𓀀");
     assert_str(str5, "🚀🚀🚀 𠈄𓀀");
-    
-    return 0;
 }

--- a/tests/runtime/strings/runner.cs
+++ b/tests/runtime/strings/runner.cs
@@ -4,9 +4,12 @@ using System.Diagnostics;
 using RunnerWorld.wit.imports.test.strings;
 using System.Text;
 
-public class Program 
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args){
+    public static void Run()
+    {
         ToTestInterop.TakeBasic("latin utf16");
         Debug.Assert(ToTestInterop.ReturnUnicode() == "🚀🚀🚀 𠈄𓀀");
 

--- a/tests/runtime/strings/runner.rs
+++ b/tests/runtime/strings/runner.rs
@@ -2,9 +2,15 @@ include!(env!("BINDINGS"));
 
 use crate::test::strings::to_test::*;
 
-fn main() {
-    take_basic("latin utf16");
-    assert_eq!(return_unicode(), "🚀🚀🚀 𠈄𓀀");
-    assert_eq!(return_empty(), "");
-    assert_eq!(roundtrip("🚀🚀🚀 𠈄𓀀"), "🚀🚀🚀 𠈄𓀀");
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        take_basic("latin utf16");
+        assert_eq!(return_unicode(), "🚀🚀🚀 𠈄𓀀");
+        assert_eq!(return_empty(), "");
+        assert_eq!(roundtrip("🚀🚀🚀 𠈄𓀀"), "🚀🚀🚀 𠈄𓀀");
+    }
 }

--- a/tests/runtime/strings/test.wit
+++ b/tests/runtime/strings/test.wit
@@ -13,4 +13,6 @@ world test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }

--- a/tests/runtime/symbol-conflicts/runner.rs
+++ b/tests/runtime/symbol-conflicts/runner.rs
@@ -1,8 +1,14 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    my::inline::foo1::foo();
-    my::inline::foo2::foo();
-    my::inline::bar1::bar();
-    my::inline::bar2::bar();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        my::inline::foo1::foo();
+        my::inline::foo2::foo();
+        my::inline::bar1::bar();
+        my::inline::bar2::bar();
+    }
 }

--- a/tests/runtime/symbol-conflicts/test.wit
+++ b/tests/runtime/symbol-conflicts/test.wit
@@ -28,4 +28,6 @@ world runner {
   import foo2;
   import bar1;
   import bar2;
+
+  export run: func();
 }

--- a/tests/runtime/unused-types/runner.rs
+++ b/tests/runtime/unused-types/runner.rs
@@ -9,6 +9,12 @@ use foo::bar::component::UnusedVariant as _;
 
 include!(env!("BINDINGS"));
 
-fn main() {
-    foo::bar::component::foo();
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        foo::bar::component::foo();
+    }
 }

--- a/tests/runtime/unused-types/test.wit
+++ b/tests/runtime/unused-types/test.wit
@@ -5,6 +5,8 @@ world test {
 }
 world runner {
     import component;
+
+    export run: func();
 }
 
 interface component {

--- a/tests/runtime/variants/runner.c
+++ b/tests/runtime/variants/runner.c
@@ -2,7 +2,7 @@
 #include <runner.h>
 #include <stddef.h>
 
-int main() {
+void exports_runner_run() {
     {
         float a = 1;
         uint8_t r;
@@ -130,6 +130,4 @@ int main() {
         assert(!ret.f1.is_err);
         assert(ret.f2 == TEST_VARIANTS_TO_TEST_MY_ERRNO_SUCCESS);
     }
-
-    return 0;
 }

--- a/tests/runtime/variants/runner.cpp
+++ b/tests/runtime/variants/runner.cpp
@@ -150,7 +150,7 @@ static bool equal(std::tuple<A,B,C> a, std::tuple<A,B,C> b) {
         equal(std::get<2>(a), std::get<2>(b));
 }
 
-int main()
+void exports::runner::Run()
 {
     using namespace ::test::variants::to_test;
 
@@ -167,9 +167,9 @@ int main()
     assert(equal(InvertBool(true), false));
     assert(equal(InvertBool(false), true));
 
-    assert(equal(VariantCasts(std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::A{1}}, C2{C2::A{2}}, C3{C3::A{3}}, C4{C4::A{4}}, C5{C5::A{5}}, C6{C6::A{6.0}})), 
+    assert(equal(VariantCasts(std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::A{1}}, C2{C2::A{2}}, C3{C3::A{3}}, C4{C4::A{4}}, C5{C5::A{5}}, C6{C6::A{6.0}})),
         std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::A{1}}, C2{C2::A{2}}, C3{C3::A{3}}, C4{C4::A{4}}, C5{C5::A{5}}, C6{C6::A{6.0}}) ));
-    assert(equal(VariantCasts(std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::B{1}}, C2{C2::B{2.0}}, C3{C3::B{3.0}}, C4{C4::B{4.0}}, C5{C5::B{5.0}}, C6{C6::B{6.0}})), 
+    assert(equal(VariantCasts(std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::B{1}}, C2{C2::B{2.0}}, C3{C3::B{3.0}}, C4{C4::B{4.0}}, C5{C5::B{5.0}}, C6{C6::B{6.0}})),
         std::tuple<C1, C2, C3, C4, C5, C6>(C1{C1::B{1}}, C2{C2::B{2.0}}, C3{C3::B{3.0}}, C4{C4::B{4.0}}, C5{C5::B{5.0}}, C6{C6::B{6.0}}) ));
 
     assert(equal(VariantZeros(std::tuple<Z1, Z2, Z3, Z4>(Z1{Z1::A{1}}, Z2{Z2::A{2}}, Z3{Z3::A{3.0}}, Z4{Z4::A{4.0}})), std::tuple<Z1, Z2, Z3, Z4>(Z1{Z1::A{1}}, Z2{Z2::A{2}}, Z3{Z3::A{3.0}}, Z4{Z4::A{4.0}})));

--- a/tests/runtime/variants/runner.cs
+++ b/tests/runtime/variants/runner.cs
@@ -5,9 +5,11 @@ using RunnerWorld.wit.imports.test.variants;
 using System.Text;
 using RunnerWorld;
 
-public class Program
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args)
+    public static void Run()
     {
         Debug.Assert(ToTestInterop.RoundtripOption(1.0f).Value == 1);
         Debug.Assert(ToTestInterop.RoundtripOption(null).HasValue == false);

--- a/tests/runtime/variants/runner.rs
+++ b/tests/runtime/variants/runner.rs
@@ -2,60 +2,66 @@ include!(env!("BINDINGS"));
 
 use crate::test::variants::to_test::*;
 
-fn main() {
-    assert_eq!(roundtrip_option(Some(1.0)), Some(1));
-    assert_eq!(roundtrip_option(None), None);
-    assert_eq!(roundtrip_option(Some(2.0)), Some(2));
-    assert_eq!(roundtrip_result(Ok(2)), Ok(2.0));
-    assert_eq!(roundtrip_result(Ok(4)), Ok(4.0));
-    assert_eq!(roundtrip_result(Err(5.3)), Err(5));
+struct Component;
 
-    assert_eq!(roundtrip_enum(E1::A), E1::A);
-    assert_eq!(roundtrip_enum(E1::B), E1::B);
+export!(Component);
 
-    assert_eq!(invert_bool(true), false);
-    assert_eq!(invert_bool(false), true);
+impl Guest for Component {
+    fn run() {
+        assert_eq!(roundtrip_option(Some(1.0)), Some(1));
+        assert_eq!(roundtrip_option(None), None);
+        assert_eq!(roundtrip_option(Some(2.0)), Some(2));
+        assert_eq!(roundtrip_result(Ok(2)), Ok(2.0));
+        assert_eq!(roundtrip_result(Ok(4)), Ok(4.0));
+        assert_eq!(roundtrip_result(Err(5.3)), Err(5));
 
-    let (a1, a2, a3, a4, a5, a6) =
-        variant_casts((C1::A(1), C2::A(2), C3::A(3), C4::A(4), C5::A(5), C6::A(6.0)));
-    assert!(matches!(a1, C1::A(1)));
-    assert!(matches!(a2, C2::A(2)));
-    assert!(matches!(a3, C3::A(3)));
-    assert!(matches!(a4, C4::A(4)));
-    assert!(matches!(a5, C5::A(5)));
-    assert!(matches!(a6, C6::A(b) if b == 6.0));
+        assert_eq!(roundtrip_enum(E1::A), E1::A);
+        assert_eq!(roundtrip_enum(E1::B), E1::B);
 
-    let (a1, a2, a3, a4, a5, a6) = variant_casts((
-        C1::B(1),
-        C2::B(2.0),
-        C3::B(3.0),
-        C4::B(4.0),
-        C5::B(5.0),
-        C6::B(6.0),
-    ));
-    assert!(matches!(a1, C1::B(1)));
-    assert!(matches!(a2, C2::B(b) if b == 2.0));
-    assert!(matches!(a3, C3::B(b) if b == 3.0));
-    assert!(matches!(a4, C4::B(b) if b == 4.0));
-    assert!(matches!(a5, C5::B(b) if b == 5.0));
-    assert!(matches!(a6, C6::B(b) if b == 6.0));
+        assert_eq!(invert_bool(true), false);
+        assert_eq!(invert_bool(false), true);
 
-    let (a1, a2, a3, a4) = variant_zeros((Z1::A(1), Z2::A(2), Z3::A(3.0), Z4::A(4.0)));
-    assert!(matches!(a1, Z1::A(1)));
-    assert!(matches!(a2, Z2::A(2)));
-    assert!(matches!(a3, Z3::A(b) if b == 3.0));
-    assert!(matches!(a4, Z4::A(b) if b == 4.0));
+        let (a1, a2, a3, a4, a5, a6) =
+            variant_casts((C1::A(1), C2::A(2), C3::A(3), C4::A(4), C5::A(5), C6::A(6.0)));
+        assert!(matches!(a1, C1::A(1)));
+        assert!(matches!(a2, C2::A(2)));
+        assert!(matches!(a3, C3::A(3)));
+        assert!(matches!(a4, C4::A(4)));
+        assert!(matches!(a5, C5::A(5)));
+        assert!(matches!(a6, C6::A(b) if b == 6.0));
 
-    let (a1, a2, a3, a4) = variant_zeros((Z1::B, Z2::B, Z3::B, Z4::B));
-    assert!(matches!(a1, Z1::B));
-    assert!(matches!(a2, Z2::B));
-    assert!(matches!(a3, Z3::B));
-    assert!(matches!(a4, Z4::B));
+        let (a1, a2, a3, a4, a5, a6) = variant_casts((
+            C1::B(1),
+            C2::B(2.0),
+            C3::B(3.0),
+            C4::B(4.0),
+            C5::B(5.0),
+            C6::B(6.0),
+        ));
+        assert!(matches!(a1, C1::B(1)));
+        assert!(matches!(a2, C2::B(b) if b == 2.0));
+        assert!(matches!(a3, C3::B(b) if b == 3.0));
+        assert!(matches!(a4, C4::B(b) if b == 4.0));
+        assert!(matches!(a5, C5::B(b) if b == 5.0));
+        assert!(matches!(a6, C6::B(b) if b == 6.0));
 
-    variant_typedefs(None, false, Err(()));
+        let (a1, a2, a3, a4) = variant_zeros((Z1::A(1), Z2::A(2), Z3::A(3.0), Z4::A(4.0)));
+        assert!(matches!(a1, Z1::A(1)));
+        assert!(matches!(a2, Z2::A(2)));
+        assert!(matches!(a3, Z3::A(b) if b == 3.0));
+        assert!(matches!(a4, Z4::A(b) if b == 4.0));
 
-    assert_eq!(
-        variant_enums(true, Ok(()), MyErrno::Success),
-        (true, Ok(()), MyErrno::Success)
-    );
+        let (a1, a2, a3, a4) = variant_zeros((Z1::B, Z2::B, Z3::B, Z4::B));
+        assert!(matches!(a1, Z1::B));
+        assert!(matches!(a2, Z2::B));
+        assert!(matches!(a3, Z3::B));
+        assert!(matches!(a4, Z4::B));
+
+        variant_typedefs(None, false, Err(()));
+
+        assert_eq!(
+            variant_enums(true, Ok(()), MyErrno::Success),
+            (true, Ok(()), MyErrno::Success)
+        );
+    }
 }

--- a/tests/runtime/variants/test.wit
+++ b/tests/runtime/variants/test.wit
@@ -36,6 +36,8 @@ interface to-test {
 
 world runner {
   import to-test;
+
+  export run: func();
 }
 
 world test {

--- a/tests/runtime/versions/runner.cs
+++ b/tests/runtime/versions/runner.cs
@@ -5,9 +5,12 @@ using v1 = RunnerWorld.wit.imports.test.dep.v0_1_0;
 using v2 = RunnerWorld.wit.imports.test.dep.v0_2_0;
 using System.Text;
 
-public class Program 
+namespace RunnerWorld;
+
+public class RunnerWorldImpl : IRunnerWorld
 {
-    public static void Main(string[] args){
+    public static void Run()
+    {
         Debug.Assert(v1.TestInterop.X() == 1.0f);
         Debug.Assert(v1.TestInterop.Y(1.0f) == 2.0f);
 

--- a/tests/runtime/versions/runner.rs
+++ b/tests/runtime/versions/runner.rs
@@ -1,11 +1,17 @@
 include!(env!("BINDINGS"));
 
-fn main() {
-    use test::dep0_1_0::test as v1;
-    assert_eq!(v1::x(), 1.0);
-    assert_eq!(v1::y(1.0), 2.0);
+struct Component;
 
-    use test::dep0_2_0::test as v2;
-    assert_eq!(v2::x(), 2.0);
-    assert_eq!(v2::z(1.0, 1.0), 4.0);
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        use test::dep0_1_0::test as v1;
+        assert_eq!(v1::x(), 1.0);
+        assert_eq!(v1::y(1.0), 2.0);
+
+        use test::dep0_2_0::test as v2;
+        assert_eq!(v2::x(), 2.0);
+        assert_eq!(v2::z(1.0, 1.0), 4.0);
+    }
 }

--- a/tests/runtime/versions/test.wit
+++ b/tests/runtime/versions/test.wit
@@ -3,6 +3,8 @@ package test:versions;
 world runner {
   import test:dep/test@0.1.0;
   import test:dep/test@0.2.0;
+
+  export run: func();
 }
 
 world test {


### PR DESCRIPTION
This commit switches the way tests are built such that all binaries produced are "reactors" or those without a `main` function. This ensures that all imports/exports are fully described with WIT in this repository as opposed to implicitly relying on `wasi:cli/run`. This additionally means that testing in this repository no longer relies on toolchain conventions for the `wasi:cli/run` world making testing a bit more self-contained here, especially in the context of async.

This notably came up on #1447 which should make some of the tests there easier to write and more idiomatic.