### PR TITLE
Remove `backpressure.set` bindings

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -756,7 +756,6 @@ typedef enum {snake}_waitable_state {{
     {shouty}_WAITABLE_CANCELLED,
 }} {snake}_waitable_state_t;
 
-void {snake}_backpressure_set(bool enable);
 void {snake}_backpressure_inc(void);
 void {snake}_backpressure_dec(void);
 void* {snake}_context_get(void);
@@ -821,13 +820,6 @@ extern void __task_cancel(void);
 
 void {snake}_task_cancel() {{
     __task_cancel();
-}}
-
-__attribute__((__import_module__("$root"), __import_name__("[backpressure-set]")))
-extern void __backpressure_set(bool enable);
-
-void {snake}_backpressure_set(bool enable) {{
-    __backpressure_set(enable);
 }}
 
 __attribute__((__import_module__("$root"), __import_name__("[backpressure-inc]")))

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -873,9 +873,6 @@ pub mod examples;
 #[doc(hidden)]
 pub mod rt;
 
-#[cfg(feature = "async")]
-#[allow(deprecated)]
-pub use rt::async_support::backpressure_set;
 #[cfg(feature = "async-spawn")]
 pub use rt::async_support::spawn;
 #[cfg(feature = "inter-task-wakeup")]

--- a/crates/guest-rust/src/rt/async_support.rs
+++ b/crates/guest-rust/src/rt/async_support.rs
@@ -622,24 +622,6 @@ pub async fn yield_async() {
     Yield::default().await;
 }
 
-/// Call the `backpressure.set` canonical built-in function.
-///
-/// When `enabled` is `true`, this tells the host to defer any new calls to this
-/// component instance until further notice (i.e. until `backpressure.set` is
-/// called again with `enabled` set to `false`).
-#[deprecated = "use backpressure_{inc,dec} instead"]
-pub fn backpressure_set(enabled: bool) {
-    extern_wasm! {
-        #[link(wasm_import_module = "$root")]
-        extern "C" {
-            #[link_name = "[backpressure-set]"]
-            fn backpressure_set(_: i32);
-        }
-    }
-
-    unsafe { backpressure_set(if enabled { 1 } else { 0 }) }
-}
-
 /// Call the `backpressure.inc` canonical built-in function.
 pub fn backpressure_inc() {
     extern_wasm! {

--- a/tests/runtime-async/async/cancel-import/test.c
+++ b/tests/runtime-async/async/cancel-import/test.c
@@ -50,5 +50,9 @@ test_callback_code_t exports_test_pending_import_callback(test_event_t *event) {
 }
 
 void exports_test_backpressure_set(bool x) {
-  test_backpressure_set(x);
+  if (x) {
+    test_backpressure_inc();
+  } else {
+    test_backpressure_dec();
+  }
 }

--- a/tests/runtime-async/async/cancel-import/test.rs
+++ b/tests/runtime-async/async/cancel-import/test.rs
@@ -12,7 +12,10 @@ impl crate::exports::my::test::i::Guest for Component {
     }
 
     fn backpressure_set(x: bool) {
-        #[expect(deprecated)]
-        return wit_bindgen::backpressure_set(x);
+        if x {
+            wit_bindgen::backpressure_inc();
+        } else {
+            wit_bindgen::backpressure_dec();
+        }
     }
 }


### PR DESCRIPTION
This is on its way out and shouldn't be used.