### PR TITLE
enable async tests for Go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,12 +127,23 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
     - run: rustup target add wasm32-wasip2
+
+    # As of this writing, we need [a patched build of
+    # Go](https://github.com/dicej/go/releases/tag/go1.25.5-wasi-on-idle) to
+    # support async.
+    - name: Install Patched Go
+      run: |
+        curl -OL https://github.com/dicej/go/releases/download/go1.25.5-wasi-on-idle/go-linux-amd64-bootstrap.tbz
+        tar xf go-linux-amd64-bootstrap.tbz
+        echo "$(pwd)/go-linux-amd64-bootstrap/bin" >> $GITHUB_PATH
+
     - uses: ./.github/actions/install-wasi-sdk
     - run: |
-        cargo run test --languages rust,c tests/runtime-async \
+        cargo run test --languages rust,c,go tests/runtime-async \
           --artifacts target/artifacts \
           --rust-wit-bindgen-path ./crates/guest-rust \
           --runner "wasmtime -W component-model-async"

--- a/crates/go/README.md
+++ b/crates/go/README.md
@@ -33,6 +33,11 @@ world provided:
 - (if needed) `wit_types/wit_stream.go`: defines a `StreamReader` and `StreamWriter` types if required by the WIT world
 - (if needed) `wit_types/wit_future.go`: defines a `FutureReader` and `FutureWriter` types if required by the WIT world
 
+Note that async support currently requires [a patched version of
+Go](https://github.com/dicej/go/releases/tag/go1.25.5-wasi-on-idle).  Code
+generated for worlds that don't use any async features can be compiled using a
+stock release of Go.
+
 ## Example
 
 ### Prerequisites

--- a/crates/go/src/wit_async.go
+++ b/crates/go/src/wit_async.go
@@ -64,6 +64,9 @@ func Callback(event0, event1, event2 uint32) uint32 {
 	return callback(event0, event1, event2)
 }
 
+//go:linkname wasiOnIdle runtime.wasiOnIdle
+func wasiOnIdle(callback func() bool)
+
 func callback(event0, event1, event2 uint32) uint32 {
 	yielding := state.yielding
 	if state.yielding != nil {
@@ -109,12 +112,12 @@ func callback(event0, event1, event2 uint32) uint32 {
 	//
 	// Note that this function is _not_ currently part of upstream Go; it
 	// requires [this
-	// patch](https://github.com/dicej/go/commit/a1c83220fc9576cdb810e9624366cb998e69b22b)
-	runtime.WasiOnIdle(func() bool {
+	// patch](https://github.com/dicej/go/commit/40fc123d5bce6448fc4e4601fd33bad4250b36a5)
+	wasiOnIdle(func() bool {
 		state.channel <- unit{}
 		return true
 	})
-	defer runtime.WasiOnIdle(func() bool {
+	defer wasiOnIdle(func() bool {
 		return false
 	})
 

--- a/crates/test/src/go.rs
+++ b/crates/test/src/go.rs
@@ -18,16 +18,16 @@ impl LanguageMethods for Go {
 
     fn should_fail_verify(
         &self,
-        _name: &str,
+        name: &str,
         config: &crate::config::WitConfig,
         _args: &[String],
     ) -> bool {
         // TODO: We _do_ support async, but only with a build of Go that has
         // [this
-        // patch](https://github.com/dicej/go/commit/a1c83220fc9576cdb810e9624366cb998e69b22b).
-        // Once we either publish builds containing that patch or upstream
-        // something equivalent, we can remove the ` || config.async_` here.
-        config.error_context || config.async_
+        // patch](https://github.com/dicej/go/commit/40fc123d5bce6448fc4e4601fd33bad4250b36a5).
+        // Once we upstream something equivalent, we can remove the ` || name ==
+        // "async-trait-function.wit"` here.
+        config.error_context || name == "async-trait-function.wit"
     }
 
     fn default_bindgen_args_for_codegen(&self) -> &[&str] {


### PR DESCRIPTION
Also, I've updated the Go runtime patch to provide a private symbol (`wasiOnIdle`) rather than a public one (`WasiOnIdle`) and access it using a `//go:linkname` directive.