### PR TITLE
fix(core): async import emission

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -1100,10 +1100,21 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 }
 
                 // Emit the function return
-                self.emit(&Instruction::Return {
-                    func,
-                    amt: usize::from(func.result.is_some()),
-                });
+                if async_ {
+                    self.emit(&Instruction::AsyncTaskReturn {
+                        name: &func.name,
+                        params: if func.result.is_some() {
+                            &[WasmType::Pointer]
+                        } else {
+                            &[]
+                        },
+                    });
+                } else {
+                    self.emit(&Instruction::Return {
+                        func,
+                        amt: usize::from(func.result.is_some()),
+                    });
+                }
             }
 
             LiftLower::LiftArgsLowerResults => {


### PR DESCRIPTION
This commit fixes async import emissions in the case of lowered args and lifted resutls.

There were a few bugs to fix:

- AsyncTaskReturn was not being emitted

- Implementation for async imports was not present