### PR TITLE
go: restore handles on incomplete writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 version = "0.49.0"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/bytecodealliance/wit-bindgen"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 
 [workspace.dependencies]
 anyhow = "1.0.72"

--- a/crates/go/src/wit_runtime.go
+++ b/crates/go/src/wit_runtime.go
@@ -26,6 +26,16 @@ func (self *Handle) Take() int32 {
 	return value
 }
 
+func (self *Handle) Set(value int32) {
+	if value == 0 {
+		panic("nil handle")
+	}
+	if self.value != 0 {
+		panic("handle already set")
+	}
+	self.value = value
+}
+
 func (self *Handle) TakeOrNil() int32 {
 	value := self.value
 	self.value = 0

--- a/tests/runtime-async/async/incomplete-writes/leaf.go
+++ b/tests/runtime-async/async/incomplete-writes/leaf.go
@@ -1,0 +1,19 @@
+package export_my_test_leaf_interface
+
+import "runtime"
+
+type LeafThing struct {
+	pinner runtime.Pinner
+	handle int32
+	value  string
+}
+
+func (self *LeafThing) Get() string {
+	return self.value
+}
+
+func (self *LeafThing) OnDrop() {}
+
+func MakeLeafThing(value string) *LeafThing {
+	return &LeafThing{runtime.Pinner{}, 0, value}
+}

--- a/tests/runtime-async/async/incomplete-writes/runner.go
+++ b/tests/runtime-async/async/incomplete-writes/runner.go
@@ -1,0 +1,151 @@
+package export_wit_world
+
+import (
+	"fmt"
+	leaf "wit_component/my_test_leaf_interface"
+	test "wit_component/my_test_test_interface"
+)
+
+func Run() {
+	{
+		tx, rx := test.MakeStreamTestThing()
+		defer tx.Drop()
+		defer rx.Drop()
+
+		stream := test.ShortReadsTest(rx)
+		defer stream.Drop()
+
+		// Write the things all at once.  The callee will read them only
+		// one at a time, forcing us to re-take ownership of any
+		// unwritten items between writes.
+		tx.WriteAll([]*test.TestThing{
+			test.MakeTestThing("a"),
+			test.MakeTestThing("b"),
+			test.MakeTestThing("c"),
+		})
+		tx.Drop()
+
+		things := []*test.TestThing{}
+		for !stream.WriterDropped() {
+			// Read just one item at a time, forcing the writer to
+			// re-take ownership of any unwritten items between
+			// writes.
+			buffer := make([]*test.TestThing, 1)
+			count := stream.Read(buffer)
+			if count == 1 {
+				things = append(things, buffer[0])
+			}
+		}
+
+		assertEqual(things[0].Get(), "a")
+		assertEqual(things[1].Get(), "b")
+		assertEqual(things[2].Get(), "c")
+	}
+
+	{
+		tx, rx := test.MakeStreamMyTestLeafInterfaceLeafThing()
+		defer tx.Drop()
+		defer rx.Drop()
+
+		stream := test.ShortReadsLeaf(rx)
+		defer stream.Drop()
+
+		// Write the things all at once.  The callee will read them only
+		// one at a time, forcing us to re-take ownership of any
+		// unwritten items between writes.
+		tx.WriteAll([]*leaf.LeafThing{
+			leaf.MakeLeafThing("a"),
+			leaf.MakeLeafThing("b"),
+			leaf.MakeLeafThing("c"),
+		})
+		tx.Drop()
+
+		things := []*leaf.LeafThing{}
+		for !stream.WriterDropped() {
+			// Read just one item at a time, forcing the writer to
+			// re-take ownership of any unwritten items between
+			// writes.
+			buffer := make([]*leaf.LeafThing, 1)
+			count := stream.Read(buffer)
+			if count == 1 {
+				things = append(things, buffer[0])
+			}
+		}
+
+		assertEqual(things[0].Get(), "a")
+		assertEqual(things[1].Get(), "b")
+		assertEqual(things[2].Get(), "c")
+	}
+
+	{
+		tx1, rx1 := test.MakeFutureTestThing()
+		tx2, rx2 := test.MakeFutureTestThing()
+		f1, f2 := test.DroppedReaderTest(rx1, rx2)
+
+		{
+			// Write a thing to the first future, the read end of
+			// which the callee will drop without reading from,
+			// forcing us to re-take ownership.
+			thing := test.MakeTestThing("a")
+			assert(!tx1.Write(thing))
+
+			// Write it again to the second future.  This time, the
+			// callee will read it.
+			assert(tx2.Write(thing))
+		}
+
+		{
+			// Drop the first future without reading from it.  This
+			// will force the callee to re-take ownership of the
+			// thing it tried to write.
+			f1.Drop()
+
+			// Read from the second future and assert it matches
+			// what we wrote above.
+			thing := f2.Read()
+			assertEqual(thing.Get(), "a")
+		}
+	}
+
+	{
+		tx1, rx1 := test.MakeFutureMyTestLeafInterfaceLeafThing()
+		tx2, rx2 := test.MakeFutureMyTestLeafInterfaceLeafThing()
+		f1, f2 := test.DroppedReaderLeaf(rx1, rx2)
+
+		{
+			// Write a thing to the first future, the read end of
+			// which the callee will drop without reading from,
+			// forcing us to re-take ownership.
+			thing := leaf.MakeLeafThing("a")
+			assert(!tx1.Write(thing))
+
+			// Write it again to the second future.  This time, the
+			// callee will read it.
+			assert(tx2.Write(thing))
+		}
+
+		{
+			// Drop the first future without reading from it.  This
+			// will force the callee to re-take ownership of the
+			// thing it tried to write.
+			f1.Drop()
+
+			// Read from the second future and assert it matches
+			// what we wrote above.
+			thing := f2.Read()
+			assertEqual(thing.Get(), "a")
+		}
+	}
+}
+
+func assertEqual[T comparable](a T, b T) {
+	if a != b {
+		panic(fmt.Sprintf("%v not equal to %v", a, b))
+	}
+}
+
+func assert(v bool) {
+	if !v {
+		panic("assertion failed")
+	}
+}

--- a/tests/runtime-async/async/incomplete-writes/test.go
+++ b/tests/runtime-async/async/incomplete-writes/test.go
@@ -1,0 +1,135 @@
+package export_my_test_test_interface
+
+import (
+	"runtime"
+	. "wit_component/my_test_test_interface"
+	. "wit_component/wit_types"
+)
+
+type TestThing struct {
+	pinner runtime.Pinner
+	handle int32
+	value  string
+}
+
+func (self *TestThing) Get() string {
+	return self.value
+}
+
+func (self *TestThing) OnDrop() {}
+
+func MakeTestThing(value string) *TestThing {
+	return &TestThing{runtime.Pinner{}, 0, value}
+}
+
+func ShortReadsTest(stream *StreamReader[*TestThing]) *StreamReader[*TestThing] {
+	tx, rx := MakeStreamTestThing()
+
+	go func() {
+		defer stream.Drop()
+		defer tx.Drop()
+
+		things := []*TestThing{}
+		for !stream.WriterDropped() {
+			// Read just one item at a time, forcing the writer to
+			// re-take ownership of any unwritten items between
+			// writes.
+			buffer := make([]*TestThing, 1)
+			count := stream.Read(buffer)
+			if count == 1 {
+				things = append(things, buffer[0])
+			}
+		}
+
+		// Write the things all at once.  The caller will read them only
+		// one at a time, forcing us to re-take ownership of any
+		// unwritten items between writes.
+		tx.WriteAll(things)
+	}()
+
+	return rx
+}
+
+func ShortReadsLeaf(stream *StreamReader[*LeafThing]) *StreamReader[*LeafThing] {
+	tx, rx := MakeStreamMyTestLeafInterfaceLeafThing()
+
+	go func() {
+		defer stream.Drop()
+		defer tx.Drop()
+
+		things := []*LeafThing{}
+		for !stream.WriterDropped() {
+			// Read just one item at a time, forcing the writer to
+			// re-take ownership of any unwritten items between
+			// writes.
+			buffer := make([]*LeafThing, 1)
+			count := stream.Read(buffer)
+			if count == 1 {
+				things = append(things, buffer[0])
+			}
+		}
+
+		// Write the things all at once.  The caller will read them only
+		// one at a time, forcing us to re-take ownership of any
+		// unwritten items between writes.
+		tx.WriteAll(things)
+	}()
+
+	return rx
+}
+
+func DroppedReaderTest(f1, f2 *FutureReader[*TestThing]) (*FutureReader[*TestThing], *FutureReader[*TestThing]) {
+	tx1, rx1 := MakeFutureTestThing()
+	tx2, rx2 := MakeFutureTestThing()
+
+	go func() {
+		// Drop the first future without reading from it.  This will
+		// force the callee to re-take ownership of the thing it tried
+		// to write.
+		f1.Drop()
+
+		thing := f2.Read()
+
+		// Write the thing to the first future, the read end of which
+		// the calle4 will drop without reading from, forcing us to
+		// re-take ownership.
+		assert(!tx1.Write(thing))
+
+		// Write it again to the second future.  This time, the caller
+		// will read it.
+		assert(tx2.Write(thing))
+	}()
+
+	return rx1, rx2
+}
+
+func DroppedReaderLeaf(f1, f2 *FutureReader[*LeafThing]) (*FutureReader[*LeafThing], *FutureReader[*LeafThing]) {
+	tx1, rx1 := MakeFutureMyTestLeafInterfaceLeafThing()
+	tx2, rx2 := MakeFutureMyTestLeafInterfaceLeafThing()
+
+	go func() {
+		// Drop the first future without reading from it.  This will
+		// force the callee to re-take ownership of the thing it tried
+		// to write.
+		f1.Drop()
+
+		thing := f2.Read()
+
+		// Write the thing to the first future, the read end of which
+		// the calle4 will drop without reading from, forcing us to
+		// re-take ownership.
+		assert(!tx1.Write(thing))
+
+		// Write it again to the second future.  This time, the caller
+		// will read it.
+		assert(tx2.Write(thing))
+	}()
+
+	return rx1, rx2
+}
+
+func assert(v bool) {
+	if !v {
+		panic("assertion failed")
+	}
+}

--- a/tests/runtime-async/async/incomplete-writes/test.wit
+++ b/tests/runtime-async/async/incomplete-writes/test.wit
@@ -1,0 +1,38 @@
+//@ dependencies = ['test', 'leaf']
+
+package my:test;
+
+interface leaf-interface {
+  resource leaf-thing {
+    constructor(s: string);
+    get: func() -> string;
+  }
+}
+
+interface test-interface {
+  use leaf-interface.{leaf-thing};
+
+  resource test-thing {
+    constructor(s: string);
+    get: func() -> string;
+  }
+
+  short-reads-test: async func(s: stream<test-thing>) -> stream<test-thing>;
+  short-reads-leaf: async func(s: stream<leaf-thing>) -> stream<leaf-thing>;  
+
+  dropped-reader-test: async func(f1: future<test-thing>, f2: future<test-thing>) -> tuple<future<test-thing>, future<test-thing>>;
+  dropped-reader-leaf: async func(f1: future<leaf-thing>, f2: future<leaf-thing>) -> tuple<future<leaf-thing>, future<leaf-thing>>;
+}
+
+world leaf {
+  export leaf-interface;
+}
+
+world test {
+  export test-interface;
+}
+
+world runner {
+  import test-interface;
+  export run: async func();
+}


### PR DESCRIPTION
We now keep track of any resource/stream/future handles we've lowered while writing to a stream or future and restore any that were unwritten so they can be used (e.g. possibly written) again.

While I was working on this, clippy pointed out that `std::io::pipe` (which I started using in a previous commit) was added in Rust 1.87, so I've bumped the MSRV to match.

Also, the test case I added to cover this revealed another bug, which I've fixed here: we weren't generating valid code for async functions which return tuples.

Fixes #1458