### PR TITLE
wit-bindgen: generate only one StreamPayload or FuturePayload implementation per type alias set

### DIFF
--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -427,13 +427,19 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             Instruction::FutureLift { payload, .. } => {
                 let async_support = self.r#gen.r#gen.async_support_path();
                 let op = &operands[0];
-                let name = payload
-                    .as_ref()
-                    .map(|ty| {
-                        self.r#gen
-                            .type_name_owned_with_id(ty, Identifier::StreamOrFuturePayload)
-                    })
-                    .unwrap_or_else(|| "()".into());
+                let name = match payload {
+                    Some(Type::Id(type_id)) => {
+                        let dealiased_id = dealias(resolve, *type_id);
+                        self.r#gen.type_name_owned_with_id(
+                            &Type::Id(dealiased_id),
+                            Identifier::StreamOrFuturePayload,
+                        )
+                    }
+                    Some(ty) => self
+                        .r#gen
+                        .type_name_owned_with_id(ty, Identifier::StreamOrFuturePayload),
+                    None => "()".into(),
+                };
                 let ordinal = self
                     .r#gen
                     .r#gen
@@ -455,13 +461,19 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             Instruction::StreamLift { payload, .. } => {
                 let async_support = self.r#gen.r#gen.async_support_path();
                 let op = &operands[0];
-                let name = payload
-                    .as_ref()
-                    .map(|ty| {
-                        self.r#gen
-                            .type_name_owned_with_id(ty, Identifier::StreamOrFuturePayload)
-                    })
-                    .unwrap_or_else(|| "()".into());
+                let name = match payload {
+                    Some(Type::Id(type_id)) => {
+                        let dealiased_id = dealias(resolve, *type_id);
+                        self.r#gen.type_name_owned_with_id(
+                            &Type::Id(dealiased_id),
+                            Identifier::StreamOrFuturePayload,
+                        )
+                    }
+                    Some(ty) => self
+                        .r#gen
+                        .type_name_owned_with_id(ty, Identifier::StreamOrFuturePayload),
+                    None => "()".into(),
+                };
                 let ordinal = self
                     .r#gen
                     .r#gen

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -523,10 +523,13 @@ macro_rules! {macro_name} {{
         func_name: &str,
         payload_type: Option<&Type>,
     ) {
-        let name = if let Some(payload_type) = payload_type {
-            self.type_name_owned(payload_type)
-        } else {
-            "()".into()
+        let name = match payload_type {
+            Some(Type::Id(type_id)) => {
+                let dealiased_id = dealias(self.resolve, *type_id);
+                self.type_name_owned(&Type::Id(dealiased_id))
+            }
+            Some(payload_type) => self.type_name_owned(payload_type),
+            None => "()".into(),
         };
         let map = match payload_for {
             PayloadFor::Future => &mut self.r#gen.future_payloads,

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -49,6 +49,8 @@ impl LanguageMethods for Cpp {
             "async-trait-function.wit"
             | "error-context.wit"
             | "futures.wit"
+            | "import-export-future.wit"
+            | "import-export-stream.wit"
             | "resources-with-futures.wit"
             | "resources-with-streams.wit"
             | "streams.wit"

--- a/crates/test/src/csharp.rs
+++ b/crates/test/src/csharp.rs
@@ -48,6 +48,7 @@ impl LanguageMethods for Csharp {
                 | "error-context.wit"
                 | "resource-fallible-constructor.wit"
                 | "async-resource-func.wit"
+                | "import-export-stream.wit"
         )
     }
 

--- a/tests/codegen/import-export-future.wit
+++ b/tests/codegen/import-export-future.wit
@@ -1,0 +1,19 @@
+//@ async = true
+
+package a:b;
+
+world w {
+    import i;
+    export i;
+}
+
+interface i {
+    use t.{r};
+    f: func(p: future<r>);
+}
+
+interface t {
+    record r {
+        x: u32,
+    }
+}

--- a/tests/codegen/import-export-stream.wit
+++ b/tests/codegen/import-export-stream.wit
@@ -1,0 +1,19 @@
+//@ async = true
+
+package a:b;
+
+world w {
+    import i;
+    export i;
+}
+
+interface i {
+    use t.{r};
+    f: func(p: stream<r>);
+}
+
+interface t {
+    record r {
+        x: u32,
+    }
+}


### PR DESCRIPTION
WIT 'use' statements translate to Rust type aliases in the generated Rust bindings.

Since these aliases may be located at different module paths, creating a StreamPayload or FuturePayload implementation for more than one of these paths will cause the Rust compiler to complain about conflicting trait implementations for the same type.

This commit allows only one StreamPayload or FuturePayload implementation to be generated for a WIT type which will get transpiled into a Rust type alias, and it records mappings of the WIT type to the canonical module path to the type alias, which allows equivalent type aliases to reuse the implementation.

Fixes issue https://github.com/bytecodealliance/wit-bindgen/issues/1432