### PR TITLE
fix(csharp): Add runtime initialization guard for reactor components

### DIFF
--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -537,12 +537,14 @@ impl InterfaceGenerator<'_> {
         };
 
         let access = self.csharp_gen.access_modifier();
+        let qualifier = self.csharp_gen.qualifier();
 
         uwrite!(
             self.csharp_interop_src,
             r#"
             [global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute(EntryPoint = "{export_name}")]
             {access} static unsafe {wasm_result_type} {interop_name}({wasm_params}) {{
+                {qualifier}WasmInteropInitializer.EnsureInitialized();
                 {vars}
                 {src}
             }}


### PR DESCRIPTION
## Summary

This PR adds initialization guard infrastructure to the C# wit-bindgen code generator for reactor (library) components. It ensures `__wasm_call_ctors` is called before any exported function executes.

## Problem

When building .NET WASM components as libraries (reactors without a `_start` entry point), calling exports directly fails with:

**wasmtime:**
wasm trap: uninitialized element wasm backtrace: 0: InitializeGlobalTablesForModule


**jco/Node.js:**
RuntimeError: null function or function signature mismatch at InitializeGlobalTablesForModule


## Root Cause Analysis

The issue involves a circular dependency in the .NET NativeAOT-LLVM runtime:

1. Reactor components have no `_start` to trigger runtime initialization
2. When exports are called, `RhpReversePInvoke` attempts to initialize the runtime
3. But `RhpReversePInvoke` itself requires initialized function tables
4. This causes a crash during initialization, not before it

## This PR's Contribution

This PR adds the **correct initialization pattern** at the wit-bindgen layer:

```csharp
internal static class WasmInteropInitializer
{
    private static volatile bool _initialized;
    private static readonly object _lock = new object();

    [DllImport("*", EntryPoint = "__wasm_call_ctors")]
    private static extern void WasmCallCtors();

    internal static void EnsureInitialized()
    {
        if (_initialized) return;
        lock (_lock)
        {
            if (_initialized) return;
            WasmCallCtors();
            _initialized = true;
        }
    }
}
```

Each generated export function calls EnsureInitialized() first:

```csharp
[UnmanagedCallersOnly(EntryPoint = "test:minimal/plugin@1.0.0#get-id")]
public static unsafe nint wasmExportGetId() {
    MinimalWorld.WasmInteropInitializer.EnsureInitialized();
    // ... rest of export code
}
```

## Limitations
This fix alone does not fully resolve the issue. The complete solution requires changes in:
- NativeAOT-LLVM runtime: To properly handle reactor initialization where RhpReversePInvoke is called before tables are populated
- Or componentize-dotnet/wasm-tools adapter: To ensure _initialize is called before any exports

This PR establishes the correct pattern so that when the runtime-level fix is implemented, the initialization will be properly triggered.

## Testing
- Verified generated code includes WasmInteropInitializer class
- Verified EnsureInitialized() is called in all export functions
- Confirmed the crash now occurs during initialization (progress from "no init attempted")

## Related Issues
- https://github.com/bytecodealliance/componentize-dotnet/issues/103
- https://github.com/bytecodealliance/jco/issues/1173

Both issues report the same root cause - .NET reactor components crash when exports are called directly because runtime initialization hasn't occurred properly.