### PR TITLE
feat(go): preventing concurrent reads/writes on streams and futures

### DIFF
--- a/crates/go/src/package/wit_types/wit_future.go
+++ b/crates/go/src/package/wit_types/wit_future.go
@@ -26,6 +26,11 @@ type FutureReader[T any] struct {
 	handle *wit_runtime.Handle
 }
 
+// Blocks until the future completes and returns its value.
+//
+// # Panic
+//
+// Read will panic if multiple concurrent or sequential reads are attempted on the same future.
 func (self *FutureReader[T]) Read() T {
 	handle := self.handle.Take()
 	defer self.vtable.DropReadable(handle)
@@ -53,6 +58,7 @@ func (self *FutureReader[T]) Read() T {
 	}
 }
 
+// Notify the host that the FutureReader is no longer being used.
 func (self *FutureReader[T]) Drop() {
 	handle := self.handle.TakeOrNil()
 	if handle != 0 {
@@ -85,6 +91,11 @@ type FutureWriter[T any] struct {
 	handle *wit_runtime.Handle
 }
 
+// Writes data to a future.
+//
+// # Panic
+//
+// Write will panic if multiple concurrent or sequential writes are attempted on the same future.
 func (self *FutureWriter[T]) Write(item T) bool {
 	handle := self.handle.Take()
 	defer self.vtable.DropWritable(handle)
@@ -119,6 +130,7 @@ func (self *FutureWriter[T]) Write(item T) bool {
 	}
 }
 
+// Notify the host that the FutureWriter is no longer being used.
 func (self *FutureWriter[T]) Drop() {
 	handle := self.handle.TakeOrNil()
 	if handle != 0 {

--- a/tests/runtime-async/async/simple-future/runner.go
+++ b/tests/runtime-async/async/simple-future/runner.go
@@ -35,10 +35,80 @@ func Run() {
 		(<-read)
 		assert(!(<-write))
 	}
+
+	{
+		tx, rx := test.MakeFutureUnit()
+		syncBarrier := make(chan struct{})
+		panicCh := make(chan any, 2)
+
+		for range 2 {
+			go func() {
+				// Because the channel is empty, it will block until it's closed, at which
+				// point all Goroutines will attempt to simultaneously read from the future.
+				<-syncBarrier
+				panicCh <- checkPanicValue(func() {
+					rx.Read()
+				})
+			}()
+		}
+		close(syncBarrier)
+
+		go func() {
+			// If this is omitted, the host will see that the "rx.Read" operations aren't paired with 
+			// a "tx.Write" and will result in a "wasm trap: deadlock detected" error. Additionally, 
+			// this is placed after "close(syncBarrier)" to ensure that the panics are resulting from 
+			// concurrent reads, and not from other scenarios that result in a nil handle.
+			tx.Write(wit_types.Unit{})
+		}()
+
+		p1, p2 := <-panicCh, <-panicCh
+
+		// One should succeed (nil), one should panic
+		assert((p1 == nil && p2 == "nil handle") || (p1 == "nil handle" && p2 == nil))
+	}
+
+	{
+		tx, rx := test.MakeFutureUnit()
+		syncBarrier := make(chan struct{})
+		panicCh := make(chan any, 2)
+
+		for range 2 {
+			go func() {
+				// Because the channel is empty, it will block until it's closed, at which
+				// point all Goroutines will attempt to simultaneously write to the future.
+				<-syncBarrier
+				panicCh <- checkPanicValue(func() {
+					tx.Write(wit_types.Unit{})
+				})
+			}()
+		}
+		close(syncBarrier)
+
+		go func() {
+			// If this is omitted, the host will see that the "tx.Write" operations aren't paired with 
+			// an "rx.Read" and will result in a "wasm trap: deadlock detected" error. Additionally, 
+			// this is placed after "close(syncBarrier)" to ensure that the panics are resulting from 
+			// concurrent writes, and not from other scenarios that result in a nil handle.
+			rx.Read()
+		}()
+
+		p1, p2 := <-panicCh, <-panicCh
+
+		// One should succeed (nil), one should panic
+		assert((p1 == nil && p2 == "nil handle") || (p1 == "nil handle" && p2 == nil))
+	}
 }
 
 func assert(v bool) {
 	if !v {
 		panic("assertion failed")
 	}
+}
+
+func checkPanicValue(f func()) (value any) {
+	defer func() {
+		value = recover()
+	}()
+	f()
+	return nil
 }

--- a/tests/runtime-async/async/simple-stream/runner.go
+++ b/tests/runtime-async/async/simple-stream/runner.go
@@ -11,26 +11,92 @@ func Run() {
 	write := make(chan wit_types.Unit)
 	read := make(chan wit_types.Unit)
 
-	tx, rx := test.MakeStreamUnit()
-	go func() {
-		assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}}), 1)
-		assert(!tx.ReaderDropped())
+	{
+		tx, rx := test.MakeStreamUnit()
+		go func() {
+			assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}}), 1)
+			assert(!tx.ReaderDropped())
 
-		assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}, wit_types.Unit{}}), 2)
+			assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}, wit_types.Unit{}}), 2)
 
-		assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}, wit_types.Unit{}}), 0)
-		assert(tx.ReaderDropped())
+			assertEqual(tx.Write([]wit_types.Unit{wit_types.Unit{}, wit_types.Unit{}}), 0)
+			assert(tx.ReaderDropped())
 
-		write <- wit_types.Unit{}
-	}()
+			write <- wit_types.Unit{}
+		}()
 
-	go func() {
-		test.ReadStream(rx)
-		read <- wit_types.Unit{}
-	}()
+		go func() {
+			test.ReadStream(rx)
+			read <- wit_types.Unit{}
+		}()
 
-	(<-read)
-	(<-write)
+		(<-read)
+		(<-write)
+	}
+
+	{
+		tx, rx := test.MakeStreamUnit()
+		syncBarrier := make(chan struct{})
+		panicCh := make(chan any, 2)
+
+		for range 2 {
+			go func() {
+				// Because the channel is empty, it will block until it's closed, at which
+				// point all Goroutines will attempt to simultaneously read from the stream.
+				<-syncBarrier
+				panicCh <- checkPanicValue(func() {
+					result := make([]wit_types.Unit, 1)
+					rx.Read(result)
+				})
+			}()
+		}
+		close(syncBarrier)
+
+		go func() {
+			// If this is omitted, the host will see that the "rx.Read" operations aren't paired with 
+			// a "tx.WriteAll" and will result in a "wasm trap: deadlock detected" error. Additionally, 
+			// this is placed after "close(syncBarrier)" to ensure that the panics are resulting from 
+			// concurrent reads, and not from other scenarios that result in a nil handle.
+			tx.WriteAll([]wit_types.Unit{wit_types.Unit{}})
+		}()
+
+		p1, p2 := <-panicCh, <-panicCh
+
+		// One should succeed (nil), one should panic
+		assert((p1 == nil && p2 == "nil handle") || (p1 == "nil handle" && p2 == nil))
+	}
+
+	{
+		tx, rx := test.MakeStreamUnit()
+		syncBarrier := make(chan struct{})
+		panicCh := make(chan any, 2)
+
+		for range 2 {
+			go func() {
+				// Because the channel is empty, it will block until it's closed, at which
+				// point all Goroutines will attempt to simultaneously write to the stream.
+				<-syncBarrier
+				panicCh <- checkPanicValue(func() {
+					tx.WriteAll([]wit_types.Unit{wit_types.Unit{}})
+				})
+			}()
+		}
+		close(syncBarrier)
+
+		go func() {
+			// If this is omitted, the host will see that the "tx.WriteAll" operations aren't paired with 
+			// an "rx.Read" and will result in a "wasm trap: deadlock detected" error. Additionally, 
+			// this is placed after "close(syncBarrier)" to ensure that the panics are resulting from 
+			// concurrent writes, and not from other scenarios that result in a nil handle.
+			result := make([]wit_types.Unit, 1)
+			rx.Read(result)
+		}()
+
+		p1, p2 := <-panicCh, <-panicCh
+
+		// One should succeed (nil), one should panic
+		assert((p1 == nil && p2 == "nil handle") || (p1 == "nil handle" && p2 == nil))
+	}
 }
 
 func assertEqual[T comparable](a, b T) {
@@ -43,4 +109,12 @@ func assert(v bool) {
 	if !v {
 		panic("assertion failed")
 	}
+}
+
+func checkPanicValue(f func()) (value any) {
+	defer func() {
+		value = recover()
+	}()
+	f()
+	return nil
 }


### PR DESCRIPTION
# Overview
This change is intended to prevent concurrent reads and writes on streams and futures

Closes #1460

## Observations
Given the following guest application code:
```go
func Handle(request *Request) Result[*Response, ErrorCode] {
	tx, rx := MakeStreamU8()

	go func() {
		defer tx.Drop()
		for i := 0; i < 100; i++ {
			tx.Write([]byte(fmt.Sprintf("Hello %d", i)))
			time.Sleep(1 * time.Millisecond)
		}
	}()

	var wg sync.WaitGroup
	for i := 0; i < 3; i++ {
		wg.Add(1)
		go func(id int) {
			defer wg.Done()
			buffer := make([]uint8, 7)
			for j := 0; j < 10; j++ {
				// ERROR: READ CONCURRENTLY
				count := rx.Read(buffer)
				if count == 0 {
					break
				}

				fmt.Printf("output: %s", string(buffer))
			}
		}(i)
	}

	wg.Wait()

	return Err[*wasi_http_handler.Response](MakeErrorCodeDestinationIpUnroutable())

}
```

I would expect there to be a panic and have there be a `"nil handle"` message; however, this is the output I get:
```
worker error: error while executing at wasm backtrace:
    0: 0x2916ef - <unknown>!<wasm function 16>
    1: 0x182eb0 - <unknown>!wit_component_wasi_http_types.wasm_stream_read_u8
    2: 0x184933 - <unknown>!github.com_bytecodealliance_wit_bindgen_wit_types.__StreamReader_go.shape.uint8__.Read
    3: 0x1890b5 - <unknown>!wit_component_export_wasi_http_handler.Handle.func2
    4: 0x188d81 - <unknown>!wit_component_export_wasi_http_handler.Handle.gowrap1
    5: 0x12204b - <unknown>!wasm_pc_f_loop_export
    6: 0x18c0d1 - <unknown>!_async_lift_wasi_http_handler_0.3.0_rc_2025_09_16_handle
error: channel closed
```

This is concerning because the Goroutine appears to be moving past the panic in the `wit_runtime.Handle.Take()` method:
```go
func (self *Handle) Take() int32 {
	if self.value == 0 {
		panic("nil handle")
	}
	value := self.value
	self.value = 0
	return value
}
```

@dicej any thoughts and/or suggestions?