### PR TITLE
fix(rust): dealias stream/future types

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1753,7 +1753,16 @@ unsafe fn call_import(&mut self, _params: Self::ParamsLower, _results: *mut u8) 
         }
 
         match ty {
-            Type::Id(t) => self.print_tyid(*t, mode),
+            Type::Id(t) => {
+                // When generating names for stream/future payload types, dealias
+                // all inner type references so that `use`d type aliases from
+                // different interfaces resolve to the same canonical type
+                let t = match self.identifier {
+                    Identifier::StreamOrFuturePayload => dealias(self.resolve, *t),
+                    _ => *t,
+                };
+                self.print_tyid(t, mode)
+            }
             Type::Bool => self.push_str("bool"),
             Type::U8 => self.push_str("u8"),
             Type::U16 => self.push_str("u16"),

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -172,3 +172,4 @@ mod retyped_list {
         }
     });
 }
+

--- a/tests/codegen/import-export-future.wit
+++ b/tests/codegen/import-export-future.wit
@@ -5,11 +5,26 @@ package a:b;
 world w {
     import i;
     export i;
+    import j;
+    import k;
 }
 
 interface i {
     use t.{r};
     f: func(p: future<r>);
+}
+
+// Multiple interfaces `use`-ing the same type from a shared interface
+// and wrapping it in an anonymous type (result<_, r>) ensures that
+// dealiasing resolves inner types, not just top-level payload types.
+interface j {
+    use t.{r};
+    f: func() -> future<result<_, r>>;
+}
+
+interface k {
+    use t.{r};
+    f: func() -> future<result<_, r>>;
 }
 
 interface t {

--- a/tests/codegen/import-export-stream.wit
+++ b/tests/codegen/import-export-stream.wit
@@ -5,11 +5,26 @@ package a:b;
 world w {
     import i;
     export i;
+    import j;
+    import k;
 }
 
 interface i {
     use t.{r};
     f: func(p: stream<r>);
+}
+
+// Multiple interfaces `use`-ing the same type from a shared interface
+// and wrapping it in an anonymous type (result<_, r>) ensures that
+// dealiasing resolves inner types, not just top-level payload types.
+interface j {
+    use t.{r};
+    f: func() -> stream<result<_, r>>;
+}
+
+interface k {
+    use t.{r};
+    f: func() -> stream<result<_, r>>;
 }
 
 interface t {


### PR DESCRIPTION
This change dealiases inside print_ty during recursion, so it catches
aliases at every nesting depth.

PR #1482 only dealiases the top-level payload type.
That works when the payload itself is an alias
(e.g., future<error-code>), but not when the payload is an anonymous
type that contains aliases (e.g., future<result<_, error-code>>).

Fixes #1523
Resolves #1432
