### PR TITLE
Handle resources in `is_structurally_equal`

### DIFF
--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -338,9 +338,9 @@ impl Types {
             (TypeDefKind::Handle(_), _) => false,
             (TypeDefKind::Unknown, _) => unreachable!(),
 
-            // TODO: for now consider all resources not-equal to each other.
-            // This is because the same type id can be used for both an imported
-            // and exported resource where those should be distinct types.
+            // Resources are only equal if their original ids are equal,
+            // otherwise all resources are un-equal to each other.
+            (TypeDefKind::Resource, TypeDefKind::Resource) => a == b,
             (TypeDefKind::Resource, _) => false,
         }
     }

--- a/tests/runtime/rust/equal-types/host.rs
+++ b/tests/runtime/rust/equal-types/host.rs
@@ -56,3 +56,24 @@ impl HGuest for Component {
         x
     }
 }
+
+const _: () = {
+    use crate::exports::test::equal_types::resources::*;
+
+    struct GuestResource;
+
+    impl Guest for Component {
+        type R1 = GuestResource;
+
+        // Intentionally swap the 1/2 relative to WIT to ensure that the types
+        // are equivalent.
+        fn alias_own(x: T2) -> T1 {
+            x
+        }
+        fn alias_aggregate(x: Option<T2>) -> Option<T1> {
+            x
+        }
+    }
+
+    impl GuestR1 for GuestResource {}
+};

--- a/tests/runtime/rust/equal-types/test.wit
+++ b/tests/runtime/rust/equal-types/test.wit
@@ -41,9 +41,20 @@ interface blah {
     alias-type: func(x: r1) -> r2;
 }
 
+interface resources {
+    resource r1;
+    type r2 = r1;
+
+    record t1 { a: r1 }
+    record t2 { a: r2 }
+    alias-own: func(x: t1) -> t2;
+    alias-aggregate: func(x: option<t1>) -> option<t2>;
+}
+
 world host {
     export blah;
     export blag;
+    export resources;
 }
 world proxy {
     import blag;


### PR DESCRIPTION
Follow-up from #1468 to account for work in #1526.