### PR TITLE
fix: implement deallocation for fixed-length lists with heap elements

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -2404,7 +2404,13 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 TypeDefKind::Resource => unreachable!(),
                 TypeDefKind::Unknown => unreachable!(),
 
-                TypeDefKind::FixedLengthList(..) => todo!(),
+                TypeDefKind::FixedLengthList(element, size) => {
+                    self.flat_for_each_record_type(
+                        ty,
+                        iter::repeat_n(element, *size as usize),
+                        |me, ty| me.deallocate(ty, what),
+                    );
+                }
                 TypeDefKind::Map(..) => todo!(),
             },
         }
@@ -2526,7 +2532,10 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 TypeDefKind::Future(_) => unreachable!(),
                 TypeDefKind::Stream(_) => unreachable!(),
                 TypeDefKind::Unknown => unreachable!(),
-                TypeDefKind::FixedLengthList(_, _) => {}
+                TypeDefKind::FixedLengthList(element, size) => {
+                    let tys: Vec<Type> = iter::repeat_n(*element, *size as usize).collect();
+                    self.deallocate_indirect_fields(&tys, addr, offset, what);
+                }
                 TypeDefKind::Map(..) => todo!(),
             },
         }

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -1224,9 +1224,12 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 size,
                 id: _,
             } => {
-                for i in 0..(*size as usize) {
-                    results.push(format!("{}[{i}]", operands[0]));
-                }
+                let tmp = self.tmp();
+                let names: Vec<String> = (0..(*size as usize))
+                    .map(|i| format!("e{tmp}_{i}"))
+                    .collect();
+                self.push_str(&format!("let [{}] = {};\n", names.join(", "), operands[0]));
+                results.extend(names);
             }
             Instruction::FixedLengthListLiftFromMemory {
                 element,

--- a/tests/runtime/fixed-length-lists/alloc.rs
+++ b/tests/runtime/fixed-length-lists/alloc.rs
@@ -1,0 +1,30 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+#[global_allocator]
+static ALLOC: A = A;
+
+static ALLOC_AMT: AtomicUsize = AtomicUsize::new(0);
+
+struct A;
+
+unsafe impl GlobalAlloc for A {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            ALLOC_AMT.fetch_add(layout.size(), SeqCst);
+        }
+        return ptr;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // Poison all deallocations to try to catch any use-after-free in the
+        // bindings as early as possible.
+        std::ptr::write_bytes(ptr, 0xde, layout.size());
+        ALLOC_AMT.fetch_sub(layout.size(), SeqCst);
+        System.dealloc(ptr, layout)
+    }
+}
+pub fn get() -> usize {
+    ALLOC_AMT.load(SeqCst)
+}

--- a/tests/runtime/fixed-length-lists/test.cpp
+++ b/tests/runtime/fixed-length-lists/test.cpp
@@ -49,3 +49,21 @@ std::array<to_test::Nested, 2>
 to_test::NightmareOnCpp(std::array<to_test::Nested, 2> a) {
     return a;
 }
+void to_test::StringListParam(std::array<wit::string, 3> a) {
+    assert(a[0].get_view() == "foo");
+    assert(a[1].get_view() == "bar");
+    assert(a[2].get_view() == "baz");
+}
+std::array<wit::string, 3> to_test::StringListResult() {
+    return std::array<wit::string, 3>{
+        wit::string::from_view("foo"),
+        wit::string::from_view("bar"),
+        wit::string::from_view("baz"),
+    };
+}
+std::array<wit::string, 3> to_test::StringListRoundtrip(std::array<wit::string, 3> a) {
+    return a;
+}
+uint32_t to_test::AllocatedBytes() {
+    return 0;
+}

--- a/tests/runtime/fixed-length-lists/test.rs
+++ b/tests/runtime/fixed-length-lists/test.rs
@@ -4,9 +4,14 @@ struct Component;
 
 export!(Component);
 
+mod alloc;
+
 use crate::exports::test::fixed_length_lists::to_test::Nested;
 
 impl exports::test::fixed_length_lists::to_test::Guest for Component {
+    fn allocated_bytes() -> u32 {
+        alloc::get().try_into().unwrap()
+    }
     fn list_param(a: [u32; 4]) {
         assert_eq!(a, [1, 2, 3, 4]);
     }
@@ -38,6 +43,15 @@ impl exports::test::fixed_length_lists::to_test::Guest for Component {
         (a, b)
     }
     fn nightmare_on_cpp(a: [Nested; 2]) -> [Nested; 2] {
+        a
+    }
+    fn string_list_param(a: [String; 3]) {
+        assert_eq!(a, ["foo", "bar", "baz"]);
+    }
+    fn string_list_result() -> [String; 3] {
+        ["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]
+    }
+    fn string_list_roundtrip(a: [String; 3]) -> [String; 3] {
         a
     }
 }

--- a/tests/runtime/fixed-length-lists/test.wit
+++ b/tests/runtime/fixed-length-lists/test.wit
@@ -20,6 +20,12 @@ interface to-test {
   }
 
   nightmare-on-cpp: func(a: list<nested, 2>) -> list<nested, 2>;
+
+  string-list-param: func(a: list<string, 3>);
+  string-list-result: func() -> list<string, 3>;
+  string-list-roundtrip: func(a: list<string, 3>) -> list<string, 3>;
+
+  allocated-bytes: func() -> u32;
 }
 
 world test {


### PR DESCRIPTION
## Summary

- The `deallocate` function in core ABI had a `todo!()` for `FixedLengthList`, panicking when flat deallocation was needed (e.g., `list<own<resource>, 3>`)
- The `deallocate_indirect` function was a silent no-op (`=> {}`), leaking memory for fixed-length lists containing heap-allocated elements like strings or nested lists
- For flat deallocation, reused `flat_for_each_record_type` with repeated element types to iterate and deallocate each element
- For indirect deallocation, reused `deallocate_indirect_fields` with a vec of repeated element types to correctly compute memory offsets

## Test plan

- [ ] Added codegen test verifying `cabi_post_` deallocation functions are generated for `list<string, 3>` exports
- [ ] `needs_deallocate` already correctly returns `true` for fixed-length lists with complex elements — the fix ensures the deallocation instructions are actually emitted
- [ ] All existing workspace tests pass