### PR TITLE
[C#] Remove 'readonly' from struct and field definitions

### DIFF
--- a/crates/csharp/src/interface.rs
+++ b/crates/csharp/src/interface.rs
@@ -1329,7 +1329,7 @@ impl<'a> CoreInterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 .iter()
                 .map(|field| {
                     format!(
-                        "{access} readonly {} {};",
+                        "{access} {} {};",
                         self.type_name(&field.ty),
                         field.name.to_csharp_ident()
                     )
@@ -1341,7 +1341,7 @@ impl<'a> CoreInterfaceGenerator<'a> for InterfaceGenerator<'a> {
         uwrite!(
             self.src,
             "
-            {access} readonly struct {name} {{
+            {access} struct {name} {{
                 {fields}
 
                 {access} {name}({parameters}) {{


### PR DESCRIPTION
The host pass a vector of `Velocity` to the guest.
You want to change only the `X`.
Today you have to re-assign each index like:

```csharp
readonly struct Velocity { public readonly float X, Y; }
...
velocities[i] = new Velocity(velocities[i].X + 1, velocities[i].Y);
```

Removing the `readonly` you can simply do:

```csharp
struct Velocity { public float X, Y; }
...
velocities[i].X += 1;
```