### PR TITLE
feat(rust): import stubs for native targets

### DIFF
--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{Token, braced, token};
 use wit_bindgen_core::AsyncFilterSet;
 use wit_bindgen_core::WorldGenerator;
 use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackageGroup, WorldId};
-use wit_bindgen_rust::{Opts, Ownership, WithOption};
+use wit_bindgen_rust::{NativeStubMacro, Opts, Ownership, WithOption};
 
 #[proc_macro]
 pub fn generate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -48,6 +48,7 @@ struct Config {
     world: WorldId,
     files: Vec<PathBuf>,
     debug: bool,
+    native_stub_macro: Option<NativeStubMacro>,
 }
 
 /// The source of the wit package definition
@@ -67,6 +68,7 @@ impl Parse for Config {
         let mut features = Vec::new();
         let mut async_configured = false;
         let mut debug = false;
+        let mut native_stub_macro = None;
 
         if input.peek(token::Brace) {
             let content;
@@ -167,8 +169,12 @@ impl Parse for Config {
                     }
                     Opt::EnableMethodChaining(enable) => {
                         opts.enable_method_chaining = enable.value();
-                    Opt::NativeStubMacro(macro_str) => {
-                        opts.native_macro_stub = Some(macro_str.to_token_stream().to_string());
+                    }
+                    Opt::NativeStubMacro(path, extra) => {
+                        native_stub_macro = Some(NativeStubMacro {
+                            macro_path: path.to_token_stream().to_string(),
+                            extra_args: extra.map(|t| t.to_string()),
+                        });
                     }
                 }
             }
@@ -191,6 +197,7 @@ impl Parse for Config {
             world,
             files,
             debug,
+            native_stub_macro,
         })
     }
 }
@@ -250,6 +257,7 @@ impl Config {
     fn expand(mut self) -> Result<TokenStream> {
         let mut files = Default::default();
         let mut generator = self.opts.build();
+        generator.native_stub_macro = self.native_stub_macro;
         generator
             .generate(&mut self.resolve, self.world, &mut files)
             .map_err(|e| anyhow_to_syn(Span::call_site(), e))?;
@@ -406,7 +414,7 @@ enum Opt {
     Async(AsyncFilterSet, Span),
     Debug(syn::LitBool),
     EnableMethodChaining(syn::LitBool),
-    NativeStubMacro(syn::Path),
+    NativeStubMacro(syn::Path, Option<proc_macro2::TokenStream>),
 }
 
 impl Parse for Opt {
@@ -593,7 +601,16 @@ impl Parse for Opt {
         } else if l.peek(kw::native_stub_macro) {
             input.parse::<kw::native_stub_macro>()?;
             input.parse::<Token![:]>()?;
-            Ok(Opt::NativeStubMacro(input.parse()?))
+            let macro_path: syn::Path = input.parse()?;
+            let extra = if input.peek(Token![!]) {
+                input.parse::<Token![!]>()?;
+                let content;
+                syn::parenthesized!(content in input);
+                Some(content.parse::<proc_macro2::TokenStream>()?)
+            } else {
+                None
+            };
+            Ok(Opt::NativeStubMacro(macro_path, extra))
         } else {
             Err(l.error())
         }

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -167,6 +167,8 @@ impl Parse for Config {
                     }
                     Opt::EnableMethodChaining(enable) => {
                         opts.enable_method_chaining = enable.value();
+                    Opt::NativeStubMacro(macro_str) => {
+                        opts.native_macro_stub = Some(macro_str.to_token_stream().to_string());
                     }
                 }
             }
@@ -322,6 +324,7 @@ mod kw {
     syn::custom_keyword!(imports);
     syn::custom_keyword!(debug);
     syn::custom_keyword!(enable_method_chaining);
+    syn::custom_keyword!(native_stub_macro);
 }
 
 #[derive(Clone)]
@@ -403,6 +406,7 @@ enum Opt {
     Async(AsyncFilterSet, Span),
     Debug(syn::LitBool),
     EnableMethodChaining(syn::LitBool),
+    NativeStubMacro(syn::Path),
 }
 
 impl Parse for Opt {
@@ -586,6 +590,10 @@ impl Parse for Opt {
                 }
                 Ok(Opt::Async(set, span))
             }
+        } else if l.peek(kw::native_stub_macro) {
+            input.parse::<kw::native_stub_macro>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::NativeStubMacro(input.parse()?))
         } else {
             Err(l.error())
         }

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -67,6 +67,7 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
             &rust_name,
             params,
             results,
+            &self.r#gen.r#gen.opts.native_macro_stub,
         ));
         rust_name
     }

--- a/crates/rust/src/bindgen.rs
+++ b/crates/rust/src/bindgen.rs
@@ -67,7 +67,8 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
             &rust_name,
             params,
             results,
-            &self.r#gen.r#gen.opts.native_macro_stub,
+            &self.r#gen.r#gen.native_stub_macro,
+            &mut self.r#gen.r#gen.native_stub_methods,
         ));
         rust_name
     }

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -210,7 +210,8 @@ impl<'i> InterfaceGenerator<'i> {
                 "new",
                 &[abi::WasmType::Pointer],
                 &[abi::WasmType::I32],
-                &self.r#gen.opts.native_macro_stub,
+                &self.r#gen.native_stub_macro,
+                &mut self.r#gen.native_stub_methods,
             );
             let import_rep = crate::declare_import(
                 &wasm_import_module,
@@ -218,7 +219,8 @@ impl<'i> InterfaceGenerator<'i> {
                 "rep",
                 &[abi::WasmType::I32],
                 &[abi::WasmType::Pointer],
-                &self.r#gen.opts.native_macro_stub,
+                &self.r#gen.native_stub_macro,
+                &mut self.r#gen.native_stub_methods,
             );
             uwriteln!(
                 self.src,
@@ -970,7 +972,8 @@ fn abi_layout(&mut self) -> ::core::alloc::Layout {{
             "call",
             &sig.params,
             &sig.results,
-            &self.r#gen.opts.native_macro_stub,
+            &self.r#gen.native_stub_macro,
+            &mut self.r#gen.native_stub_methods,
         );
         let mut args = String::new();
         for i in 0..params_lower.len() {
@@ -2855,7 +2858,8 @@ impl<'a> {camel}Borrow<'a>{{
             "drop",
             &[abi::WasmType::I32],
             &[],
-            &self.r#gen.opts.native_macro_stub,
+            &self.r#gen.native_stub_macro,
+            &mut self.r#gen.native_stub_methods,
         );
         uwriteln!(
             self.src,

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -210,6 +210,7 @@ impl<'i> InterfaceGenerator<'i> {
                 "new",
                 &[abi::WasmType::Pointer],
                 &[abi::WasmType::I32],
+                &self.r#gen.opts.native_macro_stub,
             );
             let import_rep = crate::declare_import(
                 &wasm_import_module,
@@ -217,6 +218,7 @@ impl<'i> InterfaceGenerator<'i> {
                 "rep",
                 &[abi::WasmType::I32],
                 &[abi::WasmType::Pointer],
+                &self.r#gen.opts.native_macro_stub,
             );
             uwriteln!(
                 self.src,
@@ -968,6 +970,7 @@ fn abi_layout(&mut self) -> ::core::alloc::Layout {{
             "call",
             &sig.params,
             &sig.results,
+            &self.r#gen.opts.native_macro_stub,
         );
         let mut args = String::new();
         for i in 0..params_lower.len() {
@@ -2852,6 +2855,7 @@ impl<'a> {camel}Borrow<'a>{{
             "drop",
             &[abi::WasmType::I32],
             &[],
+            &self.r#gen.opts.native_macro_stub,
         );
         uwriteln!(
             self.src,

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -52,6 +52,23 @@ pub struct RustWasm {
 
     future_payloads: IndexMap<Option<Type>, String>,
     stream_payloads: IndexMap<Option<Type>, String>,
+
+    pub native_stub_macro: Option<NativeStubMacro>,
+    pub native_stub_methods: Vec<NativeStubMethod>,
+}
+
+pub struct NativeStubMacro {
+    pub macro_path: String,
+    pub extra_args: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeStubMethod {
+    pub wasm_import_module: String,
+    pub wasm_import_name: String,
+    pub rust_name: String,
+    pub params: Vec<WasmType>,
+    pub results: Vec<WasmType>,
 }
 
 #[derive(Default)]
@@ -304,10 +321,6 @@ pub struct Opts {
     /// If true, methods normally returning `()` instead return `&Self`. This applies to both imported and exported methods.
     #[cfg_attr(feature = "clap", arg(long))]
     pub enable_method_chaining: bool,
-
-    /// Enables macros to be stubbed by a user provided macro instead of the
-    /// default unwrap for native implementations.
-    pub native_macro_stub: Option<String>,
 }
 
 impl Opts {
@@ -860,6 +873,50 @@ impl As{upcase} for {to_convert} {{
                 "#
             ));
         }
+    }
+
+    fn finish_native_stubs(&mut self) {
+        let Some(stub) = &self.native_stub_macro else {
+            return;
+        };
+        if self.native_stub_methods.is_empty() {
+            return;
+        }
+
+        let macro_path = &stub.macro_path;
+        let extra = match &stub.extra_args {
+            Some(args) => format!("{args}, "),
+            None => String::new(),
+        };
+
+        let mut entries = String::new();
+        for method in self.native_stub_methods.iter() {
+            let NativeStubMethod {
+                wasm_import_module,
+                wasm_import_name,
+                rust_name,
+                params,
+                results,
+            } = &method;
+
+            entries.push_str(&format!(
+                "    \"{wasm_import_module}\", \"{wasm_import_name}\", fn {rust_name}("
+            ));
+
+            for (i, param) in params.iter().enumerate() {
+                if i > 0 {
+                    entries.push_str(", ");
+                }
+                entries.push_str(&format!("p{i}: {}", wasm_type(*param)));
+            }
+            entries.push(')');
+            if !method.results.is_empty() {
+                entries.push_str(&format!(" -> {}", wasm_type(results[0])));
+            }
+            entries.push_str(";\n");
+        }
+
+        uwriteln!(self.src, "{macro_path}!(@definitions {extra}{entries});");
     }
 
     /// Generates an `export!` macro for the `world_id` specified.
@@ -1439,6 +1496,7 @@ impl WorldGenerator for RustWasm {
         self.emit_modules(exports);
 
         self.finish_runtime_module();
+        self.finish_native_stubs();
         self.finish_export_macro(resolve, world);
 
         // This is a bit tricky, but we sometimes want to "split" the `world` in
@@ -1788,11 +1846,12 @@ fn declare_import(
     rust_name: &str,
     params: &[WasmType],
     results: &[WasmType],
-    native_stub_macro: &Option<String>,
+    native_stub_macro: &Option<NativeStubMacro>,
+    native_stub_methods: &mut Vec<NativeStubMethod>,
 ) -> String {
     let mut sig = "(".to_owned();
-    for param in params.iter() {
-        sig.push_str("_: ");
+    for (i, param) in params.iter().enumerate() {
+        sig.push_str(&format!("p{i}: "));
         sig.push_str(wasm_type(*param));
         sig.push_str(", ");
     }
@@ -1803,9 +1862,25 @@ fn declare_import(
         sig.push_str(wasm_type(*result));
     }
 
-    let native_stub = if let Some(macro_path) = native_stub_macro {
+    let native_stub = if let Some(stub) = native_stub_macro {
+        native_stub_methods.push(NativeStubMethod {
+            wasm_import_module: wasm_import_module.to_string(),
+            wasm_import_name: wasm_import_name.to_string(),
+            rust_name: rust_name.to_string(),
+            params: params.to_vec(),
+            results: results.to_vec(),
+        });
+
+        let macro_path = &stub.macro_path;
+        let extra = match &stub.extra_args {
+            Some(args) => format!("{args}, "),
+            None => String::new(),
+        };
         format!(
-            "unsafe extern \"C\" fn {rust_name}{sig} {{ {macro_path}!(\"{wasm_import_module}\", \"{wasm_import_name}\", fn {rust_name}{sig}) }}"
+            "unsafe extern \"C\" fn {rust_name}{sig} {{ \
+                {macro_path}!({extra} \"{wasm_import_module}\", \
+                \"{wasm_import_name}\", fn {rust_name}{sig}) \
+            }}"
         )
     } else {
         format!("unsafe extern \"C\" fn {rust_name}{sig} {{ unreachable!() }}")

--- a/crates/rust/src/lib.rs
+++ b/crates/rust/src/lib.rs
@@ -304,6 +304,10 @@ pub struct Opts {
     /// If true, methods normally returning `()` instead return `&Self`. This applies to both imported and exported methods.
     #[cfg_attr(feature = "clap", arg(long))]
     pub enable_method_chaining: bool,
+
+    /// Enables macros to be stubbed by a user provided macro instead of the
+    /// default unwrap for native implementations.
+    pub native_macro_stub: Option<String>,
 }
 
 impl Opts {
@@ -1784,6 +1788,7 @@ fn declare_import(
     rust_name: &str,
     params: &[WasmType],
     results: &[WasmType],
+    native_stub_macro: &Option<String>,
 ) -> String {
     let mut sig = "(".to_owned();
     for param in params.iter() {
@@ -1797,6 +1802,15 @@ fn declare_import(
         sig.push_str(" -> ");
         sig.push_str(wasm_type(*result));
     }
+
+    let native_stub = if let Some(macro_path) = native_stub_macro {
+        format!(
+            "unsafe extern \"C\" fn {rust_name}{sig} {{ {macro_path}!(\"{wasm_import_module}\", \"{wasm_import_name}\", fn {rust_name}{sig}) }}"
+        )
+    } else {
+        format!("unsafe extern \"C\" fn {rust_name}{sig} {{ unreachable!() }}")
+    };
+
     format!(
         "
             #[cfg(target_arch = \"wasm32\")]
@@ -1807,7 +1821,7 @@ fn declare_import(
             }}
 
             #[cfg(not(target_arch = \"wasm32\"))]
-            unsafe extern \"C\" fn {rust_name}{sig} {{ unreachable!() }}
+            {native_stub}
         "
     )
 }


### PR DESCRIPTION
This PR adds the ability for the user to provide a macro to rust that then can generate native funciton stubs, as described in https://github.com/bytecodealliance/wit-bindgen/issues/1062.

There were a few explored different alternatives, and the reasoning for using a macro is provided in the original issue.

> Alright, I've embarked on implementing this. I've thought of a couple of different solutions, but they all have their pitfalls.
> 
> Weak links would be ideal, but either require nigthly until [rust-lang/rust#29603](https://github.com/rust-lang/rust/issues/29603) is implemented, or for the end user to have a c compiler on their machine, which I've read in the github action code isn't ideal.
> 
> I then thought to just emit a trait that has every function that then can be defined, but this has limitations on using codegen to implement all of the native functions with a default implementation.
> 
> This left me with an admittedly more complex solution then I'd like of passing in a macro to bindgen that then can generate the implementations.
> 
> It is not great code, but I'll open up a draft PR. Please feel free to give me feedback on the approach that I'm taking, and whether there should be any changes.

There are still a few things I'd like to change, but as a proof of concept you can do something like the following to automatically create a trait for all native stubs.

```rust
pub use crate::wit::Context;

mod wit {
    macro_rules! native_trait_stubs {
        ($stub:ty, $module:literal, $import:literal,
         fn $name:ident($($p:ident: $t:ty,)*)) => {
            <$stub as crate::wit::NativeStub>::$name($($p,)*)
        };
        ($stub:ty, $module:literal, $import:literal,
         fn $name:ident($($p:ident: $t:ty,)*) -> $ret:ty) => {
            <$stub as crate::wit::NativeStub>::$name($($p,)*)
        };
        (@definitions $stub:ty,
         $($module:literal, $import:literal, fn $name:ident($($p:ident: $t:ty),*) $(-> $ret:ty)?;)*
        ) => {
            pub trait NativeStub {
                $(fn $name($($p: $t),*) $(-> $ret)? {
                    unreachable!()
                })*
            }
        };
    }

    wit_bindgen::generate!({
        skip: ["init-plugin"],
        path: "../../wit",
        world: "plugin",
        native_stub_macro: native_trait_stubs!(crate::MyContextStub)
    });

    use super::Component;
    export!(Component);
}

struct MyContextStub {}
impl wit::NativeStub for MyContextStub {
    fn drop(_p0: i32) {
        todo!()
    }

    fn wit_import1(_p0: i32, _p1: *mut u8) {
        todo!()
    }
}
```

I have a minimum testing repo that can be found [here](https://github.com/BjornTheProgrammer/wit-native-plugin-system)