### PR TITLE
ci: add riscv64gc-unknown-linux-gnu to release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,11 @@ jobs:
           env:
             CARGO_BUILD_TARGET: aarch64-unknown-linux-gnu
             DOCKER_IMAGE: ./ci/docker/aarch64-linux/Dockerfile
+        - build: riscv64gc-linux
+          os: ubuntu-latest
+          env:
+            CARGO_BUILD_TARGET: riscv64gc-unknown-linux-gnu
+            DOCKER_IMAGE: ./ci/docker/riscv64gc-linux/Dockerfile
 
         - build: x86_64-macos
           os: macos-latest

--- a/ci/docker/riscv64gc-linux/Dockerfile
+++ b/ci/docker/riscv64gc-linux/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates git
+
+ENV PATH=$PATH:/rust/bin
+ENV CARGO_BUILD_TARGET=riscv64gc-unknown-linux-gnu
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc


### PR DESCRIPTION
This adds `riscv64gc-unknown-linux-gnu` to the release build matrix, so that official releases ship a pre-built Linux/RISC-V 64-bit binary.

## Changes

- **`ci/docker/riscv64gc-linux/Dockerfile`**: new cross-compilation container (modeled on the existing `aarch64-linux` one, using `gcc-riscv64-linux-gnu`; uses Ubuntu 18.04 as riscv64 cross-compiler is not available in 16.04)
- **`.github/workflows/main.yml`**: new `riscv64gc-linux` matrix entry in the `build` job

## Context

The wasm-tools and wkg repositories recently merged equivalent changes (bytecodealliance/wasm-tools#2464, bytecodealliance/wasm-pkg-tools#196). wit-bindgen is the remaining piece needed for a complete WASIP2 toolchain on RISC-V.

## Evidence

A fork release built with this exact configuration is available at https://github.com/gounthar/wit-bindgen; the riscv64gc binary was verified on physical RISC-V hardware (BananaPi BPI-F3, SpacemiT K1).

Fixes #1567