### PR TITLE
[cpp] Add missing doc strings for some types

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -535,7 +535,10 @@ impl WorldGenerator for Cpp {
                 let namespace =
                     namespace(resolve, &TypeOwner::Interface(id), false, &r#gen.r#gen.opts);
                 let docs = resolve.interfaces[id].docs.contents.as_deref();
-                r#gen.r#gen.h_src.change_namespace_with_docs(&namespace, docs);
+                r#gen
+                    .r#gen
+                    .h_src
+                    .change_namespace_with_docs(&namespace, docs);
                 r#gen.types(id);
 
                 for (_name, func) in resolve.interfaces[id].functions.iter() {
@@ -587,7 +590,10 @@ impl WorldGenerator for Cpp {
         r#gen.interface = Some(id);
         let namespace = namespace(resolve, &TypeOwner::Interface(id), true, &r#gen.r#gen.opts);
         let docs = resolve.interfaces[id].docs.contents.as_deref();
-        r#gen.r#gen.h_src.change_namespace_with_docs(&namespace, docs);
+        r#gen
+            .r#gen
+            .h_src
+            .change_namespace_with_docs(&namespace, docs);
         r#gen.types(id);
 
         for (_name, func) in resolve.interfaces[id].functions.iter() {


### PR DESCRIPTION
I noticed that some docstrings were missing for generated C++ output, namely for namespaces and some functions. 

I used `tests/codegen/issue573.wit` since that has comments basically everywhere for comparison.

Diff:
```diff
@@ -51,4 +51,5 @@
       using T10 = wit::vector<wit::string>;
     }
+    /// Comment for import interface
     namespace api_imports {
       using T7 = std::expected<uint32_t, types_interface::Errno>;
@@ -62,4 +63,5 @@
       std::tuple<std::expected<uint32_t, types_interface::Errno>, Human> ApiA1B2(std::span<Human const> arg);
     }
+    /// Comment for import inline function
     std::expected<void, uint32_t> InlineImp(std::span<std::optional<uint32_t> const> args);
   }
@@ -88,4 +90,5 @@
     wit::vector<wit::string> FF1(wit::vector<wit::string> typedef_);
     std::tuple<int64_t, wit::string> F1(float f, wit::vector<std::tuple<uint32_t, double>> f_list);
+    /// t2 has been renamed with `use self.types-interface.{t2 as t2-renamed}`
     std::tuple<uint32_t, uint64_t> ReNamed(std::optional<::foo::foo::types_interface::Permissions> perm, std::optional<::types_example::Empty> e);
     std::tuple<std::optional<uint8_t>, int8_t> ReNamed2(std::tuple<wit::vector<uint16_t>> tup, ::types_example::Empty e);
@@ -142,4 +145,5 @@
           std::optional<uint32_t> c;
         };
+        /// Comment for export function
         std::tuple<std::tuple<int32_t>, wit::string> F1();
         std::tuple<uint32_t> Class(std::optional<std::optional<std::expected<void, std::optional<Errno>>>> break_);
```

<details>

<summary>Full Generated output (main)</summary>

```c++
// Generated by `wit-bindgen` 0.54.0. DO NOT EDIT!
#ifndef __CPP_GUEST_BINDINGS_TYPES_EXAMPLE_H
#define __CPP_GUEST_BINDINGS_TYPES_EXAMPLE_H
#include <cstdint>
#include <utility>
#include <string_view>
#include <expected>
#include <optional>
#include <variant>
#include <tuple>
#include "wit.h"
namespace foo {
  namespace foo {
    namespace types_interface {
      /// values of this type will be one of the specified cases
      struct Human {
        struct Baby {};
        /// type payload
        struct Child { uint32_t value; };
        /// optional type payload
        struct Adult {};
        std::variant<Baby, Child, Adult> variants;
      };
      /// similar to `variant`, but no type payloads
      enum class Errno : uint8_t {
        kTooBig = 0,
        kTooSmall = 1,
        kTooFast = 2,
        kTooSlow = 3,
      };

      /// a bitflags type
      enum class Permissions : uint8_t {
        k_None = 0,
        kRead = (1ULL<<0),
        kWrite = (1ULL<<1),
        kExec = (1ULL<<2),
      };
      static inline Permissions operator|(Permissions a, Permissions b) { return Permissions(uint8_t(a)|uint8_t(b)); }
      static inline Permissions operator&(Permissions a, Permissions b) { return Permissions(uint8_t(a)&uint8_t(b)); }
      /// type aliases are allowed to primitive types and additionally here are some
      /// examples of other types
      using T1 = uint32_t;
      using T3 = wit::string;
      /// "package of named fields"
      struct R {
        uint32_t a;
        wit::string b;
        wit::vector<std::tuple<wit::string, std::optional<std::optional<uint32_t>>>> c;
      };
      using T10 = wit::vector<wit::string>;
    }
    namespace api_imports {
      using T7 = std::expected<uint32_t, types_interface::Errno>;
      /// Same name as the type in `types-interface`, but this is a different type
      struct Human {
        struct Baby {};
        struct Child { uint64_t value; };
        struct Adult { std::tuple<wit::string, std::optional<std::optional<wit::string>>, std::tuple<int64_t>> value; };
        std::variant<Baby, Child, Adult> variants;
      };
      std::tuple<std::expected<uint32_t, types_interface::Errno>, Human> ApiA1B2(std::span<Human const> arg);
    }
    std::expected<void, uint32_t> InlineImp(std::span<std::optional<uint32_t> const> args);
  }
}
namespace types_example {
  using T2Renamed = std::tuple<uint32_t, uint64_t>;
  using T10 = wit::vector<wit::string>;
  using Permissions = foo::foo::types_interface::Permissions;
  enum class LogLevel : uint8_t {
    /// lowest level
    kDebug = 0,
    kInfo = 1,
    kWarn = 2,
    kError = 3,
  };

  /// NB: this record used to be empty, but that's no longer valid, so now it's
  /// non-empty. Don't want to delete the whole test however.
  struct Empty {
    bool not_empty_anymore;
  };
  void Print(std::string_view message, LogLevel level);
}
namespace exports {
  namespace types_example {
    wit::vector<wit::string> FF1(wit::vector<wit::string> typedef_);
    std::tuple<int64_t, wit::string> F1(float f, wit::vector<std::tuple<uint32_t, double>> f_list);
    std::tuple<uint32_t, uint64_t> ReNamed(std::optional<::foo::foo::types_interface::Permissions> perm, std::optional<::types_example::Empty> e);
    std::tuple<std::optional<uint8_t>, int8_t> ReNamed2(std::tuple<wit::vector<uint16_t>> tup, ::types_example::Empty e);
    // export_interface Interface(Id { idx: 4 })
  }
  namespace foo {
    namespace foo {
      namespace types_interface {
        /// values of this type will be one of the specified cases
        struct Human {
          struct Baby {};
          /// type payload
          struct Child { uint32_t value; };
          /// optional type payload
          struct Adult {};
          std::variant<Baby, Child, Adult> variants;
        };
        /// similar to `variant`, but no type payloads
        enum class Errno : uint8_t {
          kTooBig = 0,
          kTooSmall = 1,
          kTooFast = 2,
          kTooSlow = 3,
        };

        /// a bitflags type
        enum class Permissions : uint8_t {
          k_None = 0,
          kRead = (1ULL<<0),
          kWrite = (1ULL<<1),
          kExec = (1ULL<<2),
        };
        static inline Permissions operator|(Permissions a, Permissions b) { return Permissions(uint8_t(a)|uint8_t(b)); }
        static inline Permissions operator&(Permissions a, Permissions b) { return Permissions(uint8_t(a)&uint8_t(b)); }
        /// type aliases are allowed to primitive types and additionally here are some
        /// examples of other types
        using T1 = uint32_t;
        using T3 = wit::string;
        /// "package of named fields"
        struct R {
          uint32_t a;
          wit::string b;
          wit::vector<std::tuple<wit::string, std::optional<std::optional<uint32_t>>>> c;
        };
        using T10 = wit::vector<wit::string>;
        // export_interface Interface(Id { idx: 2 })
      }
      namespace api {
        struct Errno {
          uint64_t a_u1;
          /// A list of signed 64-bit integers
          wit::vector<int64_t> list_s1;
          std::optional<wit::string> str;
          std::optional<uint32_t> c;
        };
        std::tuple<std::tuple<int32_t>, wit::string> F1();
        std::tuple<uint32_t> Class(std::optional<std::optional<std::expected<void, std::optional<Errno>>>> break_);
        std::tuple<std::optional<std::tuple<uint32_t>>> Continue(std::optional<std::expected<void, Errno>> abstract, std::tuple<uint32_t> extends);
      }
    }
  }
}

#endif
``` 

</details> 



<details>

<summary>Full Generated output (this branch)</summary>

```c++
// Generated by `wit-bindgen` 0.54.0. DO NOT EDIT!
#ifndef __CPP_GUEST_BINDINGS_TYPES_EXAMPLE_H
#define __CPP_GUEST_BINDINGS_TYPES_EXAMPLE_H
#include <cstdint>
#include <utility>
#include <string_view>
#include <expected>
#include <optional>
#include <variant>
#include <tuple>
#include "wit.h"
namespace foo {
  namespace foo {
    namespace types_interface {
      /// values of this type will be one of the specified cases
      struct Human {
        struct Baby {};
        /// type payload
        struct Child { uint32_t value; };
        /// optional type payload
        struct Adult {};
        std::variant<Baby, Child, Adult> variants;
      };
      /// similar to `variant`, but no type payloads
      enum class Errno : uint8_t {
        kTooBig = 0,
        kTooSmall = 1,
        kTooFast = 2,
        kTooSlow = 3,
      };

      /// a bitflags type
      enum class Permissions : uint8_t {
        k_None = 0,
        kRead = (1ULL<<0),
        kWrite = (1ULL<<1),
        kExec = (1ULL<<2),
      };
      static inline Permissions operator|(Permissions a, Permissions b) { return Permissions(uint8_t(a)|uint8_t(b)); }
      static inline Permissions operator&(Permissions a, Permissions b) { return Permissions(uint8_t(a)&uint8_t(b)); }
      /// type aliases are allowed to primitive types and additionally here are some
      /// examples of other types
      using T1 = uint32_t;
      using T3 = wit::string;
      /// "package of named fields"
      struct R {
        uint32_t a;
        wit::string b;
        wit::vector<std::tuple<wit::string, std::optional<std::optional<uint32_t>>>> c;
      };
      using T10 = wit::vector<wit::string>;
    }
    /// Comment for import interface
    namespace api_imports {
      using T7 = std::expected<uint32_t, types_interface::Errno>;
      /// Same name as the type in `types-interface`, but this is a different type
      struct Human {
        struct Baby {};
        struct Child { uint64_t value; };
        struct Adult { std::tuple<wit::string, std::optional<std::optional<wit::string>>, std::tuple<int64_t>> value; };
        std::variant<Baby, Child, Adult> variants;
      };
      std::tuple<std::expected<uint32_t, types_interface::Errno>, Human> ApiA1B2(std::span<Human const> arg);
    }
    /// Comment for import inline function
    std::expected<void, uint32_t> InlineImp(std::span<std::optional<uint32_t> const> args);
  }
}
namespace types_example {
  using T2Renamed = std::tuple<uint32_t, uint64_t>;
  using T10 = wit::vector<wit::string>;
  using Permissions = foo::foo::types_interface::Permissions;
  enum class LogLevel : uint8_t {
    /// lowest level
    kDebug = 0,
    kInfo = 1,
    kWarn = 2,
    kError = 3,
  };

  /// NB: this record used to be empty, but that's no longer valid, so now it's
  /// non-empty. Don't want to delete the whole test however.
  struct Empty {
    bool not_empty_anymore;
  };
  void Print(std::string_view message, LogLevel level);
}
namespace exports {
  namespace types_example {
    wit::vector<wit::string> FF1(wit::vector<wit::string> typedef_);
    std::tuple<int64_t, wit::string> F1(float f, wit::vector<std::tuple<uint32_t, double>> f_list);
    /// t2 has been renamed with `use self.types-interface.{t2 as t2-renamed}`
    std::tuple<uint32_t, uint64_t> ReNamed(std::optional<::foo::foo::types_interface::Permissions> perm, std::optional<::types_example::Empty> e);
    std::tuple<std::optional<uint8_t>, int8_t> ReNamed2(std::tuple<wit::vector<uint16_t>> tup, ::types_example::Empty e);
    // export_interface Interface(Id { idx: 4 })
  }
  namespace foo {
    namespace foo {
      namespace types_interface {
        /// values of this type will be one of the specified cases
        struct Human {
          struct Baby {};
          /// type payload
          struct Child { uint32_t value; };
          /// optional type payload
          struct Adult {};
          std::variant<Baby, Child, Adult> variants;
        };
        /// similar to `variant`, but no type payloads
        enum class Errno : uint8_t {
          kTooBig = 0,
          kTooSmall = 1,
          kTooFast = 2,
          kTooSlow = 3,
        };

        /// a bitflags type
        enum class Permissions : uint8_t {
          k_None = 0,
          kRead = (1ULL<<0),
          kWrite = (1ULL<<1),
          kExec = (1ULL<<2),
        };
        static inline Permissions operator|(Permissions a, Permissions b) { return Permissions(uint8_t(a)|uint8_t(b)); }
        static inline Permissions operator&(Permissions a, Permissions b) { return Permissions(uint8_t(a)&uint8_t(b)); }
        /// type aliases are allowed to primitive types and additionally here are some
        /// examples of other types
        using T1 = uint32_t;
        using T3 = wit::string;
        /// "package of named fields"
        struct R {
          uint32_t a;
          wit::string b;
          wit::vector<std::tuple<wit::string, std::optional<std::optional<uint32_t>>>> c;
        };
        using T10 = wit::vector<wit::string>;
        // export_interface Interface(Id { idx: 2 })
      }
      namespace api {
        struct Errno {
          uint64_t a_u1;
          /// A list of signed 64-bit integers
          wit::vector<int64_t> list_s1;
          std::optional<wit::string> str;
          std::optional<uint32_t> c;
        };
        /// Comment for export function
        std::tuple<std::tuple<int32_t>, wit::string> F1();
        std::tuple<uint32_t> Class(std::optional<std::optional<std::expected<void, std::optional<Errno>>>> break_);
        std::tuple<std::optional<std::tuple<uint32_t>>> Continue(std::optional<std::expected<void, Errno>> abstract, std::tuple<uint32_t> extends);
      }
    }
  }
}

#endif
``` 

</details> 