### PR TITLE
feat(moonbit): add map type support

### DIFF
--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -1459,7 +1459,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn type_map(&mut self, _id: TypeId, _name: &str, _key: &Type, _value: &Type, _docs: &Docs) {
-        todo!("map types are not yet supported in the MoonBit backend")
+        // Not needed. Maps become `Map[K, V]` inline in MoonBit
     }
 
     fn type_future(&mut self, _id: TypeId, _name: &str, _ty: &Option<Type>, _docs: &Docs) {
@@ -2889,12 +2889,118 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 results.push(format!("FixedArray::from_array({array}[:])"));
             }
 
-            Instruction::MapLower { .. }
-            | Instruction::MapLift { .. }
-            | Instruction::IterMapKey { .. }
-            | Instruction::IterMapValue { .. }
-            | Instruction::GuestDeallocateMap { .. } => {
-                todo!("map types are not yet supported in this backend")
+            Instruction::MapLower {
+                key,
+                value,
+                realloc,
+            } => {
+                let Block {
+                    body,
+                    results: block_results,
+                } = self.blocks.pop().unwrap();
+                assert!(block_results.is_empty());
+
+                let op = &operands[0];
+                let entry = self.interface_gen.world_gen.sizes.record([*key, *value]);
+                let size = entry.size.size_wasm32();
+                let address = self.locals.tmp("address");
+                let index = self.locals.tmp("index");
+                let iter_map_key = self.locals.tmp("iter_map_key");
+                let iter_map_value = self.locals.tmp("iter_map_value");
+
+                self.use_ffi(ffi::MALLOC);
+                uwrite!(
+                    self.src,
+                    "
+                    let {address} = mbt_ffi_malloc(({op}).length() * {size});
+                    let mut {index} = 0
+                    ({op}).each(fn({iter_map_key}, {iter_map_value}) {{
+                        let iter_map_key = {iter_map_key}
+                        let iter_map_value = {iter_map_value}
+                        let iter_base = {address} + ({index} * {size})
+                        {body}
+                        {index} = {index} + 1
+                    }})
+                    ",
+                );
+
+                results.push(address.clone());
+                results.push(format!("({op}).length()"));
+
+                if realloc.is_none() {
+                    self.cleanup.push(Cleanup { address });
+                }
+            }
+
+            Instruction::MapLift { key, value, .. } => {
+                let Block {
+                    body,
+                    results: block_results,
+                } = self.blocks.pop().unwrap();
+                let address = &operands[0];
+                let length = &operands[1];
+                let map = self.locals.tmp("map");
+                let key_ty = self.resolve_type_name(key);
+                let value_ty = self.resolve_type_name(value);
+                let entry = self.interface_gen.world_gen.sizes.record([*key, *value]);
+                let size = entry.size.size_wasm32();
+                let index = self.locals.tmp("index");
+
+                let (body_key, body_value) = match &block_results[..] {
+                    [k, v] => (k, v),
+                    _ => todo!(
+                        "expected 2 results from map lift block, got {}",
+                        block_results.len()
+                    ),
+                };
+
+                self.use_ffi(ffi::FREE);
+                uwrite!(
+                    self.src,
+                    "
+                    let {map} : Map[{key_ty}, {value_ty}] = {{}}
+                    for {index} = 0; {index} < ({length}); {index} = {index} + 1 {{
+                        let iter_base = ({address}) + ({index} * {size})
+                        {body}
+                        {map}[{body_key}] = {body_value}
+                    }}
+                    mbt_ffi_free({address})
+                    ",
+                );
+
+                results.push(map);
+            }
+
+            Instruction::IterMapKey { .. } => results.push("iter_map_key".into()),
+
+            Instruction::IterMapValue { .. } => results.push("iter_map_value".into()),
+
+            Instruction::GuestDeallocateMap { key, value } => {
+                let Block { body, results, .. } = self.blocks.pop().unwrap();
+                assert!(results.is_empty());
+
+                let address = &operands[0];
+                let length = &operands[1];
+
+                let entry = self.interface_gen.world_gen.sizes.record([*key, *value]);
+                let size = entry.size.size_wasm32();
+
+                if !body.trim().is_empty() {
+                    let index = self.locals.tmp("index");
+
+                    uwrite!(
+                        self.src,
+                        "
+                        for {index} = 0; {index} < ({length}); {index} = {index} + 1 {{
+                            let iter_base = ({address}) + ({index} * {size})
+                            {body}
+                        }}
+                        "
+                    );
+                }
+
+                self.use_ffi(ffi::FREE);
+                uwriteln!(self.src, "mbt_ffi_free({address})",);
             }
         }
     }

--- a/crates/moonbit/src/pkg.rs
+++ b/crates/moonbit/src/pkg.rs
@@ -270,6 +270,14 @@ impl PkgResolver {
                         )
                     }
 
+                    TypeDefKind::Map(key, value) => {
+                        format!(
+                            "Map[{}, {}]",
+                            self.type_name(this, &key),
+                            self.type_name(this, &value)
+                        )
+                    }
+
                     _ => {
                         if let Some(name) = &ty.name {
                             format!(

--- a/crates/test/src/moonbit.rs
+++ b/crates/test/src/moonbit.rs
@@ -126,7 +126,7 @@ impl LanguageMethods for MoonBit {
     ) -> bool {
         // async-resource-func actually works, but most other async tests
         // fail during codegen or verification
-        name == "map.wit" || (config.async_ && name != "async-resource-func.wit")
+        config.async_ && name != "async-resource-func.wit"
     }
 
     fn verify(&self, runner: &Runner, verify: &crate::Verify) -> anyhow::Result<()> {

--- a/tests/runtime/map/test.mbt
+++ b/tests/runtime/map/test.mbt
@@ -1,0 +1,73 @@
+//@ [lang]
+//@ path = 'gen/interface/test_/maps/toTest/stub.mbt'
+
+///|
+pub fn named_roundtrip(a : Map[UInt, String]) -> Map[String, UInt] {
+  let result : Map[String, UInt] = {}
+  a.each(fn(id, name) { result[name] = id })
+  result
+}
+
+///|
+pub fn bytes_roundtrip(a : Map[String, FixedArray[Byte]]) -> Map[String, FixedArray[Byte]] {
+  a
+}
+
+///|
+pub fn empty_roundtrip(a : Map[UInt, String]) -> Map[UInt, String] {
+  a
+}
+
+///|
+pub fn option_roundtrip(a : Map[String, UInt?]) -> Map[String, UInt?] {
+  a
+}
+
+///|
+pub fn record_roundtrip(a : LabeledEntry) -> LabeledEntry {
+  a
+}
+
+///|
+pub fn inline_roundtrip(a : Map[UInt, String]) -> Map[String, UInt] {
+  let result : Map[String, UInt] = {}
+  a.each(fn(k, v) { result[v] = k })
+  result
+}
+
+///|
+pub fn large_roundtrip(a : Map[UInt, String]) -> Map[UInt, String] {
+  a
+}
+
+///|
+pub fn multi_param_roundtrip(a : Map[UInt, String], b : Map[String, FixedArray[Byte]]) -> (Map[String, UInt], Map[String, FixedArray[Byte]]) {
+  let ids : Map[String, UInt] = {}
+  a.each(fn(id, name) { ids[name] = id })
+  (ids, b)
+}
+
+///|
+pub fn nested_roundtrip(a : Map[String, Map[UInt, String]]) -> Map[String, Map[UInt, String]] {
+  a
+}
+
+///|
+pub fn variant_roundtrip(a : MapOrString) -> MapOrString {
+  a
+}
+
+///|
+pub fn result_roundtrip(a : Result[Map[UInt, String], String]) -> Result[Map[UInt, String], String] {
+  a
+}
+
+///|
+pub fn tuple_roundtrip(a : (Map[UInt, String], UInt64)) -> (Map[UInt, String], UInt64) {
+  a
+}
+
+///|
+pub fn single_entry_roundtrip(a : Map[UInt, String]) -> Map[UInt, String] {
+  a
+}


### PR DESCRIPTION
This PR adds map type support to the MoonBit backend, following the same pattern established in #1562 (core) and #1583 (Go).