### PR TITLE
core: make `abi::cast` and `abi::flat_types` public

### DIFF
--- a/crates/core/src/abi.rs
+++ b/crates/core/src/abi.rs
@@ -2656,7 +2656,10 @@ impl<'a, B: Bindgen> Generator<'a, B> {
     }
 }
 
-fn cast(from: WasmType, to: WasmType) -> Bitcast {
+/// Returns the [`Bitcast`] required to move a value of flat type
+/// `from` into flat type `to` under the canonical ABI's unification
+/// rules. Panics if the pair isn't a legal bitcast per the spec.
+pub fn cast(from: WasmType, to: WasmType) -> Bitcast {
     use WasmType::*;
 
     match (from, to) {
@@ -2712,11 +2715,18 @@ fn cast(from: WasmType, to: WasmType) -> Bitcast {
     }
 }
 
-/// Flatten types in a given type
+/// Flatten a component-level type into its canonical-ABI wasm-type
+/// sequence, or return `None` if the result would exceed `max_params`.
 ///
-/// It is sometimes necessary to restrict the number of max parameters dynamically,
-/// for example during an async guest import call (flat params are limited to 4)
-fn flat_types(resolve: &Resolve, ty: &Type, max_params: Option<usize>) -> Option<Vec<WasmType>> {
+/// `max_params` defaults to [`Resolve::MAX_FLAT_PARAMS`] (16). It is
+/// sometimes necessary to restrict the cap dynamically — for example
+/// during an async guest-import call, where flat params are limited
+/// to 4.
+pub fn flat_types(
+    resolve: &Resolve,
+    ty: &Type,
+    max_params: Option<usize>,
+) -> Option<Vec<WasmType>> {
     let max_params = max_params.unwrap_or(MAX_FLAT_PARAMS);
     let mut storage = iter::repeat_n(WasmType::I32, max_params).collect::<Vec<_>>();
     let mut flat = FlatTypes::new(storage.as_mut_slice());


### PR DESCRIPTION
First, thanks so much for this crate, it's really simplified the implementation of my tool! I think you kept me from aging about 20 years over the course of a month :)

# Motivation #

The Generator emits `Instruction::Bitcasts` automatically during lowering of heterogeneous-arm variants ([`lower_variant_arms`](https://github.com/bytecodealliance/wit-bindgen/blob/2e00369a643c0c8048b8636401e36b0cbf2dfb05/crates/core/src/abi.rs#L1708)), but never during lifting. Rather, [`read_variant_arms_from_memory`](https://github.com/bytecodealliance/wit-bindgen/blob/2e00369a643c0c8048b8636401e36b0cbf2dfb05/crates/core/src/abi.rs#L2303) reads each arm in its natural flat shape, then fires VariantLift without any widening in between.

That asymmetry is fine for language backends whose `Operand` is source text (since the variant-arm widening is deferred until the value is next lowered or pattern-matched, and the source-level type system handles it).

However, it's a problem for `Bindgen` implementations that emit wasm directly. For any variant whose arms join to a wider type (e.g. `result<string, u64>`, where `[Pointer, Length]` and `[I64]` unify to `[PointerOrI64, Length]`), the wasm stack after each arm block has to converge on the joined-flat signature before the block ends...otherwise the module fails validation with "expected i64, found i32". The backend must emit the casts itself.

# The Fix #

Enabling the backend to emit the casts just requires access to two things the upstream owns:
  - `cast(WasmType, WasmType) -> Bitcast`: the canonical-ABI bitcast-selection table.                                                                                                                             
  - `flat_types(&Resolve, &Type, Option<usize>) -> Option<Vec<WasmType>>`: the joined flat shape to target.

We can simply flip both to pub (they currently reference only already-public types: WasmType, Bitcast, Resolve, Type). No behavioral change; existing private callers are unaffected.

# Discovering Use Case #

I'm currently leveraging this crate to offload the canonical ABI lifting/lowering in my [`splicer`](https://github.com/ejrgilbert/splicer) tool that performs interface-agnostic component interposition by generating component adapters in pure Wasm. Right now, I have verbatim copies of these two functions. This PR would let me delete those copies and depend on your upstream implementation.