### PR TITLE
feat(rust): `async-spawn` - build under `no_std` + `alloc`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,8 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Install wasm32-wasip1 target
       run: rustup target add wasm32-wasip1
+    - name: Install wasm32v1-none target
+      run: rustup target add wasm32v1-none
 
     # Verify the output of the `./ci/rebuild-libwit-bindgen-cabi.sh` script is
     # up-to-date.
@@ -226,6 +228,10 @@ jobs:
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features async,macros
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features inter-task-wakeup
     - run: cargo build --target wasm32-wasip1 -p wit-bindgen --no-default-features --features futures-stream
+
+    # wasm32v1-none has no std, so a stray std::* usage fails to link here.
+    - run: cargo build --target wasm32v1-none -p wit-bindgen --no-default-features --features async
+    - run: cargo build --target wasm32v1-none -p wit-bindgen --no-default-features --features async-spawn
 
     # Verity that documentation can be generated for the rust bindings crate.
     - run: rustup update nightly --no-self-update

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 [dependencies]
 wit-bindgen-rust-macro = { path = "./macro", optional = true, default-features = false, version = "0.57.1" }
 bitflags = { workspace = true, optional = true }
-futures = { version = "0.3.30", optional = true }
+futures = { version = "0.3.30", optional = true, default-features = false, features = ["alloc"] }
 
 # When built as part of libstd
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
@@ -40,7 +40,7 @@ realloc = []
 std = []
 async = []
 bitflags = ["dep:bitflags"]
-async-spawn = ['async', 'dep:futures', 'std']
+async-spawn = ['async', 'dep:futures']
 futures-stream = ['async', 'dep:futures']
 macro-string = ["wit-bindgen-rust-macro?/macro-string"]
 

--- a/crates/guest-rust/src/rt/async_support/spawn.rs
+++ b/crates/guest-rust/src/rt/async_support/spawn.rs
@@ -4,11 +4,11 @@
 #![allow(static_mut_refs)]
 
 use crate::rt::async_support::BoxFuture;
-use futures::stream::{FuturesUnordered, StreamExt};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::future::Future;
 use core::task::{Context, Poll};
+use futures::stream::{FuturesUnordered, StreamExt};
 
 /// Any newly-deferred work queued by calls to the `spawn` function while
 /// polling the current task.

--- a/crates/guest-rust/src/rt/async_support/spawn.rs
+++ b/crates/guest-rust/src/rt/async_support/spawn.rs
@@ -5,10 +5,10 @@
 
 use crate::rt::async_support::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
-use std::boxed::Box;
-use std::future::Future;
-use std::task::{Context, Poll};
-use std::vec::Vec;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::future::Future;
+use core::task::{Context, Poll};
 
 /// Any newly-deferred work queued by calls to the `spawn` function while
 /// polling the current task.


### PR DESCRIPTION
## Summary

Closes #1599.

Follow-up to #1591, which made the `async` feature work under `no_std`. That PR left `std` on the `async-spawn` feature, but nothing in `src/rt/async_support/spawn.rs` actually requires `std` — it's `Box`, `Vec`, `Future`, `Context`, `Poll`, and `FuturesUnordered` / `StreamExt` from the `futures` crate. All of these are available through `core` / `alloc` once `futures` opts out of its default `std` feature.

This PR is the mechanical swap: `std::*` → `alloc::*` / `core::*`, drop `std` from the feature definition, and add `default-features = false, features = ["alloc"]` to the `futures` dep.

## Changes

Five edits across three files:

- `crates/guest-rust/Cargo.toml`:
  - `async-spawn = ['async', 'dep:futures', 'std']` → `async-spawn = ['async', 'dep:futures']`
  - `futures = { version = "0.3.30", optional = true }` → `futures = { version = "0.3.30", optional = true, default-features = false, features = ["alloc"] }`
- `crates/guest-rust/src/rt/async_support/spawn.rs`:
  - `use std::{boxed, future, task, vec};` swapped for `use alloc::{boxed, vec};` + `use core::{future, task};`
- `.github/workflows/main.yml`:
  - `rustup target add wasm32v1-none` in the `check` job setup
  - Two `cargo build --target wasm32v1-none -p wit-bindgen --no-default-features --features {async,async-spawn}` lines so a regression that pulls `std` back in fails CI instead of silently relinking against `wasm32-wasip1`'s std.

`wasm32v1-none` (Tier 2, stable) is used for the guard because it has no `std` at all, unlike `wasm32-unknown-unknown` which happily links std even when you opt out via features.

## Verification

Default-features build is unchanged. The `async-spawn` feature also builds without `std`:

```console
$ cargo check -p wit-bindgen --no-default-features --features "realloc,async,async-spawn,bitflags,macros"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.70s
```

The new CI guards are correct — on `main` (before this PR) the `wasm32v1-none` line fails to link because `futures-executor` pulls in `std`:

```console
$ cargo build --target wasm32v1-none -p wit-bindgen --no-default-features --features async-spawn
error[E0463]: can't find crate for `std`
   --> memchr-2.8.0/src/lib.rs:198:1
    |
198 | extern crate std;
    | ^^^^^^^^^^^^^^^^^ can't find crate
```

With the patch applied, it compiles clean.

Downstream verification: my WIP project (not public yet) carries this exact patch on top of 0.55.0 and builds its agent as a fully `no_std` component on `wasm32-wasip3` with `-Zbuild-std=core,alloc`.