### PR TITLE
fix(rust): qualify world-owned type paths in future/stream payload vtables

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1887,6 +1887,11 @@ unsafe fn call_import(&mut self, _params: Self::ParamsLower, _results: *mut u8) 
                 return format!("{path}::{name}");
             }
         }
+        // World-level aliases live at macro root. `path_to_root()` is
+        // `""` at root, `"super::super::"` in stream/future payload mode.
+        if let TypeOwner::World(_) = self.resolve.types[id].owner {
+            return format!("{}{name}", self.path_to_root());
+        }
         name
     }
 

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -235,3 +235,25 @@ mod method_chaining {
         enable_method_chaining: true
     });
 }
+
+// Regression for #1598: world-level `use t.{r};` inside
+// `future<result<r, _>>` used to emit unresolved bare `R` in vtable{N}.
+#[allow(unused, reason = "testing codegen, not functionality")]
+mod issue_1598_future_result_use {
+    wit_bindgen::generate!({
+        inline: r#"
+        package a:b;
+
+        world w {
+            use t.{r};
+            export f: func() -> future<result<r, string>>;
+        }
+
+        interface t {
+            record r {
+                x: u32,
+            }
+        }
+        "#,
+    });
+}

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -235,25 +235,3 @@ mod method_chaining {
         enable_method_chaining: true
     });
 }
-
-// Regression for #1598: world-level `use t.{r};` inside
-// `future<result<r, _>>` used to emit unresolved bare `R` in vtable{N}.
-#[allow(unused, reason = "testing codegen, not functionality")]
-mod issue_1598_future_result_use {
-    wit_bindgen::generate!({
-        inline: r#"
-        package a:b;
-
-        world w {
-            use t.{r};
-            export f: func() -> future<result<r, string>>;
-        }
-
-        interface t {
-            record r {
-                x: u32,
-            }
-        }
-        "#,
-    });
-}

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -45,6 +45,10 @@ impl LanguageMethods for Cpp {
         config: &crate::config::WitConfig,
         _args: &[String],
     ) -> bool {
+        // Compiles on C++ despite the blanket async exclusion below.
+        if name == "issue-1598.wit" {
+            return false;
+        }
         return match name {
             "issue1514-6.wit" | "named-fixed-length-list.wit" | "map.wit" => true,
             _ => false,

--- a/crates/test/src/csharp.rs
+++ b/crates/test/src/csharp.rs
@@ -48,6 +48,7 @@ impl LanguageMethods for Csharp {
                 | "async-resource-func.wit"
                 | "import-export-resource.wit"
                 | "issue-1433.wit"
+                | "issue-1598.wit"
                 | "named-fixed-length-list.wit"
                 | "map.wit"
         )

--- a/crates/test/src/go.rs
+++ b/crates/test/src/go.rs
@@ -30,6 +30,7 @@ impl LanguageMethods for Go {
         config.error_context
             || name == "async-trait-function.wit"
             || name == "named-fixed-length-list.wit"
+            || name == "issue-1598.wit"
     }
 
     fn default_bindgen_args_for_codegen(&self) -> &[&str] {

--- a/tests/codegen/issue-1598.wit
+++ b/tests/codegen/issue-1598.wit
@@ -1,0 +1,14 @@
+//@ async = true
+
+package a:b;
+
+world w {
+    use t.{r};
+    export f: async func() -> future<result<r, string>>;
+}
+
+interface t {
+    record r {
+        x: u32,
+    }
+}


### PR DESCRIPTION
Fixes #1598.

Reworked per review: instead of injecting `use` statements into the generated `vtable{N}` module, extend `type_path_with_name` to qualify world-owned types with `path_to_root()`. That's `""` normally and `"super::super::"` in `Identifier::StreamOrFuturePayload` mode, so a world-level `use t.{r};` inside `future<result<r, _>>` now resolves inside the vtable scope.

Regression test in `tests/codegen.rs`: fails on main with `cannot find type R in this scope`.