### PR TITLE
fix: add defer pinner.Unpin()

### DIFF
--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -1326,7 +1326,10 @@ func {camel}({go_params}) {go_results} {{
 
             (
                 if abi::guest_export_needs_post_return(resolve, func) {
-                    format!("{PINNER} := &runtime.Pinner{{}}")
+                    format!(
+                        "{PINNER} := &runtime.Pinner{{}}
+                    defer {PINNER}.Unpin()"
+                    )
                 } else {
                     String::new()
                 },

--- a/tests/runtime-async/async/return-string/runner.go
+++ b/tests/runtime-async/async/return-string/runner.go
@@ -1,0 +1,35 @@
+//@ wasmtime-flags = '-Wcomponent-model-async'
+
+package export_wit_world
+
+import (
+	"fmt"
+	"runtime"
+
+	test "wit_component/my_test_i"
+)
+
+/*
+
+This tests for pinner leaks in generated Go code for async exported
+function that return heap-allocated types (strings, lists, etc.). Without
+`pinner.Unpin()`, the `runtime.Pinner` object goes out of scope after
+the function returns with pinned pointers still alive. When GC finalizes
+the Pinner, it panics:
+
+```
+panic: runtime error: runtime.Pinner: found leaking pinned pointer;
+forgot to call Unpin()?
+```
+*/
+
+func Run() {
+	// Perform a heap allocation
+	got := test.ReturnString()
+	if got != "hello" {
+		panic(fmt.Sprintf("expected \"hello\", got %q", got))
+	}
+
+	// Force GC to finalize any leaked Pinners
+	runtime.GC()
+}

--- a/tests/runtime-async/async/return-string/test.go
+++ b/tests/runtime-async/async/return-string/test.go
@@ -1,0 +1,5 @@
+package export_my_test_i
+
+func ReturnString() string {
+	return "hello"
+}

--- a/tests/runtime-async/async/return-string/test.wit
+++ b/tests/runtime-async/async/return-string/test.wit
@@ -1,0 +1,14 @@
+package my:test;
+
+interface i {
+  return-string: async func() -> string;
+}
+
+world test {
+  export i;
+}
+
+world runner {
+  import i;
+  export run: async func();
+}


### PR DESCRIPTION
This fixes the following panic I'm getting when using async WIT functions:

```
 panic: runtime error: runtime.Pinner: found leaking pinned pointer; forgot to call Unpin()?

goroutine 6 [running]:
runtime.runFinalizers()
    /home/asteurer/.cache/componentize-go/v2/go-linux-amd64-bootstrap/src/runtime/mfinal.go:272 +0x5e
error while executing at wasm backtrace:
0: 0x11d931 - <unknown>!runtime.abort
1: 0x95f45 - <unknown>!runtime.fatalpanic
2: 0x113d55 - <unknown>!runtime.gopanic
3: 0x1201a8 - <unknown>!wasm_pc_f_loop_export
4: 0x18c0de - <unknown>!_async_lift_my_func
```

@dicej 