### PR TITLE
Rename `spawn` to `spawn_local`

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -881,7 +881,7 @@ pub mod rt;
 #[cfg(feature = "inter-task-wakeup")]
 pub use rt::async_support::UnitStreamOps;
 #[cfg(feature = "async-spawn")]
-pub use rt::async_support::spawn;
+pub use rt::async_support::spawn_local;
 #[cfg(feature = "async")]
 pub use rt::async_support::{
     AbiBuffer, FutureOps, FutureRead, FutureReader, FutureWrite, FutureWriteCancel,

--- a/crates/guest-rust/src/rt/async_support.rs
+++ b/crates/guest-rust/src/rt/async_support.rs
@@ -96,7 +96,7 @@ type BoxFuture<'a> = Pin<Box<dyn Future<Output = ()> + 'a>>;
 #[cfg(feature = "async-spawn")]
 mod spawn;
 #[cfg(feature = "async-spawn")]
-pub use spawn::spawn;
+pub use spawn::spawn_local;
 #[cfg(not(feature = "async-spawn"))]
 mod spawn_disabled;
 #[cfg(not(feature = "async-spawn"))]

--- a/crates/guest-rust/src/rt/async_support/spawn.rs
+++ b/crates/guest-rust/src/rt/async_support/spawn.rs
@@ -110,6 +110,6 @@ impl<'a> Tasks<'a> {
 ///
 /// [`block_on`]: crate::block_on
 /// [#1305]: https://github.com/bytecodealliance/wit-bindgen/issues/1305
-pub fn spawn(future: impl Future<Output = ()> + 'static) {
+pub fn spawn_local(future: impl Future<Output = ()> + 'static) {
     unsafe { SPAWNED.push(Box::pin(future)) }
 }

--- a/tests/runtime-async/async/ping-pong/test.rs
+++ b/tests/runtime-async/async/ping-pong/test.rs
@@ -10,7 +10,7 @@ impl crate::exports::my::test::i::Guest for Component {
     async fn ping(x: FutureReader<String>, y: String) -> FutureReader<String> {
         let msg = x.await + y.as_str();
         let (tx, rx) = wit_future::new(|| unreachable!());
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             tx.write(msg).await.unwrap();
         });
         rx

--- a/tests/runtime-async/async/yield-loop-receives-events/middle.rs
+++ b/tests/runtime-async/async/yield-loop-receives-events/middle.rs
@@ -11,7 +11,7 @@ static mut HIT: bool = false;
 
 impl crate::exports::test::common::i_runner::Guest for Component {
     async fn f() {
-        wit_bindgen::spawn(async move {
+        wit_bindgen::spawn_local(async move {
             f().await;
             unsafe {
                 HIT = true;


### PR DESCRIPTION
Rationale is listed in #1626.

Closes #1626