### PR TITLE
csharp: omit version namespace segment when package is unambiguous (#1078)

### DIFF
--- a/crates/csharp/src/world_generator.rs
+++ b/crates/csharp/src/world_generator.rs
@@ -1049,8 +1049,18 @@ fn interface_name(
             );
 
             if let Some(version) = &name.version {
-                let v = version.to_string().replace(['.', '-', '+'], "_");
-                ns = format!("{}v{}.", ns, &v);
+                // Only include the version segment when the same package name exists at
+                // multiple versions in this Resolve; omit it when unambiguous.
+                // Mirrors the equivalent guard in the C generator (crates/c/src/lib.rs).
+                let pkg_has_multiple_versions = resolve.packages.iter().any(|(_, p)| {
+                    p.name.namespace == name.namespace
+                        && p.name.name == name.name
+                        && p.name.version != name.version
+                });
+                if pkg_has_multiple_versions {
+                    let v = version.to_string().replace(['.', '-', '+'], "_");
+                    ns = format!("{}v{}.", ns, &v);
+                }
             }
             ns
         }
@@ -1105,4 +1115,87 @@ fn by_resource<'a>(
         by_resource.entry(Some(id)).or_default();
     }
     by_resource
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `Resolve` from inline WIT and return the generated C# namespace
+    /// for every imported interface in `world`.
+    fn imported_interface_namespaces(wit: &[(&str, &str)], world: &str) -> Vec<String> {
+        let mut resolve = Resolve::default();
+        for (path, contents) in wit {
+            resolve.push_str(path, contents).unwrap();
+        }
+        let (world_id, _) = resolve
+            .worlds
+            .iter()
+            .find(|(_, w)| w.name == world)
+            .unwrap();
+        let keys: Vec<WorldKey> = resolve.worlds[world_id]
+            .imports
+            .keys()
+            .filter(|k| matches!(k, WorldKey::Interface(_)))
+            .cloned()
+            .collect();
+        let mut csharp = CSharp::default();
+        keys.iter()
+            .map(|k| interface_name(&mut csharp, &resolve, k, Direction::Import))
+            .collect()
+    }
+
+    #[test]
+    fn version_segment_omitted_when_package_is_unambiguous() {
+        let names = imported_interface_namespaces(
+            &[
+                (
+                    "dep.wit",
+                    "package my:dep@0.1.0;\ninterface a { x: func(); }",
+                ),
+                (
+                    "root.wit",
+                    "package foo:bar;\nworld the-world { import my:dep/a@0.1.0; }",
+                ),
+            ],
+            "the-world",
+        );
+        assert!(!names.is_empty());
+        for n in &names {
+            assert!(n.contains("my.dep"), "expected package segment: {n}");
+            assert!(
+                !n.contains("v0_1_0"),
+                "version segment should be omitted: {n}"
+            );
+        }
+    }
+
+    #[test]
+    fn version_segment_kept_when_multiple_versions_coexist() {
+        let names = imported_interface_namespaces(
+            &[
+                (
+                    "v1.wit",
+                    "package my:dep@0.1.0;\ninterface a { x: func(); }",
+                ),
+                (
+                    "v2.wit",
+                    "package my:dep@0.2.0;\ninterface a { x: func(); }",
+                ),
+                (
+                    "root.wit",
+                    "package foo:bar;\nworld the-world { import my:dep/a@0.1.0; import my:dep/a@0.2.0; }",
+                ),
+            ],
+            "the-world",
+        );
+        assert!(
+            names.iter().any(|n| n.contains("v0_1_0")),
+            "expected a v0_1_0 segment: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.contains("v0_2_0")),
+            "expected a v0_2_0 segment: {names:?}"
+        );
+    }
 }

--- a/tests/codegen/single-version-package/wit/deps/dep/root.wit
+++ b/tests/codegen/single-version-package/wit/deps/dep/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.1.0;
+
+interface a {
+  x: func();
+}

--- a/tests/codegen/single-version-package/wit/root.wit
+++ b/tests/codegen/single-version-package/wit/root.wit
@@ -1,0 +1,5 @@
+package foo:bar;
+
+world the-world {
+  import my:dep/a@0.1.0;
+}


### PR DESCRIPTION
Ports the `pkg_has_multiple_versions` guard from the C generator (`crates/c/src/lib.rs`, `interface_identifier`) to the C# backend, closing #1078.

## What changes

Previously the C# generator unconditionally appended a version segment to the namespace of every versioned WIT package:

```
my.dep.v0_1_0.wit.imports.a.Ia   // always, even when only one version exists
```

After this change the segment is only emitted when the same package `namespace:name` appears at more than one version in the Resolve — the only situation where omitting it would cause a collision:

```
my.dep.wit.imports.a.Ia          // single version → no segment
my.dep.v0_1_0.wit.imports.a.Ia   // coexists with v0_2_0 → segment kept
```

The guard logic is identical to the C backend's. The mangling format intentionally differs by design: C# emits `v{major}_{minor}_{patch}.` while C uses a trailing-underscore snake-case segment. The Rust and Go backends already do the same via the shared `name_package_module` helper (`crates/core/src/path.rs`).

## Tests

- **Unit tests** on `interface_name` assert the generated namespace directly: the segment is dropped for a single-version package and kept when two versions coexist. I verified they fail if the guard is reverted to the unconditional form, so they lock the behavior (not just compilation) and run on every platform without the dotnet toolchain.
- **Codegen fixture** `tests/codegen/single-version-package` (one versioned import, single version in the Resolve) builds the drop path across all backends, alongside the existing `multiversion` fixture (two versions of the same package) which guards the must-keep path.

C# codegen build tests don't run on my machine (macOS), so the `dotnet build` step is left to CI; `cargo build` and the unit tests pass locally.

## Design decision

I asked on the issue whether this should be a silent default or gated behind a flag. @yowl preferred the default/no-flag approach for consistency with the C backend (https://github.com/bytecodealliance/wit-bindgen/issues/1078#issuecomment-4687002167). This changes generated C# namespace names for single-version packages — a breaking change that's acceptable pre-1.0 per that discussion.