### PR TITLE
async: remove inter-task wakeup stream from waitable set before cancelling

### DIFF
--- a/crates/guest-rust/src/rt/async_support/inter_task_wakeup.rs
+++ b/crates/guest-rust/src/rt/async_support/inter_task_wakeup.rs
@@ -57,13 +57,17 @@ impl FutureState<'_> {
         }
         self.inter_task_wakeup.stream_reading = false;
         let handle = self.inter_task_wakeup.stream.as_mut().unwrap().handle();
+        // Remove the stream from our waitable set before cancelling. A
+        // synchronous `stream.cancel-read` traps if the stream is still a member
+        // of a waitable set, so this must happen first. This matches the
+        // unregister-then-cancel ordering in `WaitableOperation::cancel`.
+        self.remove_waitable(handle);
         // Note that the return code here is discarded. No matter what the read
         // is cancelled, and whether we actually read something or whether we
         // cancelled doesn't matter.
         unsafe {
             UnitStreamOps.cancel_read(handle);
         }
-        self.remove_waitable(handle);
     }
 }
 


### PR DESCRIPTION
`cancel_inter_task_stream_read` issues a synchronous `stream.cancel-read` on the
inter-task wakeup stream while that stream is still a member of the task's
waitable set, calling `remove_waitable` only afterwards:

```rust
unsafe {
    UnitStreamOps.cancel_read(handle);   // sync cancel — stream still in the set
}
self.remove_waitable(handle);            // removed afterwards
```

Per [component-model#647], a synchronous `{stream,future}.cancel-{read,write}`
must trap if the waitable is still in a waitable set, for the same reason the
synchronous read/write operations do (the cancel may need to block on the very
waitable the set is watching). The canonical ABI codifies this as
`trap_if(e.in_waitable_set() and not async_)`.

The general cancellation path in `WaitableOperation::cancel` already respects
this — it calls `unregister_waker` (removing the waitable from the set) *before*
invoking the synchronous cancel intrinsic. `cancel_inter_task_stream_read` is
the one place that doesn't follow that ordering, so on a runtime that enforces
the trap it faults during ordinary async operation.

This reorders the two operations so the stream leaves the waitable set before
the synchronous cancel, matching the established unregister-then-cancel pattern.
The cancel's return code is discarded exactly as before, so behavior is
otherwise unchanged.

### Context / testing

This surfaced while implementing the corresponding cancel traps in Wasmtime
(bytecodealliance/wasmtime#13690): once Wasmtime traps on a synchronous cancel
of an in-set waitable, every `wasi:http@0.3.0` (p3) program built with this
runtime traps in `cancel_inter_task_stream_read`. With this change applied
(via a local `[patch.crates-io]`), Wasmtime's full p3 HTTP/CLI suites pass
again (52 previously-failing tests across `wasmtime-wasi`/`wasmtime-wasi-http`).

[component-model#647]: https://github.com/WebAssembly/component-model/pull/647
