### PR TITLE
Add support for named implements in Go

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -551,8 +551,7 @@ impl WorldGenerator for Cpp {
                 let binding = Some(name);
                 let mut r#gen = self.interface(resolve, binding, true, Some(wasm_import_module));
                 r#gen.interface = Some(id);
-                let namespace =
-                    namespace(resolve, &TypeOwner::Interface(id), false, &*r#gen.r#gen);
+                let namespace = namespace(resolve, &TypeOwner::Interface(id), false, &*r#gen.r#gen);
                 let docs = resolve.interfaces[id].docs.contents.as_deref();
                 r#gen
                     .r#gen

--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -103,6 +103,7 @@ struct Cpp {
     world: String,
     world_id: Option<WorldId>,
     imported_interfaces: HashSet<InterfaceId>,
+    instance_names: HashMap<InterfaceId, String>,
     user_class_files: HashMap<String, String>,
     defined_types: HashSet<(Vec<String>, String)>,
     types: Types,
@@ -281,6 +282,17 @@ impl Opts {
 impl Cpp {
     fn new() -> Cpp {
         Cpp::default()
+    }
+
+    fn update_instance_name(&mut self, resolve: &Resolve, name: &WorldKey, id: InterfaceId) {
+        match name {
+            WorldKey::Name(instance) if resolve.interfaces[id].name.is_some() => {
+                self.instance_names.insert(id, instance.clone());
+            }
+            _ => {
+                self.instance_names.remove(&id);
+            }
+        }
     }
 
     pub fn is_first_definition(&mut self, ns: &Vec<String>, name: &str) -> bool {
@@ -522,6 +534,7 @@ impl WorldGenerator for Cpp {
         _files: &mut Files,
     ) -> anyhow::Result<()> {
         self.imported_interfaces.insert(id);
+        self.update_instance_name(resolve, name, id);
 
         let full_name = resolve.name_world_key(name);
         match self.opts.with.iter().find(|e| e.0 == full_name) {
@@ -539,7 +552,7 @@ impl WorldGenerator for Cpp {
                 let mut r#gen = self.interface(resolve, binding, true, Some(wasm_import_module));
                 r#gen.interface = Some(id);
                 let namespace =
-                    namespace(resolve, &TypeOwner::Interface(id), false, &r#gen.r#gen.opts);
+                    namespace(resolve, &TypeOwner::Interface(id), false, &*r#gen.r#gen);
                 let docs = resolve.interfaces[id].docs.contents.as_deref();
                 r#gen
                     .r#gen
@@ -590,11 +603,12 @@ impl WorldGenerator for Cpp {
             .src
             .push_str(&format!("// export_interface {name:?}\n"));
         self.imported_interfaces.remove(&id);
+        self.update_instance_name(resolve, name, id);
         let wasm_import_module = resolve.name_world_key(name);
         let binding = Some(name);
         let mut r#gen = self.interface(resolve, binding, false, Some(wasm_import_module));
         r#gen.interface = Some(id);
-        let namespace = namespace(resolve, &TypeOwner::Interface(id), true, &r#gen.r#gen.opts);
+        let namespace = namespace(resolve, &TypeOwner::Interface(id), true, &*r#gen.r#gen);
         let docs = resolve.interfaces[id].docs.contents.as_deref();
         r#gen
             .r#gen
@@ -624,7 +638,7 @@ impl WorldGenerator for Cpp {
         let wasm_import_module = resolve.name_world_key(&name);
         let binding = Some(name);
         let mut r#gen = self.interface(resolve, binding.as_ref(), true, Some(wasm_import_module));
-        let namespace = namespace(resolve, &TypeOwner::World(world), false, &r#gen.r#gen.opts);
+        let namespace = namespace(resolve, &TypeOwner::World(world), false, &*r#gen.r#gen);
 
         for (_name, func) in funcs.iter() {
             if matches!(func.kind, FunctionKind::Freestanding) {
@@ -644,7 +658,7 @@ impl WorldGenerator for Cpp {
         let name = WorldKey::Name(resolve.worlds[world].name.clone());
         let binding = Some(name);
         let mut r#gen = self.interface(resolve, binding.as_ref(), false, None);
-        let namespace = namespace(resolve, &TypeOwner::World(world), true, &r#gen.r#gen.opts);
+        let namespace = namespace(resolve, &TypeOwner::World(world), true, &*r#gen.r#gen);
 
         for (_name, func) in funcs.iter() {
             if matches!(func.kind, FunctionKind::Freestanding) {
@@ -779,9 +793,9 @@ impl WorldGenerator for Cpp {
 }
 
 // determine namespace (for the lifted C++ function)
-fn namespace(resolve: &Resolve, owner: &TypeOwner, guest_export: bool, opts: &Opts) -> Vec<String> {
+fn namespace(resolve: &Resolve, owner: &TypeOwner, guest_export: bool, r#gen: &Cpp) -> Vec<String> {
     let mut result = Vec::default();
-    if let Some(prefix) = &opts.internal_prefix {
+    if let Some(prefix) = &r#gen.opts.internal_prefix {
         result.push(prefix.clone());
     }
     if guest_export {
@@ -790,14 +804,18 @@ fn namespace(resolve: &Resolve, owner: &TypeOwner, guest_export: bool, opts: &Op
     match owner {
         TypeOwner::World(w) => result.push(to_c_ident(&resolve.worlds[*w].name)),
         TypeOwner::Interface(i) => {
-            let iface = &resolve.interfaces[*i];
-            let pkg_id = iface.package.unwrap();
-            let pkg = &resolve.packages[pkg_id];
-            result.push(to_c_ident(&pkg.name.namespace));
-            // Use name_package_module to get version-specific package names
-            result.push(to_c_ident(&name_package_module(resolve, pkg_id)));
-            if let Some(name) = &iface.name {
-                result.push(to_c_ident(name));
+            if let Some(instance) = r#gen.instance_names.get(i) {
+                result.push(to_c_ident(instance));
+            } else {
+                let iface = &resolve.interfaces[*i];
+                let pkg_id = iface.package.unwrap();
+                let pkg = &resolve.packages[pkg_id];
+                result.push(to_c_ident(&pkg.name.namespace));
+                // Use name_package_module to get version-specific package names
+                result.push(to_c_ident(&name_package_module(resolve, pkg_id)));
+                if let Some(name) = &iface.name {
+                    result.push(to_c_ident(name));
+                }
             }
         }
         TypeOwner::None => (),
@@ -941,7 +959,7 @@ impl CppInterfaceGenerator<'_> {
                 .map(TypeOwner::Interface)
                 .unwrap_or(TypeOwner::World(self.r#gen.world_id.unwrap())),
         ));
-        let mut namespace = namespace(self.resolve, &owner, guest_export, &self.r#gen.opts);
+        let mut namespace = namespace(self.resolve, &owner, guest_export, &*self.r#gen);
         let is_drop = is_special_method(func);
         let func_name_h = if !matches!(&func.kind, FunctionKind::Freestanding) {
             namespace.push(object.clone());
@@ -1294,7 +1312,7 @@ impl CppInterfaceGenerator<'_> {
                 cifg.resolve,
                 &owner.owner,
                 matches!(variant, AbiVariant::GuestExport),
-                &cifg.r#gen.opts,
+                &*cifg.r#gen,
             );
             namespace.push(owner.name.as_ref().unwrap().to_upper_camel_case());
             namespace
@@ -1403,7 +1421,7 @@ impl CppInterfaceGenerator<'_> {
                             self.resolve,
                             owner,
                             matches!(variant, AbiVariant::GuestExport),
-                            &self.r#gen.opts,
+                            &*self.r#gen,
                         )
                     } else {
                         let owner = &self.resolve.types[match &func.kind {
@@ -1420,7 +1438,7 @@ impl CppInterfaceGenerator<'_> {
                             self.resolve,
                             &owner.owner,
                             matches!(variant, AbiVariant::GuestExport),
-                            &self.r#gen.opts,
+                            &*self.r#gen,
                         );
                         namespace.push(owner.name.as_ref().unwrap().to_upper_camel_case());
                         namespace
@@ -1534,7 +1552,7 @@ impl CppInterfaceGenerator<'_> {
         guest_export: bool,
     ) -> String {
         let ty = &self.resolve.types[id];
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
         let mut relative = SourceWithState {
             namespace: Vec::from(from_namespace),
             ..Default::default()
@@ -1882,7 +1900,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
     ) {
         let ty = &self.resolve.types[id];
         let guest_export = self.is_exported_type(ty);
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
 
         if self.r#gen.is_first_definition(&namespc, name) {
             self.r#gen.h_src.change_namespace(&namespc);
@@ -1914,7 +1932,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
             let store = self.r#gen.start_new_file(Some(definition));
             let mut world_name = to_c_ident(&self.r#gen.world);
             world_name.push_str("::");
-            let namespc = namespace(self.resolve, &type_.owner, !guest_import, &self.r#gen.opts);
+            let namespc = namespace(self.resolve, &type_.owner, !guest_import, &*self.r#gen);
             let pascal = name.to_upper_camel_case();
             let mut user_filename = namespc.clone();
             user_filename.push(pascal.clone());
@@ -2087,7 +2105,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
         } else if matches!(type_.owner, TypeOwner::World(_)) {
             // Handle world-level resources - treat as imported resources
             let guest_export = false; // World-level resources are treated as imports
-            let namespc = namespace(self.resolve, &type_.owner, guest_export, &self.r#gen.opts);
+            let namespc = namespace(self.resolve, &type_.owner, guest_export, &*self.r#gen);
             self.r#gen.h_src.change_namespace(&namespc);
 
             let pascal = name.to_upper_camel_case();
@@ -2123,7 +2141,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
     ) {
         let ty = &self.resolve.types[id];
         let guest_export = self.is_exported_type(ty);
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
         if self.r#gen.is_first_definition(&namespc, name) {
             self.r#gen.h_src.change_namespace(&namespc);
             Self::docs(&mut self.r#gen.h_src.src, docs);
@@ -2164,7 +2182,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
     ) {
         let ty = &self.resolve.types[id];
         let guest_export = self.is_exported_type(ty);
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
         if self.r#gen.is_first_definition(&namespc, name) {
             self.r#gen.h_src.change_namespace(&namespc);
             Self::docs(&mut self.r#gen.h_src.src, docs);
@@ -2225,7 +2243,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
     ) {
         let ty = &self.resolve.types[id];
         let guest_export = self.is_exported_type(ty);
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
         if self.r#gen.is_first_definition(&namespc, name) {
             self.r#gen.h_src.change_namespace(&namespc);
             let pascal = name.to_pascal_case();
@@ -2253,7 +2271,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for CppInterfaceGenerator<'a> 
     ) {
         let ty = &self.resolve.types[id];
         let guest_export = self.is_exported_type(ty);
-        let namespc = namespace(self.resolve, &ty.owner, guest_export, &self.r#gen.opts);
+        let namespc = namespace(self.resolve, &ty.owner, guest_export, &*self.r#gen);
         self.r#gen.h_src.change_namespace(&namespc);
         let pascal = name.to_pascal_case();
         Self::docs(&mut self.r#gen.h_src.src, docs);

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -739,9 +739,7 @@ impl WorldGenerator for Go {
         id: InterfaceId,
         _files: &mut Files,
     ) -> Result<()> {
-        if let WorldKey::Name(_) = name {
-            self.interface_names.insert(id, name.clone());
-        }
+        self.interface_names.insert(id, name.clone());
 
         let package = self.interface_name(resolve, Some(name));
         let mut data = {
@@ -786,9 +784,7 @@ impl WorldGenerator for Go {
         id: InterfaceId,
         _files: &mut Files,
     ) -> Result<()> {
-        if let WorldKey::Name(_) = name {
-            self.interface_names.insert(id, name.clone());
-        }
+        self.interface_names.insert(id, name.clone());
 
         let package = self.interface_name(resolve, Some(name));
         for (type_name, ty) in &resolve.interfaces[id].types {

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -252,7 +252,7 @@ impl Go {
         if local == owner && (exported ^ in_import) {
             String::new()
         } else {
-            let package = self.interface_name(resolve, owner);
+            let package = self.go_package_name(resolve, owner);
             let package = if exported {
                 format!("export_{package}")
             } else {
@@ -638,7 +638,7 @@ func Lift{upper_kind}{camel}(handle int32) *witTypes.{upper_kind}Reader[{payload
                                 } else {
                                     format!(
                                         "{}_",
-                                        self.interface_name(
+                                        self.go_package_name(
                                             resolve,
                                             Some(
                                                 &self
@@ -741,11 +741,11 @@ impl WorldGenerator for Go {
     ) -> Result<()> {
         self.interface_names.insert(id, name.clone());
 
-        let package = self.interface_name(resolve, Some(name));
+        let go_package_name = self.go_package_name(resolve, Some(name));
         let mut data = {
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), true);
             for (name, ty) in resolve.interfaces[id].types.iter() {
-                if generator.generator.types.insert((package.clone(), *ty)) {
+                if generator.generator.types.insert((go_package_name.clone(), *ty)) {
                     generator.define_type(name, *ty);
                 }
             }
@@ -755,7 +755,7 @@ impl WorldGenerator for Go {
         for (_, func) in &resolve.interfaces[id].functions {
             data.extend(self.import(resolve, func, Some(name)));
         }
-        self.interfaces.entry(package).or_default().extend(data);
+        self.interfaces.entry(go_package_name).or_default().extend(data);
 
         Ok(())
     }
@@ -772,7 +772,7 @@ impl WorldGenerator for Go {
             data.extend(self.import(resolve, func, None));
         }
         self.interfaces
-            .entry(self.interface_name(resolve, None))
+            .entry(self.go_package_name(resolve, None))
             .or_default()
             .extend(data);
     }
@@ -786,14 +786,14 @@ impl WorldGenerator for Go {
     ) -> Result<()> {
         self.interface_names.insert(id, name.clone());
 
-        let package = self.interface_name(resolve, Some(name));
+        let go_package_name = self.go_package_name(resolve, Some(name));
         for (type_name, ty) in &resolve.interfaces[id].types {
             let exported = matches!(resolve.types[*ty].kind, TypeDefKind::Resource)
                 || self.has_exported_resource(resolve, Type::Id(*ty));
 
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), false);
 
-            if generator.generator.types.insert((package.clone(), *ty)) || exported {
+            if generator.generator.types.insert((go_package_name.clone(), *ty)) || exported {
                 generator.define_type(type_name, *ty);
             }
 
@@ -804,7 +804,7 @@ impl WorldGenerator for Go {
             } else {
                 &mut self.interfaces
             }
-            .entry(package.clone())
+            .entry(go_package_name.clone())
             .or_default()
             .extend(data);
         }
@@ -838,7 +838,7 @@ impl WorldGenerator for Go {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let package = self.interface_name(resolve, None);
+        let package = self.go_package_name(resolve, None);
         let mut generator = InterfaceGenerator::new(self, resolve, None, true);
         for (name, ty) in types {
             if generator.generator.types.insert((package.clone(), *ty)) {
@@ -1367,7 +1367,7 @@ func wasm_export_post_return_{name}(result {results}) {{
             let results = self.func_results(resolve, func, interface, false, &mut imports);
 
             self.export_interfaces
-                .entry(self.interface_name(resolve, interface))
+                .entry(self.go_package_name(resolve, interface))
                 .or_default()
                 .extend(InterfaceData {
                     code: format!(
@@ -1486,7 +1486,7 @@ func wasm_export_{name}({params}) {results} {{
                     &func.name,
                 );
 
-                let name = self.interface_name(resolve, interface);
+                let name = self.go_package_name(resolve, interface);
                 if in_import || !exported {
                     &mut self.interfaces
                 } else {
@@ -1512,7 +1512,7 @@ func wasm_export_{name}({params}) {results} {{
         })
     }
 
-    fn interface_name(&self, resolve: &Resolve, interface: Option<&WorldKey>) -> String {
+    fn go_package_name(&self, resolve: &Resolve, interface: Option<&WorldKey>) -> String {
         match interface {
             Some(WorldKey::Name(name)) => name.to_snake_case(),
             Some(WorldKey::Interface(id)) => {
@@ -1547,7 +1547,7 @@ func wasm_export_{name}({params}) {results} {{
         interface: Option<&WorldKey>,
         func: &Function,
     ) -> String {
-        let prefix = self.interface_name(resolve, interface);
+        let prefix = self.go_package_name(resolve, interface);
         let name = func.name.to_snake_case().replace('.', "_");
 
         format!("{prefix}_{name}")
@@ -1843,7 +1843,7 @@ for index := 0; index < int({length}); index++ {{
                 let name = func.item_name().to_upper_camel_case();
                 let package = format!(
                     "export_{}",
-                    self.generator.interface_name(resolve, self.interface)
+                    self.generator.go_package_name(resolve, self.interface)
                 );
 
                 let call = match &func.kind {

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -221,7 +221,8 @@ struct Go {
     interface_names: HashMap<InterfaceId, WorldKey>,
     interfaces: BTreeMap<String, InterfaceData>,
     export_interfaces: BTreeMap<String, InterfaceData>,
-    types: HashSet<TypeId>,
+    // Add String to the types to allow for implements of the same type in different interfaces to be generated.
+    types: HashSet<(String, TypeId)>,
     resources: HashMap<TypeId, Direction>,
     futures_and_streams: HashMap<(TypeId, bool), Option<WorldKey>>,
 }
@@ -742,11 +743,11 @@ impl WorldGenerator for Go {
             self.interface_names.insert(id, name.clone());
         }
 
+        let package = self.interface_name(resolve, Some(name));
         let mut data = {
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), true);
             for (name, ty) in resolve.interfaces[id].types.iter() {
-                if !generator.generator.types.contains(ty) {
-                    generator.generator.types.insert(*ty);
+                if generator.generator.types.insert((package.clone(), *ty)) {
                     generator.define_type(name, *ty);
                 }
             }
@@ -756,10 +757,7 @@ impl WorldGenerator for Go {
         for (_, func) in &resolve.interfaces[id].functions {
             data.extend(self.import(resolve, func, Some(name)));
         }
-        self.interfaces
-            .entry(self.interface_name(resolve, Some(name)))
-            .or_default()
-            .extend(data);
+        self.interfaces.entry(package).or_default().extend(data);
 
         Ok(())
     }
@@ -792,26 +790,25 @@ impl WorldGenerator for Go {
             self.interface_names.insert(id, name.clone());
         }
 
+        let package = self.interface_name(resolve, Some(name));
         for (type_name, ty) in &resolve.interfaces[id].types {
             let exported = matches!(resolve.types[*ty].kind, TypeDefKind::Resource)
                 || self.has_exported_resource(resolve, Type::Id(*ty));
 
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), false);
 
-            if exported || !generator.generator.types.contains(ty) {
-                generator.generator.types.insert(*ty);
+            if generator.generator.types.insert((package.clone(), *ty)) || exported {
                 generator.define_type(type_name, *ty);
             }
 
             let data = generator.into();
 
-            let name = self.interface_name(resolve, Some(name));
             if exported {
                 &mut self.export_interfaces
             } else {
                 &mut self.interfaces
             }
-            .entry(name)
+            .entry(package.clone())
             .or_default()
             .extend(data);
         }
@@ -845,18 +842,15 @@ impl WorldGenerator for Go {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
+        let package = self.interface_name(resolve, None);
         let mut generator = InterfaceGenerator::new(self, resolve, None, true);
         for (name, ty) in types {
-            if !generator.generator.types.contains(ty) {
-                generator.generator.types.insert(*ty);
+            if generator.generator.types.insert((package.clone(), *ty)) {
                 generator.define_type(name, *ty);
             }
         }
         let data = generator.into();
-        self.interfaces
-            .entry(self.interface_name(resolve, None))
-            .or_default()
-            .extend(data);
+        self.interfaces.entry(package).or_default().extend(data);
     }
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -745,7 +745,11 @@ impl WorldGenerator for Go {
         let mut data = {
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), true);
             for (name, ty) in resolve.interfaces[id].types.iter() {
-                if generator.generator.types.insert((go_package_name.clone(), *ty)) {
+                if generator
+                    .generator
+                    .types
+                    .insert((go_package_name.clone(), *ty))
+                {
                     generator.define_type(name, *ty);
                 }
             }
@@ -755,7 +759,10 @@ impl WorldGenerator for Go {
         for (_, func) in &resolve.interfaces[id].functions {
             data.extend(self.import(resolve, func, Some(name)));
         }
-        self.interfaces.entry(go_package_name).or_default().extend(data);
+        self.interfaces
+            .entry(go_package_name)
+            .or_default()
+            .extend(data);
 
         Ok(())
     }
@@ -793,7 +800,12 @@ impl WorldGenerator for Go {
 
             let mut generator = InterfaceGenerator::new(self, resolve, Some((id, name)), false);
 
-            if generator.generator.types.insert((go_package_name.clone(), *ty)) || exported {
+            if generator
+                .generator
+                .types
+                .insert((go_package_name.clone(), *ty))
+                || exported
+            {
                 generator.define_type(type_name, *ty);
             }
 

--- a/crates/guest-rust/macro/src/lib.rs
+++ b/crates/guest-rust/macro/src/lib.rs
@@ -237,7 +237,7 @@ fn parse_source(
                     }
                 }
             }
-            pkgs.truncate(0);
+            pkgs.clear();
             pkgs.push(resolve.push_str("macro-input", s)?);
         }
         Some(Source::Paths(p)) => parse(p)?,

--- a/tests/codegen/issue1642.wit
+++ b/tests/codegen/issue1642.wit
@@ -1,0 +1,28 @@
+package foo:foo;
+
+interface store {
+  variant error {
+    no-such-store,
+    access-denied,
+    other(string),
+  }
+
+  record key-response {
+    keys: list<string>,
+    cursor: option<u64>,
+  }
+
+  resource bucket {
+    open: static func(identifier: string) -> result<bucket, error>;
+    get: func(key: string) -> result<option<list<u8>>, error>;
+    list-keys: func(cursor: option<u64>) -> result<key-response, error>;
+  }
+}
+
+world the-world {
+  // Import the same type under separate names to test implements.
+  import primary: store;
+  import secondary: store;
+  // Ensure non-named imports still works.
+  import store;
+}


### PR DESCRIPTION
Fixes #1642 

## Overview

In the scenario where you are importing the same interface under multiple names (implements feature in wasm), the Go generator only emitted the interface types from the first package, since there is a check for not adding a duplicate interface. 

This change adds the Go package name to the Hash key instead of just `TypeId`, allowing for all interfaces to be exported in all packages. There is no concern on duplicate interfaces in the same package, since that would be a Go compile error.

C++ bin gen was also changed to support the implements feature as well, with using the derived namespace in the WorldKey (`primary::Bucket`, `secondary::Bucket`).

## Testing

- Added `tests/codegen/issue1642.wit` importing the same interface with two names (to test implements) as well as non-named (to test prior functionality)
- Verified with local `wit-bindgen go` and re-generated the bindings for the [implements-test](https://github.com/jamesstocktonj1/implements-test) project.

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
