### PR TITLE
Change `cabi_realloc` gates to WASIp1-only

### DIFF
--- a/crates/guest-rust/src/rt/mod.rs
+++ b/crates/guest-rust/src/rt/mod.rs
@@ -111,7 +111,7 @@ impl<K: core::hash::Hash + Eq, V> WitMap<K, V> for std::collections::HashMap<K, 
 }
 
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
-#[cfg(not(target_env = "p2"))]
+#[cfg(target_env = "p1")]
 mod wit_bindgen_cabi_realloc;
 
 /// This function is called from generated bindings and will be deleted by
@@ -122,7 +122,7 @@ mod wit_bindgen_cabi_realloc;
 ///
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
 pub fn maybe_link_cabi_realloc() {
-    #[cfg(all(target_family = "wasm", not(target_env = "p2")))]
+    #[cfg(target_env = "p1")]
     {
         unsafe extern "C" {
             fn cabi_realloc(
@@ -153,7 +153,7 @@ pub fn maybe_link_cabi_realloc() {
 /// `cabi_realloc` module above. It's otherwise never explicitly called.
 ///
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
-#[cfg(not(target_env = "p2"))]
+#[cfg(target_env = "p1")]
 pub unsafe fn cabi_realloc(
     old_ptr: *mut u8,
     old_len: usize,


### PR DESCRIPTION
These were originally added when Rust first added `target_env = "p1"` but that's been there long enough now. These are only needed on WASIp1 and WASIp2/3 targets have this symbol provided by wasi-libc.