### PR TITLE
Optimize MoonBit primitive stream buffering

### DIFF
--- a/crates/moonbit/src/async/trait.mbt
+++ b/crates/moonbit/src/async/trait.mbt
@@ -5,10 +5,11 @@ pub struct Sink[X] {
   priv is_open : () -> Bool
   priv has_cleanup : () -> Bool
   priv cleanup : ((X) -> Unit)?
+  priv write_window_size : Int
 }
 
 ///|
-let sink_write_window_size : Int = 64
+let default_sink_write_window_size : Int = 64
 
 ///|
 /// The write callback must either raise before consuming any value or return
@@ -21,8 +22,17 @@ pub fn[X] Sink::from_callbacks(
   close : async () -> Unit,
   is_open : () -> Bool,
   cleanup : ((X) -> Unit)?,
+  write_window_size : Int,
 ) -> Sink[X] {
-  { write, close, is_open, has_cleanup: () => cleanup is Some(_), cleanup }
+  guard write_window_size > 0
+  {
+    write,
+    close,
+    is_open,
+    has_cleanup: () => cleanup is Some(_),
+    cleanup,
+    write_window_size,
+  }
 }
 
 ///|
@@ -34,13 +44,13 @@ pub async fn[X] Sink::write(self : Sink[X], data : ArrayView[X]) -> Int {
   if data.length() == 0 {
     return 0
   }
-  let length = if data.length() < sink_write_window_size {
+  let length = if data.length() < self.write_window_size {
     data.length()
   } else {
-    sink_write_window_size
+    self.write_window_size
   }
   // The callback may suspend, so it must not retain the caller's borrowed view.
-  let buffer = FixedArray::makei(length, i => data[i])
+  let buffer = FixedArray::from_array(data[:length])
   let written = (self.write)(buffer[:])
   guard written >= 0 && written <= length
   if !(self.is_open)() && written < length && (self.has_cleanup)() {
@@ -60,12 +70,12 @@ pub async fn Sink::write_bytes(self : Sink[Byte], data : BytesView) -> Int {
   if data.length() == 0 {
     return 0
   }
-  let length = if data.length() < sink_write_window_size {
+  let length = if data.length() < self.write_window_size {
     data.length()
   } else {
-    sink_write_window_size
+    self.write_window_size
   }
-  let buffer = FixedArray::makei(length, i => data[i])
+  let buffer = data[:length].to_fixedarray()
   let written = (self.write)(buffer[:])
   guard written >= 0 && written <= length
   if !(self.is_open)() && written < length && (self.has_cleanup)() {
@@ -314,7 +324,7 @@ fn[X] fill_stream_pipe_from_writers(pipe : Ref[StreamPipe[X]]) -> Unit {
     guard take_stream_pipe_writer(pipe) is Some(writer) else { return }
     guard writer.value is Some(data) else { continue }
     let take = if available < data.length() { available } else { data.length() }
-    let chunk = FixedArray::makei(take, i => data[i])
+    let chunk = FixedArray::from_array(data[:take])
     pipe.val.chunks.push_back(chunk)
     pipe.val.buffered = pipe.val.buffered + take
     wake_stream_pipe_writer(writer, take)
@@ -415,7 +425,7 @@ async fn[X] stream_pipe_write(
       } else {
         data.length()
       }
-      let chunk = FixedArray::makei(take, i => data[i])
+      let chunk = FixedArray::from_array(data[:take])
       wake_stream_pipe_reader(reader, Some(chunk), false)
       return take
     }
@@ -424,13 +434,13 @@ async fn[X] stream_pipe_write(
   if pipe.val.capacity > 0 && pipe.val.buffered < pipe.val.capacity {
     let available = pipe.val.capacity - pipe.val.buffered
     let take = if available < data.length() { available } else { data.length() }
-    let chunk = FixedArray::makei(take, i => data[i])
+    let chunk = FixedArray::from_array(data[:take])
     pipe.val.chunks.push_back(chunk)
     pipe.val.buffered = pipe.val.buffered + take
     return take
   }
   let writer = StreamPipeWriter::{
-    value: Some(FixedArray::makei(data.length(), i => data[i])),
+    value: Some(FixedArray::from_array(data)),
     accepted: 0,
     coro: Some(current_coroutine()),
   }
@@ -463,7 +473,9 @@ async fn[X] stream_pipe_read(
       Some(head) => {
         let available = head.length() - pipe.val.head_pos
         let take = if count < available { count } else { available }
-        let result = FixedArray::makei(take, i => head[pipe.val.head_pos + i])
+        let result = FixedArray::from_array(
+          head[pipe.val.head_pos:pipe.val.head_pos + take],
+        )
         pipe.val.head_pos = pipe.val.head_pos + take
         pipe.val.buffered = pipe.val.buffered - take
         if pipe.val.head_pos >= head.length() {
@@ -484,7 +496,7 @@ async fn[X] stream_pipe_read(
       Some(writer) => {
         guard writer.value is Some(data) else { continue }
         let take = if count < data.length() { count } else { data.length() }
-        let result = FixedArray::makei(take, i => data[i])
+        let result = FixedArray::from_array(data[:take])
         wake_stream_pipe_writer(writer, take)
         return Some(result)
       }
@@ -740,6 +752,7 @@ fn[X] stream_pipe_sink(pipe : Ref[StreamPipe[X]]) -> Sink[X] {
         None => ()
       }
     }),
+    write_window_size: default_sink_write_window_size,
   }
 }
 

--- a/crates/moonbit/src/async_support.rs
+++ b/crates/moonbit/src/async_support.rs
@@ -21,6 +21,30 @@ use super::FunctionBindgen;
 use super::InterfaceGenerator;
 use super::wasm_type;
 
+const DEFAULT_STREAM_WINDOW_ELEMENTS: usize = 64;
+const PRIMITIVE_STREAM_BUFFER_BYTES: usize = 4 * 1024;
+
+fn is_fixed_primitive(resolve: &Resolve, ty: &Type) -> bool {
+    match ty {
+        Type::U8
+        | Type::S8
+        | Type::U16
+        | Type::S16
+        | Type::U32
+        | Type::S32
+        | Type::U64
+        | Type::S64
+        | Type::F32
+        | Type::F64
+        | Type::Char => true,
+        Type::Id(id) => match &resolve.types[*id].kind {
+            TypeDefKind::Type(ty) => is_fixed_primitive(resolve, ty),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum PayloadFor {
     Future,
@@ -1233,8 +1257,15 @@ impl<'a> InterfaceGenerator<'a> {
             .map(|ty| self.world_gen.sizes.size(ty).size_wasm32())
             .unwrap_or(0);
         let read_chunk_owns_buffer = result_type.is_some_and(|ty| self.is_list_canonical(ty));
-        let staging_window = if payload_sites.is_empty() { 64 } else { 1 };
-        let max_read_count = 64;
+        let primitive_window = result_type
+            .filter(|ty| is_fixed_primitive(self.resolve, ty))
+            .map(|_| (PRIMITIVE_STREAM_BUFFER_BYTES / elem_size).max(1));
+        let staging_window = if payload_sites.is_empty() {
+            primitive_window.unwrap_or(DEFAULT_STREAM_WINDOW_ELEMENTS)
+        } else {
+            1
+        };
+        let max_read_count = primitive_window.unwrap_or(DEFAULT_STREAM_WINDOW_ELEMENTS);
 
         let EndpointPayloadFragments {
             lift,
@@ -2104,6 +2135,7 @@ fn wasm{symbol_name}StreamCommit(handle : Int) -> Unit {{
             () => close_writer_serialized(),
             () => !writer_closed.val,
             Some(cleanup_value),
+            {staging_window},
         )
         let relay_source = producer is None
         let run_producer = async fn() -> Unit {{

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -3446,6 +3446,76 @@ mod tests {
     }
 
     #[test]
+    fn fixed_primitive_streams_use_four_kibibyte_buffer_budget() {
+        for (wit_type, expected_window) in [
+            ("u8", 4096),
+            ("s8", 4096),
+            ("u16", 2048),
+            ("s16", 2048),
+            ("u32", 1024),
+            ("s32", 1024),
+            ("f32", 1024),
+            ("char", 1024),
+            ("u64", 512),
+            ("s64", 512),
+            ("f64", 512),
+            ("bool", 64),
+            ("string", 64),
+        ] {
+            let wit = format!(
+                r#"
+                package a:b;
+
+                interface api {{
+                    type scalar = {wit_type};
+                    exchange: func(input: stream<scalar>) -> stream<scalar>;
+                }}
+
+                world runner {{ import api; }}
+                "#
+            );
+            let files = generate(&wit, "runner");
+            let generated = files
+                .iter()
+                .map(|(_, contents)| String::from_utf8_lossy(contents))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                generated.contains(&format!("let read_count = if count < {expected_window}")),
+                "unexpected read window for {wit_type}: {generated}"
+            );
+            assert!(
+                generated.contains(&format!(
+                    "let data_len = if data.length() < {expected_window}"
+                )),
+                "unexpected write window for {wit_type}: {generated}"
+            );
+            let compact = generated.split_whitespace().collect::<Vec<_>>().join(" ");
+            assert!(
+                compact.contains(&format!("Some(cleanup_value), {expected_window}, )")),
+                "sink did not receive the {expected_window}-element window for {wit_type}: \
+                 {generated}"
+            );
+        }
+
+        let runtime = generate(
+            r#"
+            package a:b;
+            world runner {
+                import exchange: func(input: stream<u8>) -> stream<u8>;
+            }
+            "#,
+            "runner",
+        );
+        let sink = file(&runtime, "async-core/async_trait.mbt");
+        assert!(sink.contains("priv write_window_size : Int"));
+        assert!(sink.contains("data.length() < self.write_window_size"));
+        assert!(sink.contains("FixedArray::from_array(data[:length])"));
+        assert!(sink.contains("data[:length].to_fixedarray()"));
+        assert!(!sink.contains("FixedArray::makei"));
+    }
+
+    #[test]
     fn async_export_background_group_name_is_deconflicted() {
         let files = generate(
             r#"


### PR DESCRIPTION
## Why

MoonBit async streams currently use a fixed 64-element window regardless of
the canonical element size. That leaves small primitive streams with tiny
transfers and causes avoidable canonical ABI callbacks and scheduler activity.

The async runtime also snapshots borrowed array views with explicit
element-by-element constructors instead of standard collection-copy APIs.

## What changed

- Budget fixed primitive stream windows at 4 KiB, resolving WIT aliases before
  selecting the element count.
- Pass the selected write window into each generated `Sink`.
- Keep the existing 64-element fallback for non-primitive streams and the
  single-element staging rule for nested endpoint payloads.
- Use `FixedArray::from_array` and `BytesView::to_fixedarray` when the runtime
  must take an owned snapshot of a borrowed view.
- Cover primitive widths, fallback behavior, and generated runtime copy shapes.

## Performance

The WASI HTTP benchmark used a 64 KiB body, 64 connections, and three
interleaved 6-second runs per variant. Fixed-rate results below are medians;
all requests succeeded.

| Endpoint | Offered rate | CPU/request, main → PR | Instructions/request, main → PR | p99, main → PR |
| --- | ---: | ---: | ---: | ---: |
| 181 B response | 24,859 req/s | 0.250 → 0.190 ms | 1.06M → 0.89M | 2.64 → 2.08 ms |
| 64 KiB upload | 8,000 req/s | 1.57 → 0.593 ms | 20.65M → 2.81M | 3.03 → 2.16 ms |
| 64 KiB one-chunk download | 250 req/s | 23.15 → 1.88 ms | 90.70M → 5.92M | 12.03 → 2.16 ms |
| 64 KiB upload + download | 200 req/s | 24.48 → 2.62 ms | 111.32M → 7.94M | 13.07 → 3.32 ms |

For the bidirectional 64 KiB case at saturation, median throughput increased
from 351 to 13,625 req/s (38.8x), while p99 fell from 667 to 7.87 ms.

Holding the byte window at 4 KiB and comparing the old `makei` snapshot with
the standard-library byte conversion isolates the copy change:

| Endpoint | CPU/request, `makei` → byte blit | Instructions/request, `makei` → byte blit |
| --- | ---: | ---: |
| 64 KiB one-chunk download | 2.59 → 1.87 ms (-27.6%) | 11.36M → 5.91M (-48.0%) |
| 64 KiB upload + download | 2.94 → 2.53 ms (-14.1%) | 13.39M → 7.93M (-40.8%) |

The baseline component was generated from upstream main at `6b3ec405`. It is
byte-identical to the previous v0.60.0 benchmark component because the MoonBit
generator did not change between those commits.

This workload exercises `stream<u8>`. The other primitive widths are covered by
the generated-code policy tests, but these byte-stream speedups are not claimed
for them.

## Why this is correct and minimal

Only fixed primitive streams receive larger windows. Non-primitive streams and
nested future/stream payload staging retain their existing behavior.

The runtime still copies borrowed views before a callback can suspend, so the
lifetime invariant is unchanged. The byte-specialized path delegates to the
standard library's blit-backed conversion. Generic copies use the standard
API boundary, leaving any future bulk-copy implementation to MoonBit core.

This does not introduce owner buffers, dynamic window adjustment, or generic
canonical element-lowering changes.
