### PR TITLE
ci: run WASIp3 threading tests against wasmtime dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,19 @@ jobs:
     - run: rustup target add wasm32-wasip2
 
     - uses: ./.github/actions/install-wasi-sdk
+
+    # The threading builtins are encoded with a canonical-function opcode
+    # newer than any released wasmtime understands (46.0.1 and 47.0.2 both
+    # reject it with "invalid leading byte (0x2d) for canonical function"),
+    # so this job runs wasmtime's `dev` build instead of the pinned release.
+    # This can go back to the shared pin once a release parses the encoding.
+    - name: Install wasmtime dev build
+      run: |
+        curl --retry 5 --retry-all-errors -L -o wasmtime-dev.tar.xz https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz
+        tar xJf wasmtime-dev.tar.xz
+        echo "`pwd`/wasmtime-dev-x86_64-linux" >> $GITHUB_PATH
+      working-directory: ${{ runner.temp }}
+
     - run: |
         cargo run test --languages rust,c,go tests/threading \
           --artifacts target/artifacts \


### PR DESCRIPTION
- The "Test WASIp3 Threading (allowed to fail)" job has been failing on every recent CI run (visible in the merge-queue runs for #1664 and #1665, and on unrelated PRs like #1667): wasmtime rejects the composed component with `invalid leading byte (0x2d) for canonical function`.
- The workspace's wasm-tools encodes the threading builtins with a canonical-function opcode that no released wasmtime parses yet. Reproduced locally: wasmtime 46.0.1 (the shared CI pin) and 47.0.2 (latest release) both fail, while the `dev` build (48.0.0 as of this writing) passes `cargo run test --languages rust,c tests/threading`.
- This installs wasmtime's `dev` build ahead of the shared pin for the threading job only, matching the job's existing "toolchains are percolating" framing. It can return to the shared pin once a wasmtime release parses the encoding.