### PR TITLE
Optimize MoonBit canonical list arguments with typed borrows

### DIFF
--- a/crates/moonbit/src/ffi.rs
+++ b/crates/moonbit/src/ffi.rs
@@ -1,9 +1,3 @@
-pub(crate) const EXTEND16: &str = r#"
-///|
-extern "wasm" fn mbt_ffi_extend16(value : Int) -> Int =
-  #|(func (param i32) (result i32) local.get 0 i32.extend16_s)
-"#;
-
 pub(crate) const EXTEND8: &str = r#"
 ///|
 extern "wasm" fn mbt_ffi_extend8(value : Int) -> Int =
@@ -133,6 +127,13 @@ extern "wasm" fn mbt_ffi_uint_array2ptr(array : FixedArray[UInt]) -> Int =
   #|(func (param i32) (result i32) local.get 0)
 "#;
 
+pub(crate) const UINT16_ARRAY2PTR: &str = r#"
+///|
+#owned(array)
+extern "wasm" fn mbt_ffi_uint16_array2ptr(array : FixedArray[UInt16]) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+"#;
+
 pub(crate) const UINT64_ARRAY2PTR: &str = r#"
 ///|
 #owned(array)
@@ -144,6 +145,13 @@ pub(crate) const INT_ARRAY2PTR: &str = r#"
 ///|
 #owned(array)
 extern "wasm" fn mbt_ffi_int_array2ptr(array : FixedArray[Int]) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+"#;
+
+pub(crate) const INT16_ARRAY2PTR: &str = r#"
+///|
+#owned(array)
+extern "wasm" fn mbt_ffi_int16_array2ptr(array : FixedArray[Int16]) -> Int =
   #|(func (param i32) (result i32) local.get 0)
 "#;
 
@@ -177,12 +185,30 @@ extern "wasm" fn mbt_ffi_ptr2uint_array(ptr : Int, len : Int) -> FixedArray[UInt
   #| local.get 0)
 "#;
 
+pub(crate) const PTR2UINT16_ARRAY: &str = r#"
+///|
+extern "wasm" fn mbt_ffi_ptr2uint16_array(ptr : Int, len : Int) -> FixedArray[UInt16] =
+  #|(func (param i32) (param i32) (result i32)
+  #| local.get 0
+  #| local.get 1 call $moonbit.init_array16
+  #| local.get 0)
+"#;
+
 pub(crate) const PTR2INT_ARRAY: &str = r#"
 ///|
 extern "wasm" fn mbt_ffi_ptr2int_array(ptr : Int, len : Int) -> FixedArray[Int] =
   #|(func (param i32) (param i32) (result i32)
   #| local.get 0
   #| local.get 1 call $moonbit.init_array32
+  #| local.get 0)
+"#;
+
+pub(crate) const PTR2INT16_ARRAY: &str = r#"
+///|
+extern "wasm" fn mbt_ffi_ptr2int16_array(ptr : Int, len : Int) -> FixedArray[Int16] =
+  #|(func (param i32) (param i32) (result i32)
+  #| local.get 0
+  #| local.get 1 call $moonbit.init_array16
   #| local.get 0)
 "#;
 

--- a/crates/moonbit/src/ffi.rs
+++ b/crates/moonbit/src/ffi.rs
@@ -120,6 +120,13 @@ extern "wasm" fn mbt_ffi_ptr2bytes(ptr : Int, len : Int) -> FixedArray[Byte] =
   #| local.get 0)
 "#;
 
+pub(crate) const BOOL_ARRAY2PTR: &str = r#"
+///|
+#owned(array)
+extern "wasm" fn mbt_ffi_bool_array2ptr(array : FixedArray[Bool]) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+"#;
+
 pub(crate) const UINT_ARRAY2PTR: &str = r#"
 ///|
 #owned(array)
@@ -174,6 +181,15 @@ pub(crate) const DOUBLE_ARRAY2PTR: &str = r#"
 #owned(array)
 extern "wasm" fn mbt_ffi_double_array2ptr(array : FixedArray[Double]) -> Int =
   #|(func (param i32) (result i32) local.get 0)
+"#;
+
+pub(crate) const PTR2BOOL_ARRAY: &str = r#"
+///|
+extern "wasm" fn mbt_ffi_ptr2bool_array(ptr : Int, len : Int) -> FixedArray[Bool] =
+  #|(func (param i32) (param i32) (result i32)
+  #| local.get 0
+  #| local.get 1 call $moonbit.init_array8
+  #| local.get 0)
 "#;
 
 pub(crate) const PTR2UINT_ARRAY: &str = r#"

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -11,7 +11,7 @@ use wit_bindgen_core::{
     AsyncFilterSet, Direction, Files, InterfaceGenerator as CoreInterfaceGenerator, Ns, Source,
     WorldGenerator,
     abi::{self, AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType},
-    uwrite, uwriteln,
+    dealias, uwrite, uwriteln,
     wit_parser::{
         Alignment, ArchitectureSize, Docs, Enum, Flags, FlagsRepr, Function, Int, InterfaceId,
         LiftLowerAbi, LiveTypes, ManglingAndAbi, Param, Record, Resolve, ResourceIntrinsic,
@@ -29,54 +29,23 @@ mod async_support;
 mod ffi;
 mod pkg;
 
-#[derive(Clone, Copy)]
-pub(crate) enum CanonicalListElement {
-    Bool,
-    U8,
-    U16,
-    U32,
-    U64,
-    S16,
-    S32,
-    S64,
-    F32,
-    F64,
-}
-
-impl CanonicalListElement {
-    pub(crate) fn fixed_array_type(self) -> &'static str {
-        match self {
-            Self::Bool => "FixedArray[Bool]",
-            Self::U8 => "FixedArray[Byte]",
-            Self::U16 => "FixedArray[UInt16]",
-            Self::U32 => "FixedArray[UInt]",
-            Self::U64 => "FixedArray[UInt64]",
-            Self::S16 => "FixedArray[Int16]",
-            Self::S32 => "FixedArray[Int]",
-            Self::S64 => "FixedArray[Int64]",
-            Self::F32 => "FixedArray[Float]",
-            Self::F64 => "FixedArray[Double]",
-        }
-    }
-}
-
-pub(crate) fn canonical_list_element(resolve: &Resolve, ty: &Type) -> Option<CanonicalListElement> {
-    match ty {
-        Type::Id(id) => match &resolve.types[*id].kind {
-            TypeDefKind::Type(ty) => canonical_list_element(resolve, ty),
-            _ => None,
+pub(crate) fn is_list_canonical(resolve: &Resolve, element: &Type) -> bool {
+    match element {
+        Type::Bool
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::S16
+        | Type::S32
+        | Type::S64
+        | Type::F32
+        | Type::F64 => true,
+        Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
+            TypeDefKind::Type(element) => is_list_canonical(resolve, element),
+            _ => false,
         },
-        Type::Bool => Some(CanonicalListElement::Bool),
-        Type::U8 => Some(CanonicalListElement::U8),
-        Type::U16 => Some(CanonicalListElement::U16),
-        Type::U32 => Some(CanonicalListElement::U32),
-        Type::U64 => Some(CanonicalListElement::U64),
-        Type::S16 => Some(CanonicalListElement::S16),
-        Type::S32 => Some(CanonicalListElement::S32),
-        Type::S64 => Some(CanonicalListElement::S64),
-        Type::F32 => Some(CanonicalListElement::F32),
-        Type::F64 => Some(CanonicalListElement::F64),
-        _ => None,
+        _ => false,
     }
 }
 
@@ -86,7 +55,7 @@ fn collect_direct_canonical_lists(
     expression: String,
     wasm_param: usize,
     expressions: &mut HashSet<String>,
-    wasm_params: &mut BTreeMap<usize, &'static str>,
+    wasm_params: &mut BTreeMap<usize, Type>,
 ) {
     let Type::Id(id) = ty else {
         return;
@@ -101,9 +70,9 @@ fn collect_direct_canonical_lists(
             wasm_params,
         ),
         TypeDefKind::List(element) => {
-            if let Some(element) = canonical_list_element(resolve, element) {
+            if is_list_canonical(resolve, element) {
                 expressions.insert(expression);
-                wasm_params.insert(wasm_param, element.fixed_array_type());
+                wasm_params.insert(wasm_param, *element);
             }
         }
         TypeDefKind::Record(record) => {
@@ -791,8 +760,9 @@ impl InterfaceGenerator<'_> {
             .iter()
             .enumerate()
             .map(|(i, param)| {
-                if let Some(array_type) = direct_canonical_wasm_params.get(&i) {
-                    format!("p{i} : {array_type}")
+                if let Some(element) = direct_canonical_wasm_params.get(&i) {
+                    let element = self.world_gen.pkg_resolver.type_name(self.name, element);
+                    format!("p{i} : FixedArray[{element}]")
                 } else if i > 0 && direct_canonical_wasm_params.contains_key(&(i - 1)) {
                     format!("p{i}? : Int = p{}.length()", i - 1)
                 } else {
@@ -2165,9 +2135,16 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             )),
 
             Instruction::ListCanonLower { element, realloc } => {
-                let element = canonical_list_element(resolve, element).unwrap();
+                let element: &Type = element;
+                let element = match element {
+                    Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
+                        TypeDefKind::Type(element) => element,
+                        _ => unreachable!("unsupported list element type"),
+                    },
+                    _ => element,
+                };
                 match element {
-                    CanonicalListElement::U8 => {
+                    Type::U8 => {
                         let op = &operands[0];
                         if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
                             results.push(op.clone());
@@ -2188,7 +2165,15 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                             self.cleanup.push(Cleanup { address: ptr });
                         }
                     }
-                    element => {
+                    Type::Bool
+                    | Type::U16
+                    | Type::U32
+                    | Type::U64
+                    | Type::S16
+                    | Type::S32
+                    | Type::S64
+                    | Type::F32
+                    | Type::F64 => {
                         let op = &operands[0];
                         if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
                             results.push(op.clone());
@@ -2197,16 +2182,16 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         }
                         let ptr = self.locals.tmp("ptr");
                         let (owned_ffi, ty) = match element {
-                            CanonicalListElement::Bool => (ffi::BOOL_ARRAY2PTR, "bool"),
-                            CanonicalListElement::U16 => (ffi::UINT16_ARRAY2PTR, "uint16"),
-                            CanonicalListElement::U32 => (ffi::UINT_ARRAY2PTR, "uint"),
-                            CanonicalListElement::U64 => (ffi::UINT64_ARRAY2PTR, "uint64"),
-                            CanonicalListElement::S16 => (ffi::INT16_ARRAY2PTR, "int16"),
-                            CanonicalListElement::S32 => (ffi::INT_ARRAY2PTR, "int"),
-                            CanonicalListElement::S64 => (ffi::INT64_ARRAY2PTR, "int64"),
-                            CanonicalListElement::F32 => (ffi::FLOAT_ARRAY2PTR, "float"),
-                            CanonicalListElement::F64 => (ffi::DOUBLE_ARRAY2PTR, "double"),
-                            CanonicalListElement::U8 => unreachable!(),
+                            Type::Bool => (ffi::BOOL_ARRAY2PTR, "bool"),
+                            Type::U16 => (ffi::UINT16_ARRAY2PTR, "uint16"),
+                            Type::U32 => (ffi::UINT_ARRAY2PTR, "uint"),
+                            Type::U64 => (ffi::UINT64_ARRAY2PTR, "uint64"),
+                            Type::S16 => (ffi::INT16_ARRAY2PTR, "int16"),
+                            Type::S32 => (ffi::INT_ARRAY2PTR, "int"),
+                            Type::S64 => (ffi::INT64_ARRAY2PTR, "int64"),
+                            Type::F32 => (ffi::FLOAT_ARRAY2PTR, "float"),
+                            Type::F64 => (ffi::DOUBLE_ARRAY2PTR, "double"),
+                            _ => unreachable!(),
                         };
                         self.use_ffi(owned_ffi);
 
@@ -2222,13 +2207,21 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                             self.cleanup.push(Cleanup { address: ptr });
                         }
                     }
+                    _ => unreachable!("unsupported list element type"),
                 }
             }
 
             Instruction::ListCanonLift { element, .. } => {
-                let element = canonical_list_element(resolve, element).unwrap();
+                let element: &Type = element;
+                let element = match element {
+                    Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
+                        TypeDefKind::Type(element) => element,
+                        _ => unreachable!("unsupported list element type"),
+                    },
+                    _ => element,
+                };
                 match element {
-                    CanonicalListElement::U8 => {
+                    Type::U8 => {
                         let result = self.locals.tmp("result");
                         let address = &operands[0];
                         let length = &operands[1];
@@ -2242,45 +2235,53 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
                         results.push(result);
                     }
-                    element => {
+                    Type::Bool
+                    | Type::U16
+                    | Type::U32
+                    | Type::U64
+                    | Type::S16
+                    | Type::S32
+                    | Type::S64
+                    | Type::F32
+                    | Type::F64 => {
                         let ty = match element {
-                            CanonicalListElement::Bool => {
+                            Type::Bool => {
                                 self.use_ffi(ffi::PTR2BOOL_ARRAY);
                                 "bool"
                             }
-                            CanonicalListElement::U16 => {
+                            Type::U16 => {
                                 self.use_ffi(ffi::PTR2UINT16_ARRAY);
                                 "uint16"
                             }
-                            CanonicalListElement::U32 => {
+                            Type::U32 => {
                                 self.use_ffi(ffi::PTR2UINT_ARRAY);
                                 "uint"
                             }
-                            CanonicalListElement::U64 => {
+                            Type::U64 => {
                                 self.use_ffi(ffi::PTR2UINT64_ARRAY);
                                 "uint64"
                             }
-                            CanonicalListElement::S16 => {
+                            Type::S16 => {
                                 self.use_ffi(ffi::PTR2INT16_ARRAY);
                                 "int16"
                             }
-                            CanonicalListElement::S32 => {
+                            Type::S32 => {
                                 self.use_ffi(ffi::PTR2INT_ARRAY);
                                 "int"
                             }
-                            CanonicalListElement::S64 => {
+                            Type::S64 => {
                                 self.use_ffi(ffi::PTR2INT64_ARRAY);
                                 "int64"
                             }
-                            CanonicalListElement::F32 => {
+                            Type::F32 => {
                                 self.use_ffi(ffi::PTR2FLOAT_ARRAY);
                                 "float"
                             }
-                            CanonicalListElement::F64 => {
+                            Type::F64 => {
                                 self.use_ffi(ffi::PTR2DOUBLE_ARRAY);
                                 "double"
                             }
-                            CanonicalListElement::U8 => unreachable!(),
+                            _ => unreachable!(),
                         };
 
                         let result = self.locals.tmp("result");
@@ -2296,6 +2297,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
                         results.push(result);
                     }
+                    _ => unreachable!("unsupported list element type"),
                 }
             }
 
@@ -3073,7 +3075,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
     }
 
     fn is_list_canonical(&self, resolve: &Resolve, element: &Type) -> bool {
-        canonical_list_element(resolve, element).is_some()
+        crate::is_list_canonical(resolve, element)
     }
 }
 

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -29,26 +29,6 @@ mod async_support;
 mod ffi;
 mod pkg;
 
-pub(crate) fn is_list_canonical(resolve: &Resolve, element: &Type) -> bool {
-    match element {
-        Type::Bool
-        | Type::U8
-        | Type::U16
-        | Type::U32
-        | Type::U64
-        | Type::S16
-        | Type::S32
-        | Type::S64
-        | Type::F32
-        | Type::F64 => true,
-        Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
-            TypeDefKind::Type(element) => is_list_canonical(resolve, element),
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
 // Assumptions:
 // - Data: u8 -> Byte, s8 | s32 -> Int, s16 -> Int16, u16 -> UInt16, u32 -> UInt, s64 -> Int64, u64 -> UInt64, f32 -> Float, f64 -> Double, address -> Int
 // - Encoding: UTF16
@@ -3002,7 +2982,26 @@ impl Bindgen for FunctionBindgen<'_, '_> {
     }
 
     fn is_list_canonical(&self, resolve: &Resolve, element: &Type) -> bool {
-        crate::is_list_canonical(resolve, element)
+        let element = match element {
+            Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
+                TypeDefKind::Type(element) => element,
+                _ => return false,
+            },
+            element => element,
+        };
+        matches!(
+            element,
+            Type::Bool
+                | Type::U8
+                | Type::U16
+                | Type::U32
+                | Type::U64
+                | Type::S16
+                | Type::S32
+                | Type::S64
+                | Type::F32
+                | Type::F64
+        )
     }
 }
 
@@ -3679,14 +3678,6 @@ mod tests {
             "direct canonical lists must retain their canonical pointer/length operands: {top}"
         );
         assert!(
-            !top.contains("mbt_ffi_borrowed_array2ptr(bytes)")
-                && !top.contains("mbt_ffi_borrowed_array2ptr(unsigned_shorts)")
-                && !top.contains("mbt_ffi_borrowed_array2ptr(signed_shorts)")
-                && !top.contains("mbt_ffi_borrowed_array2ptr(words)"),
-            "direct list parameters must not round-trip through Int: {top}"
-        );
-        assert!(!top.contains("mbt_ffi_borrowed_array2ptr"), "{top}");
-        assert!(
             ffi.contains(
                 "#unsafe_skip_stub_check\n#borrow(p0, p2, p4, p6, p8, p10)\nfn wasmImportSend(\
                  p0 : FixedArray[Byte], p1 : Int, \
@@ -3698,12 +3689,6 @@ mod tests {
             ),
             "the imported FFI must borrow arrays while retaining explicit lengths: {ffi}"
         );
-        assert!(
-            !ffi.contains("mbt_ffi_borrowed_array2ptr"),
-            "direct list parameters must not need an array-to-pointer helper: {ffi}"
-        );
-        assert!(!ffi.contains("mbt_ffi_borrowed_bytes2ptr"), "{ffi}");
-        assert!(!ffi.contains("mbt_ffi_borrowed_uint_array2ptr"), "{ffi}");
         assert!(
             !top.contains("mbt_ffi_free(ptr)\n"),
             "borrowed canonical backing storage must not be freed after the call: {top}"

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use core::panic;
 use heck::{ToShoutySnakeCase, ToUpperCamelCase};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Write,
     mem,
     ops::Deref,
@@ -29,10 +29,116 @@ mod async_support;
 mod ffi;
 mod pkg;
 
+#[derive(Clone, Copy)]
+pub(crate) enum CanonicalListElement {
+    U8,
+    U16,
+    U32,
+    U64,
+    S16,
+    S32,
+    S64,
+    F32,
+    F64,
+}
+
+impl CanonicalListElement {
+    pub(crate) fn fixed_array_type(self) -> &'static str {
+        match self {
+            Self::U8 => "FixedArray[Byte]",
+            Self::U16 => "FixedArray[UInt16]",
+            Self::U32 => "FixedArray[UInt]",
+            Self::U64 => "FixedArray[UInt64]",
+            Self::S16 => "FixedArray[Int16]",
+            Self::S32 => "FixedArray[Int]",
+            Self::S64 => "FixedArray[Int64]",
+            Self::F32 => "FixedArray[Float]",
+            Self::F64 => "FixedArray[Double]",
+        }
+    }
+}
+
+pub(crate) fn canonical_list_element(resolve: &Resolve, ty: &Type) -> Option<CanonicalListElement> {
+    match ty {
+        Type::Id(id) => match &resolve.types[*id].kind {
+            TypeDefKind::Type(ty) => canonical_list_element(resolve, ty),
+            _ => None,
+        },
+        Type::U8 => Some(CanonicalListElement::U8),
+        Type::U16 => Some(CanonicalListElement::U16),
+        Type::U32 => Some(CanonicalListElement::U32),
+        Type::U64 => Some(CanonicalListElement::U64),
+        Type::S16 => Some(CanonicalListElement::S16),
+        Type::S32 => Some(CanonicalListElement::S32),
+        Type::S64 => Some(CanonicalListElement::S64),
+        Type::F32 => Some(CanonicalListElement::F32),
+        Type::F64 => Some(CanonicalListElement::F64),
+        _ => None,
+    }
+}
+
+fn collect_direct_canonical_lists(
+    resolve: &Resolve,
+    ty: &Type,
+    expression: String,
+    wasm_param: usize,
+    expressions: &mut HashSet<String>,
+    wasm_params: &mut BTreeMap<usize, &'static str>,
+) {
+    let Type::Id(id) = ty else {
+        return;
+    };
+    match &resolve.types[*id].kind {
+        TypeDefKind::Type(ty) => collect_direct_canonical_lists(
+            resolve,
+            ty,
+            expression,
+            wasm_param,
+            expressions,
+            wasm_params,
+        ),
+        TypeDefKind::List(element) => {
+            if let Some(element) = canonical_list_element(resolve, element) {
+                expressions.insert(expression);
+                wasm_params.insert(wasm_param, element.fixed_array_type());
+            }
+        }
+        TypeDefKind::Record(record) => {
+            let mut field_wasm_param = wasm_param;
+            for field in &record.fields {
+                collect_direct_canonical_lists(
+                    resolve,
+                    &field.ty,
+                    format!("({expression}).{}", field.name.to_moonbit_ident()),
+                    field_wasm_param,
+                    expressions,
+                    wasm_params,
+                );
+                field_wasm_param += abi::flat_types(resolve, &field.ty, None).unwrap().len();
+            }
+        }
+        TypeDefKind::Tuple(tuple) => {
+            let mut field_wasm_param = wasm_param;
+            for (index, field) in tuple.types.iter().enumerate() {
+                collect_direct_canonical_lists(
+                    resolve,
+                    field,
+                    format!("({expression}).{index}"),
+                    field_wasm_param,
+                    expressions,
+                    wasm_params,
+                );
+                field_wasm_param += abi::flat_types(resolve, field, None).unwrap().len();
+            }
+        }
+        _ => {}
+    }
+}
+
 // Assumptions:
-// - Data: u8 -> Byte, s8 | s16 | s32 -> Int, u16 | u32 -> UInt, s64 -> Int64, u64 -> UInt64, f32 | f64 -> Double, address -> Int
+// - Data: u8 -> Byte, s8 | s32 -> Int, s16 -> Int16, u16 -> UInt16, u32 -> UInt, s64 -> Int64, u64 -> UInt64, f32 -> Float, f64 -> Double, address -> Int
 // - Encoding: UTF16
-// - Lift/Lower list<T>: T == Int/UInt/Int64/UInt64/Float/Double -> FixedArray[T], T == Byte -> Bytes, T == Char -> String
+// - Lift/Lower list<T>: canonically represented numeric elements -> FixedArray[T], otherwise Array[T]
 // Organization:
 // - one package per interface (export and import are treated as different interfaces)
 // - ffi utils are under `./ffi`, and the project entrance (package as link target) is under `./gen`
@@ -607,6 +713,22 @@ impl InterfaceGenerator<'_> {
         let endpoint_plan = self.import_async_function_plan(self.interface, func);
         let wasm_sig = self.resolve.wasm_signature(variant, func);
         let mbt_sig = self.world_gen.pkg_resolver.mbt_sig(self.name, func, false);
+        let mut direct_canonical_lists = HashSet::new();
+        let mut direct_canonical_wasm_params = BTreeMap::new();
+        if !async_plan.is_async() && !wasm_sig.indirect_params {
+            let mut wasm_param = 0;
+            for Param { name, ty, .. } in &func.params {
+                collect_direct_canonical_lists(
+                    self.resolve,
+                    ty,
+                    name.to_moonbit_ident(),
+                    wasm_param,
+                    &mut direct_canonical_lists,
+                    &mut direct_canonical_wasm_params,
+                );
+                wasm_param += abi::flat_types(self.resolve, ty, None).unwrap().len();
+            }
+        }
         let (src, needs_cleanup_list, endpoint_state) = if async_plan.is_async() {
             let body = self.generate_async_import_body(&endpoint_plan, func, &mbt_sig, &wasm_sig);
             (body.src, body.needs_cleanup_list, body.state)
@@ -616,6 +738,13 @@ impl InterfaceGenerator<'_> {
                 func.params
                     .iter()
                     .map(|Param { name, .. }| name.to_moonbit_ident())
+                    .collect(),
+            )
+            .with_direct_canonical_list_params(
+                direct_canonical_lists,
+                direct_canonical_wasm_params
+                    .keys()
+                    .map(|param| param + 1)
                     .collect(),
             )
             .with_async_state(endpoint_plan.state());
@@ -658,14 +787,34 @@ impl InterfaceGenerator<'_> {
             .params
             .iter()
             .enumerate()
-            .map(|(i, param)| format!("p{i} : {}", wasm_type(*param)))
+            .map(|(i, param)| {
+                if let Some(array_type) = direct_canonical_wasm_params.get(&i) {
+                    format!("p{i} : {array_type}")
+                } else if i > 0 && direct_canonical_wasm_params.contains_key(&(i - 1)) {
+                    format!("p{i}? : Int = p{}.length()", i - 1)
+                } else {
+                    format!("p{i} : {}", wasm_type(*param))
+                }
+            })
             .collect::<Vec<_>>()
             .join(", ");
+        let direct_borrows = direct_canonical_wasm_params
+            .keys()
+            .map(|i| format!("p{i}"))
+            .collect::<Vec<_>>();
+        let direct_borrow_attributes = if direct_borrows.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "#unsafe_skip_stub_check\n#borrow({})\n",
+                direct_borrows.join(", ")
+            )
+        };
         let ffi_import_name = format!("wasmImport{}", func.name.to_upper_camel_case());
         uwriteln!(
             self.ffi,
             r#"
-            fn {ffi_import_name}({params}) {result_type} = "{import_module}" "{import_name}"
+            {direct_borrow_attributes}fn {ffi_import_name}({params}) {result_type} = "{import_module}" "{import_name}"
             "#
         );
 
@@ -1415,6 +1564,8 @@ struct FunctionBindgen<'a, 'b> {
     sync_endpoint_drop: bool,
     commit_endpoints: bool,
     sync_import_argument_types: Option<Vec<Type>>,
+    direct_canonical_list_params: HashSet<String>,
+    direct_canonical_list_length_params: HashSet<usize>,
     async_state: AsyncFunctionState,
 }
 
@@ -1445,8 +1596,20 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
             sync_endpoint_drop: false,
             commit_endpoints: false,
             sync_import_argument_types: None,
+            direct_canonical_list_params: HashSet::new(),
+            direct_canonical_list_length_params: HashSet::new(),
             async_state: AsyncFunctionState::default(),
         }
+    }
+
+    fn with_direct_canonical_list_params(
+        mut self,
+        params: HashSet<String>,
+        length_params: HashSet<usize>,
+    ) -> Self {
+        self.direct_canonical_list_params = params;
+        self.direct_canonical_list_length_params = length_params;
+        self
     }
 
     fn lower_variant(
@@ -1640,7 +1803,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
     fn emit(
         &mut self,
-        _resolve: &Resolve,
+        resolve: &Resolve,
         inst: &Instruction<'_>,
         operands: &mut Vec<String>,
         results: &mut Vec<String>,
@@ -1683,9 +1846,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             Instruction::I32FromChar => results.push(format!("({}).to_int()", operands[0])),
 
             Instruction::I32FromU8 => results.push(format!("({}).to_int()", operands[0])),
-            Instruction::I32FromU16 => {
-                results.push(format!("({}).reinterpret_as_int()", operands[0]))
-            }
+            Instruction::I32FromU16 => results.push(format!("({}).to_int()", operands[0])),
             Instruction::U8FromI32 => results.push(format!("({}).to_byte()", operands[0])),
 
             Instruction::I32FromS8 => {
@@ -1693,15 +1854,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 results.push(format!("mbt_ffi_extend8({})", operands[0]))
             }
             Instruction::S8FromI32 => results.push(format!("({} - 0x100)", operands[0])),
-            Instruction::S16FromI32 => results.push(format!("({} - 0x10000)", operands[0])),
-            Instruction::I32FromS16 => {
-                self.use_ffi(ffi::EXTEND16);
-                results.push(format!("mbt_ffi_extend16({})", operands[0]))
-            }
-            Instruction::U16FromI32 => results.push(format!(
-                "({}.land(0xFFFF).reinterpret_as_uint())",
-                operands[0]
-            )),
+            Instruction::S16FromI32 => results.push(format!("Int16::from_int({})", operands[0])),
+            Instruction::I32FromS16 => results.push(format!("({}).to_int()", operands[0])),
+            Instruction::U16FromI32 => results.push(format!("({}).to_uint16()", operands[0])),
             Instruction::U32FromI32 => {
                 results.push(format!("({}).reinterpret_as_uint()", operands[0]))
             }
@@ -2006,128 +2161,135 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 operands[0]
             )),
 
-            Instruction::ListCanonLower { element, realloc } => match element {
-                Type::U8 => {
-                    let op = &operands[0];
-                    let ptr = self.locals.tmp("ptr");
-                    self.use_ffi(ffi::BYTES2PTR);
-                    uwriteln!(
-                        self.src,
-                        "
+            Instruction::ListCanonLower { element, realloc } => {
+                let element = canonical_list_element(resolve, element).unwrap();
+                match element {
+                    CanonicalListElement::U8 => {
+                        let op = &operands[0];
+                        if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
+                            results.push(op.clone());
+                            results.push(format!("{op}.length()"));
+                            return;
+                        }
+                        let ptr = self.locals.tmp("ptr");
+                        self.use_ffi(ffi::BYTES2PTR);
+                        uwriteln!(
+                            self.src,
+                            "
                         let {ptr} = mbt_ffi_bytes2ptr({op})
                         ",
-                    );
-                    results.push(ptr.clone());
-                    results.push(format!("{op}.length()"));
-                    if realloc.is_none() {
-                        self.cleanup.push(Cleanup { address: ptr });
+                        );
+                        results.push(ptr.clone());
+                        results.push(format!("{op}.length()"));
+                        if realloc.is_none() {
+                            self.cleanup.push(Cleanup { address: ptr });
+                        }
                     }
-                }
-                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64 => {
-                    let op = &operands[0];
-                    let ptr = self.locals.tmp("ptr");
-                    let ty = match element {
-                        Type::U32 => {
-                            self.use_ffi(ffi::UINT_ARRAY2PTR);
-                            "uint"
+                    element => {
+                        let op = &operands[0];
+                        if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
+                            results.push(op.clone());
+                            results.push(format!("{op}.length()"));
+                            return;
                         }
-                        Type::U64 => {
-                            self.use_ffi(ffi::UINT64_ARRAY2PTR);
-                            "uint64"
-                        }
-                        Type::S32 => {
-                            self.use_ffi(ffi::INT_ARRAY2PTR);
-                            "int"
-                        }
-                        Type::S64 => {
-                            self.use_ffi(ffi::INT64_ARRAY2PTR);
-                            "int64"
-                        }
-                        Type::F32 => {
-                            self.use_ffi(ffi::FLOAT_ARRAY2PTR);
-                            "float"
-                        }
-                        Type::F64 => {
-                            self.use_ffi(ffi::DOUBLE_ARRAY2PTR);
-                            "double"
-                        }
-                        _ => unreachable!(),
-                    };
+                        let ptr = self.locals.tmp("ptr");
+                        let (owned_ffi, ty) = match element {
+                            CanonicalListElement::U16 => (ffi::UINT16_ARRAY2PTR, "uint16"),
+                            CanonicalListElement::U32 => (ffi::UINT_ARRAY2PTR, "uint"),
+                            CanonicalListElement::U64 => (ffi::UINT64_ARRAY2PTR, "uint64"),
+                            CanonicalListElement::S16 => (ffi::INT16_ARRAY2PTR, "int16"),
+                            CanonicalListElement::S32 => (ffi::INT_ARRAY2PTR, "int"),
+                            CanonicalListElement::S64 => (ffi::INT64_ARRAY2PTR, "int64"),
+                            CanonicalListElement::F32 => (ffi::FLOAT_ARRAY2PTR, "float"),
+                            CanonicalListElement::F64 => (ffi::DOUBLE_ARRAY2PTR, "double"),
+                            CanonicalListElement::U8 => unreachable!(),
+                        };
+                        self.use_ffi(owned_ffi);
 
-                    uwriteln!(
-                        self.src,
-                        "
+                        uwriteln!(
+                            self.src,
+                            "
                         let {ptr} = mbt_ffi_{ty}_array2ptr({op})
                         ",
-                    );
-                    results.push(ptr.clone());
-                    results.push(format!("{op}.length()"));
-                    if realloc.is_none() {
-                        self.cleanup.push(Cleanup { address: ptr });
+                        );
+                        results.push(ptr.clone());
+                        results.push(format!("{op}.length()"));
+                        if realloc.is_none() {
+                            self.cleanup.push(Cleanup { address: ptr });
+                        }
                     }
                 }
-                _ => unreachable!("unsupported list element type"),
-            },
+            }
 
-            Instruction::ListCanonLift { element, .. } => match element {
-                Type::U8 => {
-                    let result = self.locals.tmp("result");
-                    let address = &operands[0];
-                    let length = &operands[1];
-                    self.use_ffi(ffi::PTR2BYTES);
-                    uwrite!(
-                        self.src,
-                        "
+            Instruction::ListCanonLift { element, .. } => {
+                let element = canonical_list_element(resolve, element).unwrap();
+                match element {
+                    CanonicalListElement::U8 => {
+                        let result = self.locals.tmp("result");
+                        let address = &operands[0];
+                        let length = &operands[1];
+                        self.use_ffi(ffi::PTR2BYTES);
+                        uwrite!(
+                            self.src,
+                            "
                         let {result} = mbt_ffi_ptr2bytes({address}, {length})
                         ",
-                    );
+                        );
 
-                    results.push(result);
-                }
-                Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64 => {
-                    let ty = match element {
-                        Type::U32 => {
-                            self.use_ffi(ffi::PTR2UINT_ARRAY);
-                            "uint"
-                        }
-                        Type::U64 => {
-                            self.use_ffi(ffi::PTR2UINT64_ARRAY);
-                            "uint64"
-                        }
-                        Type::S32 => {
-                            self.use_ffi(ffi::PTR2INT_ARRAY);
-                            "int"
-                        }
-                        Type::S64 => {
-                            self.use_ffi(ffi::PTR2INT64_ARRAY);
-                            "int64"
-                        }
-                        Type::F32 => {
-                            self.use_ffi(ffi::PTR2FLOAT_ARRAY);
-                            "float"
-                        }
-                        Type::F64 => {
-                            self.use_ffi(ffi::PTR2DOUBLE_ARRAY);
-                            "double"
-                        }
-                        _ => unreachable!(),
-                    };
+                        results.push(result);
+                    }
+                    element => {
+                        let ty = match element {
+                            CanonicalListElement::U16 => {
+                                self.use_ffi(ffi::PTR2UINT16_ARRAY);
+                                "uint16"
+                            }
+                            CanonicalListElement::U32 => {
+                                self.use_ffi(ffi::PTR2UINT_ARRAY);
+                                "uint"
+                            }
+                            CanonicalListElement::U64 => {
+                                self.use_ffi(ffi::PTR2UINT64_ARRAY);
+                                "uint64"
+                            }
+                            CanonicalListElement::S16 => {
+                                self.use_ffi(ffi::PTR2INT16_ARRAY);
+                                "int16"
+                            }
+                            CanonicalListElement::S32 => {
+                                self.use_ffi(ffi::PTR2INT_ARRAY);
+                                "int"
+                            }
+                            CanonicalListElement::S64 => {
+                                self.use_ffi(ffi::PTR2INT64_ARRAY);
+                                "int64"
+                            }
+                            CanonicalListElement::F32 => {
+                                self.use_ffi(ffi::PTR2FLOAT_ARRAY);
+                                "float"
+                            }
+                            CanonicalListElement::F64 => {
+                                self.use_ffi(ffi::PTR2DOUBLE_ARRAY);
+                                "double"
+                            }
+                            CanonicalListElement::U8 => unreachable!(),
+                        };
 
-                    let result = self.locals.tmp("result");
-                    let address = &operands[0];
-                    let length = &operands[1];
+                        let result = self.locals.tmp("result");
+                        let address = &operands[0];
+                        let length = &operands[1];
 
-                    uwrite!(
-                        self.src,
-                        "
+                        uwrite!(
+                            self.src,
+                            "
                         let {result} = mbt_ffi_ptr2{ty}_array({address}, {length})
                         ",
-                    );
+                        );
 
-                    results.push(result);
+                        results.push(result);
+                    }
                 }
-                _ => unreachable!("unsupported list element type"),
-            },
+            }
 
             Instruction::StringLower { realloc } => {
                 let op = &operands[0];
@@ -2281,7 +2443,15 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 } else {
                     operands.clone()
                 };
-                let arguments = call_operands.join(", ");
+                let arguments = call_operands
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, operand)| {
+                        (!self.direct_canonical_list_length_params.contains(&i))
+                            .then_some(operand.as_str())
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 // TODO: handle this to support async functions
                 uwriteln!(self.src, "{assignment} wasmImport{func_name}({arguments});");
                 self.commit_sync_import_arguments(sig, &call_operands);
@@ -2894,11 +3064,8 @@ impl Bindgen for FunctionBindgen<'_, '_> {
         &self.interface_gen.world_gen.sizes
     }
 
-    fn is_list_canonical(&self, _resolve: &Resolve, element: &Type) -> bool {
-        matches!(
-            element,
-            Type::U8 | Type::U32 | Type::U64 | Type::S32 | Type::S64 | Type::F32 | Type::F64
-        )
+    fn is_list_canonical(&self, resolve: &Resolve, element: &Type) -> bool {
+        canonical_list_element(resolve, element).is_some()
     }
 }
 
@@ -3513,6 +3680,107 @@ mod tests {
         assert!(sink.contains("FixedArray::from_array(data[:length])"));
         assert!(sink.contains("data[:length].to_fixedarray()"));
         assert!(!sink.contains("FixedArray::makei"));
+    }
+
+    #[test]
+    fn sixteen_bit_integers_use_width_preserving_moonbit_types() {
+        let files = generate(
+            r#"
+            package a:b;
+
+            interface api {
+                roundtrip: func(unsigned: u16, signed: s16) -> tuple<u16, s16>;
+            }
+
+            world client { import api; }
+            "#,
+            "client",
+        );
+        let top = file(&files, "interface/a/b/api/top.mbt");
+
+        assert!(
+            top.contains("pub fn roundtrip(unsigned : UInt16, signed : Int16) -> (UInt16, Int16)"),
+            "u16 and s16 must preserve their public element widths: {top}"
+        );
+    }
+
+    #[test]
+    fn imported_canonical_lists_borrow_backing_storage_until_the_call_returns() {
+        let files = generate(
+            r#"
+            package a:b;
+
+            interface api {
+                type unsigned-short = u16;
+                type signed-short = s16;
+                record envelope {
+                    words: list<u32>,
+                }
+                send: func(
+                    bytes: list<u8>,
+                    unsigned-shorts: list<unsigned-short>,
+                    signed-shorts: list<signed-short>,
+                    words: list<u32>,
+                    envelope: envelope,
+                    booleans: list<bool>,
+                );
+            }
+
+            world client { import api; }
+            "#,
+            "client",
+        );
+        let top = file(&files, "interface/a/b/api/top.mbt");
+        let ffi = file(&files, "interface/a/b/api/ffi.mbt");
+
+        assert!(
+            top.contains(
+                "wasmImportSend(bytes, unsigned_shorts, signed_shorts, words, (envelope).words,"
+            ),
+            "direct canonical lists must let the FFI supply their lengths: {top}"
+        );
+        assert!(
+            !top.contains("mbt_ffi_borrowed_array2ptr(bytes)")
+                && !top.contains("mbt_ffi_borrowed_array2ptr(unsigned_shorts)")
+                && !top.contains("mbt_ffi_borrowed_array2ptr(signed_shorts)")
+                && !top.contains("mbt_ffi_borrowed_array2ptr(words)"),
+            "direct list parameters must not round-trip through Int: {top}"
+        );
+        assert!(
+            !top.contains("bytes.length()")
+                && !top.contains("unsigned_shorts.length()")
+                && !top.contains("signed_shorts.length()")
+                && !top.contains("words.length()")
+                && !top.contains("(envelope).words.length()"),
+            "direct canonical list lengths must be supplied by FFI defaults: {top}"
+        );
+        assert!(!top.contains("mbt_ffi_borrowed_array2ptr"), "{top}");
+        assert!(
+            ffi.contains(
+                "#unsafe_skip_stub_check\n#borrow(p0, p2, p4, p6, p8)\nfn wasmImportSend(\
+                 p0 : FixedArray[Byte], p1? : Int = p0.length(), \
+                 p2 : FixedArray[UInt16], p3? : Int = p2.length(), \
+                 p4 : FixedArray[Int16], p5? : Int = p4.length(), \
+                 p6 : FixedArray[UInt], p7? : Int = p6.length(), \
+                 p8 : FixedArray[UInt], p9? : Int = p8.length(),"
+            ),
+            "the imported FFI must derive borrowed array lengths by default: {ffi}"
+        );
+        assert!(
+            !ffi.contains("mbt_ffi_borrowed_array2ptr"),
+            "direct list parameters must not need an array-to-pointer helper: {ffi}"
+        );
+        assert!(!ffi.contains("mbt_ffi_borrowed_bytes2ptr"), "{ffi}");
+        assert!(!ffi.contains("mbt_ffi_borrowed_uint_array2ptr"), "{ffi}");
+        assert!(
+            !top.contains("mbt_ffi_free(ptr)\n"),
+            "borrowed canonical backing storage must not be freed after the call: {top}"
+        );
+        assert!(
+            top.contains("mbt_ffi_malloc((booleans).length() * 1)")
+                && top.contains("for index = 0; index < (booleans).length();"),
+            "non-canonical lists must retain generic lowering: {top}"
+        );
     }
 
     #[test]

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -31,6 +31,7 @@ mod pkg;
 
 #[derive(Clone, Copy)]
 pub(crate) enum CanonicalListElement {
+    Bool,
     U8,
     U16,
     U32,
@@ -45,6 +46,7 @@ pub(crate) enum CanonicalListElement {
 impl CanonicalListElement {
     pub(crate) fn fixed_array_type(self) -> &'static str {
         match self {
+            Self::Bool => "FixedArray[Bool]",
             Self::U8 => "FixedArray[Byte]",
             Self::U16 => "FixedArray[UInt16]",
             Self::U32 => "FixedArray[UInt]",
@@ -64,6 +66,7 @@ pub(crate) fn canonical_list_element(resolve: &Resolve, ty: &Type) -> Option<Can
             TypeDefKind::Type(ty) => canonical_list_element(resolve, ty),
             _ => None,
         },
+        Type::Bool => Some(CanonicalListElement::Bool),
         Type::U8 => Some(CanonicalListElement::U8),
         Type::U16 => Some(CanonicalListElement::U16),
         Type::U32 => Some(CanonicalListElement::U32),
@@ -138,7 +141,7 @@ fn collect_direct_canonical_lists(
 // Assumptions:
 // - Data: u8 -> Byte, s8 | s32 -> Int, s16 -> Int16, u16 -> UInt16, u32 -> UInt, s64 -> Int64, u64 -> UInt64, f32 -> Float, f64 -> Double, address -> Int
 // - Encoding: UTF16
-// - Lift/Lower list<T>: canonically represented numeric elements -> FixedArray[T], otherwise Array[T]
+// - Lift/Lower list<T>: representation-compatible elements -> FixedArray[T], otherwise Array[T]
 // Organization:
 // - one package per interface (export and import are treated as different interfaces)
 // - ffi utils are under `./ffi`, and the project entrance (package as link target) is under `./gen`
@@ -2194,6 +2197,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                         }
                         let ptr = self.locals.tmp("ptr");
                         let (owned_ffi, ty) = match element {
+                            CanonicalListElement::Bool => (ffi::BOOL_ARRAY2PTR, "bool"),
                             CanonicalListElement::U16 => (ffi::UINT16_ARRAY2PTR, "uint16"),
                             CanonicalListElement::U32 => (ffi::UINT_ARRAY2PTR, "uint"),
                             CanonicalListElement::U64 => (ffi::UINT64_ARRAY2PTR, "uint64"),
@@ -2240,6 +2244,10 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     }
                     element => {
                         let ty = match element {
+                            CanonicalListElement::Bool => {
+                                self.use_ffi(ffi::PTR2BOOL_ARRAY);
+                                "bool"
+                            }
                             CanonicalListElement::U16 => {
                                 self.use_ffi(ffi::PTR2UINT16_ARRAY);
                                 "uint16"
@@ -3735,7 +3743,7 @@ mod tests {
 
         assert!(
             top.contains(
-                "wasmImportSend(bytes, unsigned_shorts, signed_shorts, words, (envelope).words,"
+                "wasmImportSend(bytes, unsigned_shorts, signed_shorts, words, (envelope).words, booleans"
             ),
             "direct canonical lists must let the FFI supply their lengths: {top}"
         );
@@ -3751,18 +3759,20 @@ mod tests {
                 && !top.contains("unsigned_shorts.length()")
                 && !top.contains("signed_shorts.length()")
                 && !top.contains("words.length()")
-                && !top.contains("(envelope).words.length()"),
+                && !top.contains("(envelope).words.length()")
+                && !top.contains("booleans.length()"),
             "direct canonical list lengths must be supplied by FFI defaults: {top}"
         );
         assert!(!top.contains("mbt_ffi_borrowed_array2ptr"), "{top}");
         assert!(
             ffi.contains(
-                "#unsafe_skip_stub_check\n#borrow(p0, p2, p4, p6, p8)\nfn wasmImportSend(\
+                "#unsafe_skip_stub_check\n#borrow(p0, p2, p4, p6, p8, p10)\nfn wasmImportSend(\
                  p0 : FixedArray[Byte], p1? : Int = p0.length(), \
                  p2 : FixedArray[UInt16], p3? : Int = p2.length(), \
                  p4 : FixedArray[Int16], p5? : Int = p4.length(), \
                  p6 : FixedArray[UInt], p7? : Int = p6.length(), \
-                 p8 : FixedArray[UInt], p9? : Int = p8.length(),"
+                 p8 : FixedArray[UInt], p9? : Int = p8.length(), \
+                 p10 : FixedArray[Bool], p11? : Int = p10.length())"
             ),
             "the imported FFI must derive borrowed array lengths by default: {ffi}"
         );
@@ -3777,9 +3787,38 @@ mod tests {
             "borrowed canonical backing storage must not be freed after the call: {top}"
         );
         assert!(
-            top.contains("mbt_ffi_malloc((booleans).length() * 1)")
-                && top.contains("for index = 0; index < (booleans).length();"),
+            !top.contains("mbt_ffi_malloc((booleans).length() * 1)")
+                && !top.contains("for index = 0; index < (booleans).length();"),
+            "boolean arrays have canonical byte storage and must be borrowed directly: {top}"
+        );
+    }
+
+    #[test]
+    fn imported_noncanonical_lists_retain_generic_lowering() {
+        let files = generate(
+            r#"
+            package a:b;
+
+            interface api {
+                send: func(strings: list<string>);
+            }
+
+            world client { import api; }
+            "#,
+            "client",
+        );
+        let top = file(&files, "interface/a/b/api/top.mbt");
+        let ffi = file(&files, "interface/a/b/api/ffi.mbt");
+
+        assert!(
+            top.contains("pub fn send(strings : Array[String]) -> Unit")
+                && top.contains("mbt_ffi_malloc((strings).length() * 8)")
+                && top.contains("for index = 0; index < (strings).length();"),
             "non-canonical lists must retain generic lowering: {top}"
+        );
+        assert!(
+            ffi.contains("fn wasmImportSend(p0 : Int, p1 : Int)") && !ffi.contains("#borrow"),
+            "non-canonical list parameters must retain the raw canonical ABI: {ffi}"
         );
     }
 

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -49,64 +49,6 @@ pub(crate) fn is_list_canonical(resolve: &Resolve, element: &Type) -> bool {
     }
 }
 
-fn collect_direct_canonical_lists(
-    resolve: &Resolve,
-    ty: &Type,
-    expression: String,
-    wasm_param: usize,
-    expressions: &mut HashSet<String>,
-    wasm_params: &mut BTreeMap<usize, Type>,
-) {
-    let Type::Id(id) = ty else {
-        return;
-    };
-    match &resolve.types[*id].kind {
-        TypeDefKind::Type(ty) => collect_direct_canonical_lists(
-            resolve,
-            ty,
-            expression,
-            wasm_param,
-            expressions,
-            wasm_params,
-        ),
-        TypeDefKind::List(element) => {
-            if is_list_canonical(resolve, element) {
-                expressions.insert(expression);
-                wasm_params.insert(wasm_param, *element);
-            }
-        }
-        TypeDefKind::Record(record) => {
-            let mut field_wasm_param = wasm_param;
-            for field in &record.fields {
-                collect_direct_canonical_lists(
-                    resolve,
-                    &field.ty,
-                    format!("({expression}).{}", field.name.to_moonbit_ident()),
-                    field_wasm_param,
-                    expressions,
-                    wasm_params,
-                );
-                field_wasm_param += abi::flat_types(resolve, &field.ty, None).unwrap().len();
-            }
-        }
-        TypeDefKind::Tuple(tuple) => {
-            let mut field_wasm_param = wasm_param;
-            for (index, field) in tuple.types.iter().enumerate() {
-                collect_direct_canonical_lists(
-                    resolve,
-                    field,
-                    format!("({expression}).{index}"),
-                    field_wasm_param,
-                    expressions,
-                    wasm_params,
-                );
-                field_wasm_param += abi::flat_types(resolve, field, None).unwrap().len();
-            }
-        }
-        _ => {}
-    }
-}
-
 // Assumptions:
 // - Data: u8 -> Byte, s8 | s32 -> Int, s16 -> Int16, u16 -> UInt16, u32 -> UInt, s64 -> Int64, u64 -> UInt64, f32 -> Float, f64 -> Double, address -> Int
 // - Encoding: UTF16
@@ -685,25 +627,16 @@ impl InterfaceGenerator<'_> {
         let endpoint_plan = self.import_async_function_plan(self.interface, func);
         let wasm_sig = self.resolve.wasm_signature(variant, func);
         let mbt_sig = self.world_gen.pkg_resolver.mbt_sig(self.name, func, false);
-        let mut direct_canonical_lists = HashSet::new();
-        let mut direct_canonical_wasm_params = BTreeMap::new();
-        if !async_plan.is_async() && !wasm_sig.indirect_params {
-            let mut wasm_param = 0;
-            for Param { name, ty, .. } in &func.params {
-                collect_direct_canonical_lists(
-                    self.resolve,
-                    ty,
-                    name.to_moonbit_ident(),
-                    wasm_param,
-                    &mut direct_canonical_lists,
-                    &mut direct_canonical_wasm_params,
-                );
-                wasm_param += abi::flat_types(self.resolve, ty, None).unwrap().len();
-            }
-        }
-        let (src, needs_cleanup_list, endpoint_state) = if async_plan.is_async() {
+        let (src, needs_cleanup_list, endpoint_state, direct_canonical_wasm_params) = if async_plan
+            .is_async()
+        {
             let body = self.generate_async_import_body(&endpoint_plan, func, &mbt_sig, &wasm_sig);
-            (body.src, body.needs_cleanup_list, body.state)
+            (
+                body.src,
+                body.needs_cleanup_list,
+                body.state,
+                BTreeMap::new(),
+            )
         } else {
             let mut bindgen = FunctionBindgen::new(
                 self,
@@ -712,13 +645,7 @@ impl InterfaceGenerator<'_> {
                     .map(|Param { name, .. }| name.to_moonbit_ident())
                     .collect(),
             )
-            .with_direct_canonical_list_params(
-                direct_canonical_lists,
-                direct_canonical_wasm_params
-                    .keys()
-                    .map(|param| param + 1)
-                    .collect(),
-            )
+            .with_direct_list_borrows(!wasm_sig.indirect_params)
             .with_async_state(endpoint_plan.state());
             if endpoint_plan.has_endpoints() {
                 bindgen = bindgen.with_sync_import_commit(
@@ -734,7 +661,12 @@ impl InterfaceGenerator<'_> {
                 &mut bindgen,
                 false,
             );
-            (bindgen.src, bindgen.needs_cleanup_list, bindgen.async_state)
+            (
+                bindgen.src,
+                bindgen.needs_cleanup_list,
+                bindgen.async_state,
+                bindgen.direct_canonical_wasm_params,
+            )
         };
 
         let cleanup_list = if needs_cleanup_list {
@@ -763,8 +695,6 @@ impl InterfaceGenerator<'_> {
                 if let Some(element) = direct_canonical_wasm_params.get(&i) {
                     let element = self.world_gen.pkg_resolver.type_name(self.name, element);
                     format!("p{i} : FixedArray[{element}]")
-                } else if i > 0 && direct_canonical_wasm_params.contains_key(&(i - 1)) {
-                    format!("p{i}? : Int = p{}.length()", i - 1)
                 } else {
                     format!("p{i} : {}", wasm_type(*param))
                 }
@@ -1537,8 +1467,9 @@ struct FunctionBindgen<'a, 'b> {
     sync_endpoint_drop: bool,
     commit_endpoints: bool,
     sync_import_argument_types: Option<Vec<Type>>,
-    direct_canonical_list_params: HashSet<String>,
-    direct_canonical_list_length_params: HashSet<usize>,
+    direct_list_borrows: bool,
+    direct_list_borrow_candidates: HashMap<String, (String, Type)>,
+    direct_canonical_wasm_params: BTreeMap<usize, Type>,
     async_state: AsyncFunctionState,
 }
 
@@ -1569,19 +1500,15 @@ impl<'a, 'b> FunctionBindgen<'a, 'b> {
             sync_endpoint_drop: false,
             commit_endpoints: false,
             sync_import_argument_types: None,
-            direct_canonical_list_params: HashSet::new(),
-            direct_canonical_list_length_params: HashSet::new(),
+            direct_list_borrows: false,
+            direct_list_borrow_candidates: HashMap::new(),
+            direct_canonical_wasm_params: BTreeMap::new(),
             async_state: AsyncFunctionState::default(),
         }
     }
 
-    fn with_direct_canonical_list_params(
-        mut self,
-        params: HashSet<String>,
-        length_params: HashSet<usize>,
-    ) -> Self {
-        self.direct_canonical_list_params = params;
-        self.direct_canonical_list_length_params = length_params;
+    fn with_direct_list_borrows(mut self, enabled: bool) -> Self {
+        self.direct_list_borrows = enabled;
         self
     }
 
@@ -2135,22 +2062,29 @@ impl Bindgen for FunctionBindgen<'_, '_> {
             )),
 
             Instruction::ListCanonLower { element, realloc } => {
-                let element: &Type = element;
-                let element = match element {
+                let original_element: &Type = element;
+                let element = match original_element {
                     Type::Id(id) => match &resolve.types[dealias(resolve, *id)].kind {
                         TypeDefKind::Type(element) => element,
                         _ => unreachable!("unsupported list element type"),
                     },
-                    _ => element,
+                    _ => original_element,
                 };
+                let op = &operands[0];
+                // A canonical list can be passed as a typed borrow only when its
+                // pointer and length flow directly to the Wasm call. Lists lowered
+                // inside blocks are merged into variants or written into enclosing
+                // list storage, so those still need their integer pointer.
+                if self.direct_list_borrows && realloc.is_none() && self.block_storage.is_empty() {
+                    let length = format!("{op}.length()");
+                    self.direct_list_borrow_candidates
+                        .insert(op.clone(), (length.clone(), *original_element));
+                    results.push(op.clone());
+                    results.push(length);
+                    return;
+                }
                 match element {
                     Type::U8 => {
-                        let op = &operands[0];
-                        if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
-                            results.push(op.clone());
-                            results.push(format!("{op}.length()"));
-                            return;
-                        }
                         let ptr = self.locals.tmp("ptr");
                         self.use_ffi(ffi::BYTES2PTR);
                         uwriteln!(
@@ -2174,12 +2108,6 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                     | Type::S64
                     | Type::F32
                     | Type::F64 => {
-                        let op = &operands[0];
-                        if realloc.is_none() && self.direct_canonical_list_params.contains(op) {
-                            results.push(op.clone());
-                            results.push(format!("{op}.length()"));
-                            return;
-                        }
                         let ptr = self.locals.tmp("ptr");
                         let (owned_ffi, ty) = match element {
                             Type::Bool => (ffi::BOOL_ARRAY2PTR, "bool"),
@@ -2441,6 +2369,13 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 };
 
                 let func_name = name.to_upper_camel_case();
+                for (index, operand) in operands.iter().enumerate() {
+                    if let Some((length, element)) = self.direct_list_borrow_candidates.get(operand)
+                    {
+                        assert_eq!(operands.get(index + 1), Some(length));
+                        self.direct_canonical_wasm_params.insert(index, *element);
+                    }
+                }
                 let call_operands = if self.sync_import_argument_types.is_some() {
                     operands
                         .iter()
@@ -2453,15 +2388,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 } else {
                     operands.clone()
                 };
-                let arguments = call_operands
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, operand)| {
-                        (!self.direct_canonical_list_length_params.contains(&i))
-                            .then_some(operand.as_str())
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let arguments = call_operands.join(", ");
                 // TODO: handle this to support async functions
                 uwriteln!(self.src, "{assignment} wasmImport{func_name}({arguments});");
                 self.commit_sync_import_arguments(sig, &call_operands);
@@ -3745,9 +3672,11 @@ mod tests {
 
         assert!(
             top.contains(
-                "wasmImportSend(bytes, unsigned_shorts, signed_shorts, words, (envelope).words, booleans"
+                "wasmImportSend(bytes, bytes.length(), unsigned_shorts, unsigned_shorts.length(), \
+                 signed_shorts, signed_shorts.length(), words, words.length(), \
+                 (envelope).words, (envelope).words.length(), booleans, booleans.length())"
             ),
-            "direct canonical lists must let the FFI supply their lengths: {top}"
+            "direct canonical lists must retain their canonical pointer/length operands: {top}"
         );
         assert!(
             !top.contains("mbt_ffi_borrowed_array2ptr(bytes)")
@@ -3756,27 +3685,18 @@ mod tests {
                 && !top.contains("mbt_ffi_borrowed_array2ptr(words)"),
             "direct list parameters must not round-trip through Int: {top}"
         );
-        assert!(
-            !top.contains("bytes.length()")
-                && !top.contains("unsigned_shorts.length()")
-                && !top.contains("signed_shorts.length()")
-                && !top.contains("words.length()")
-                && !top.contains("(envelope).words.length()")
-                && !top.contains("booleans.length()"),
-            "direct canonical list lengths must be supplied by FFI defaults: {top}"
-        );
         assert!(!top.contains("mbt_ffi_borrowed_array2ptr"), "{top}");
         assert!(
             ffi.contains(
                 "#unsafe_skip_stub_check\n#borrow(p0, p2, p4, p6, p8, p10)\nfn wasmImportSend(\
-                 p0 : FixedArray[Byte], p1? : Int = p0.length(), \
-                 p2 : FixedArray[UInt16], p3? : Int = p2.length(), \
-                 p4 : FixedArray[Int16], p5? : Int = p4.length(), \
-                 p6 : FixedArray[UInt], p7? : Int = p6.length(), \
-                 p8 : FixedArray[UInt], p9? : Int = p8.length(), \
-                 p10 : FixedArray[Bool], p11? : Int = p10.length())"
+                 p0 : FixedArray[Byte], p1 : Int, \
+                 p2 : FixedArray[UInt16], p3 : Int, \
+                 p4 : FixedArray[Int16], p5 : Int, \
+                 p6 : FixedArray[UInt], p7 : Int, \
+                 p8 : FixedArray[UInt], p9 : Int, \
+                 p10 : FixedArray[Bool], p11 : Int)"
             ),
-            "the imported FFI must derive borrowed array lengths by default: {ffi}"
+            "the imported FFI must borrow arrays while retaining explicit lengths: {ffi}"
         );
         assert!(
             !ffi.contains("mbt_ffi_borrowed_array2ptr"),
@@ -3821,6 +3741,74 @@ mod tests {
         assert!(
             ffi.contains("fn wasmImportSend(p0 : Int, p1 : Int)") && !ffi.contains("#borrow"),
             "non-canonical list parameters must retain the raw canonical ABI: {ffi}"
+        );
+    }
+
+    #[test]
+    fn imported_conditional_canonical_lists_retain_pointer_lowering() {
+        let files = generate(
+            r#"
+            package a:b;
+
+            interface api {
+                variant optional-bytes {
+                    none,
+                    some(list<u8>),
+                }
+                send: func(bytes: optional-bytes);
+            }
+
+            world client { import api; }
+            "#,
+            "client",
+        );
+        let top = file(&files, "interface/a/b/api/top.mbt");
+        let ffi = file(&files, "interface/a/b/api/ffi.mbt");
+
+        assert!(
+            top.contains("mbt_ffi_bytes2ptr"),
+            "conditional list pointers must be lowered before merging variant cases: {top}"
+        );
+        assert!(
+            !ffi.contains("#borrow"),
+            "a conditionally occupied pointer parameter cannot be a typed borrow: {ffi}"
+        );
+    }
+
+    #[test]
+    fn imported_indirect_canonical_lists_retain_pointer_lowering() {
+        let files = generate(
+            r#"
+            package a:b;
+
+            interface api {
+                send: func(
+                    a: list<u8>,
+                    b: list<u8>,
+                    c: list<u8>,
+                    d: list<u8>,
+                    e: list<u8>,
+                    f: list<u8>,
+                    g: list<u8>,
+                    h: list<u8>,
+                    i: list<u8>,
+                );
+            }
+
+            world client { import api; }
+            "#,
+            "client",
+        );
+        let top = file(&files, "interface/a/b/api/top.mbt");
+        let ffi = file(&files, "interface/a/b/api/ffi.mbt");
+
+        assert!(
+            top.contains("mbt_ffi_bytes2ptr(a)"),
+            "lists stored in an indirect argument area still need integer pointers: {top}"
+        );
+        assert!(
+            ffi.contains("fn wasmImportSend(p0 : Int)") && !ffi.contains("#borrow"),
+            "an indirect import receives only its argument-area pointer: {ffi}"
         );
     }
 

--- a/crates/moonbit/src/pkg.rs
+++ b/crates/moonbit/src/pkg.rs
@@ -192,7 +192,28 @@ impl PkgResolver {
                 match ty.kind {
                     TypeDefKind::Type(ty) => self.type_name(this, &ty),
                     TypeDefKind::List(ty) => {
-                        if crate::is_list_canonical(&self.resolve, &ty) {
+                        let element = match &ty {
+                            Type::Id(id) => {
+                                match &self.resolve.types[dealias(&self.resolve, *id)].kind {
+                                    TypeDefKind::Type(element) => element,
+                                    _ => &ty,
+                                }
+                            }
+                            element => element,
+                        };
+                        if matches!(
+                            element,
+                            Type::Bool
+                                | Type::U8
+                                | Type::U16
+                                | Type::U32
+                                | Type::U64
+                                | Type::S16
+                                | Type::S32
+                                | Type::S64
+                                | Type::F32
+                                | Type::F64
+                        ) {
                             format!("FixedArray[{}]", self.type_name(this, &ty))
                         } else {
                             format!("Array[{}]", self.type_name(this, &ty))

--- a/crates/moonbit/src/pkg.rs
+++ b/crates/moonbit/src/pkg.rs
@@ -192,8 +192,8 @@ impl PkgResolver {
                 match ty.kind {
                     TypeDefKind::Type(ty) => self.type_name(this, &ty),
                     TypeDefKind::List(ty) => {
-                        if let Some(element) = crate::canonical_list_element(&self.resolve, &ty) {
-                            element.fixed_array_type().to_string()
+                        if crate::is_list_canonical(&self.resolve, &ty) {
+                            format!("FixedArray[{}]", self.type_name(this, &ty))
                         } else {
                             format!("Array[{}]", self.type_name(this, &ty))
                         }

--- a/crates/moonbit/src/pkg.rs
+++ b/crates/moonbit/src/pkg.rs
@@ -176,8 +176,10 @@ impl PkgResolver {
         match ty {
             Type::Bool => "Bool".into(),
             Type::U8 => "Byte".into(),
-            Type::S32 | Type::S8 | Type::S16 => "Int".into(),
-            Type::U16 | Type::U32 => "UInt".into(),
+            Type::S8 | Type::S32 => "Int".into(),
+            Type::S16 => "Int16".into(),
+            Type::U16 => "UInt16".into(),
+            Type::U32 => "UInt".into(),
             Type::Char => "Char".into(),
             Type::U64 => "UInt64".into(),
             Type::S64 => "Int64".into(),
@@ -189,18 +191,13 @@ impl PkgResolver {
                 let ty = self.resolve.types[dealias(&self.resolve, *id)].clone();
                 match ty.kind {
                     TypeDefKind::Type(ty) => self.type_name(this, &ty),
-                    TypeDefKind::List(ty) => match ty {
-                        Type::U8
-                        | Type::U32
-                        | Type::U64
-                        | Type::S32
-                        | Type::S64
-                        | Type::F32
-                        | Type::F64 => {
-                            format!("FixedArray[{}]", self.type_name(this, &ty))
+                    TypeDefKind::List(ty) => {
+                        if let Some(element) = crate::canonical_list_element(&self.resolve, &ty) {
+                            element.fixed_array_type().to_string()
+                        } else {
+                            format!("Array[{}]", self.type_name(this, &ty))
                         }
-                        _ => format!("Array[{}]", self.type_name(this, &ty)),
-                    },
+                    }
                     TypeDefKind::FixedLengthList(ty, _size) => {
                         format!("FixedArray[{}]", self.type_name(this, &ty))
                     }

--- a/tests/runtime/flavorful/test.mbt
+++ b/tests/runtime/flavorful/test.mbt
@@ -127,10 +127,10 @@ pub fn list_typedefs(
 
 ///|
 pub fn list_of_variants(
-  _a : Array[Bool],
+  _a : FixedArray[Bool],
   _b : Array[Result[Unit, Unit]],
   _c : Array[MyErrno],
-) -> (Array[Bool], Array[Result[Unit, Unit]], Array[MyErrno]) {
+) -> (FixedArray[Bool], Array[Result[Unit, Unit]], Array[MyErrno]) {
   try {
     assert_eq(_a, [true, false])
     assert_eq(_b, [Ok(()), Err(())])

--- a/tests/runtime/list-in-variant/runner.mbt
+++ b/tests/runtime/list-in-variant/runner.mbt
@@ -44,7 +44,7 @@ pub fn run() -> Unit {
     bytes: [5, 6, 7],
     unsigned_shorts: [300, 400],
     signed_shorts: [-30, 40],
-    words: [40, 50],
+    booleans: [false, true, false],
   }
   let r8 = @to-test.canonical_list_params(
     bytes,

--- a/tests/runtime/list-in-variant/runner.mbt
+++ b/tests/runtime/list-in-variant/runner.mbt
@@ -33,4 +33,25 @@ pub fn run() -> Unit {
   // top-level-list (contrast)
   let r7 = @to-test.top_level_list(["x", "y", "z"])
   guard r7 == "x,y,z"
+
+  // Canonical primitive lists borrow their MoonBit backing arrays through the
+  // call, including when nested under another parameter.
+  let bytes : FixedArray[Byte] = [1, 2, 3, 4]
+  let unsigned_shorts : FixedArray[UInt16] = [100, 200]
+  let signed_shorts : FixedArray[Int16] = [-10, 20]
+  let words : FixedArray[UInt] = [10, 20, 30]
+  let nested = @to-test.CanonicalLists::{
+    bytes: [5, 6, 7],
+    unsigned_shorts: [300, 400],
+    signed_shorts: [-30, 40],
+    words: [40, 50],
+  }
+  let r8 = @to-test.canonical_list_params(
+    bytes,
+    unsigned_shorts,
+    signed_shorts,
+    words,
+    nested,
+  )
+  guard r8 == 172U
 }

--- a/tests/runtime/list-in-variant/test.rs
+++ b/tests/runtime/list-in-variant/test.rs
@@ -44,4 +44,22 @@ impl exports::test::list_in_variant::to_test::Guest for Component {
     fn top_level_list(items: Vec<String>) -> String {
         items.join(",")
     }
+
+    fn canonical_list_params(
+        bytes: Vec<u8>,
+        unsigned_shorts: Vec<u16>,
+        signed_shorts: Vec<i16>,
+        words: Vec<u32>,
+        nested: CanonicalLists,
+    ) -> u32 {
+        assert_eq!(bytes, [1, 2, 3, 4]);
+        assert_eq!(unsigned_shorts, [100, 200]);
+        assert_eq!(signed_shorts, [-10, 20]);
+        assert_eq!(words, [10, 20, 30]);
+        assert_eq!(nested.bytes, [5, 6, 7]);
+        assert_eq!(nested.unsigned_shorts, [300, 400]);
+        assert_eq!(nested.signed_shorts, [-30, 40]);
+        assert_eq!(nested.words, [40, 50]);
+        172
+    }
 }

--- a/tests/runtime/list-in-variant/test.rs
+++ b/tests/runtime/list-in-variant/test.rs
@@ -59,7 +59,7 @@ impl exports::test::list_in_variant::to_test::Guest for Component {
         assert_eq!(nested.bytes, [5, 6, 7]);
         assert_eq!(nested.unsigned_shorts, [300, 400]);
         assert_eq!(nested.signed_shorts, [-30, 40]);
-        assert_eq!(nested.words, [40, 50]);
+        assert_eq!(nested.booleans, [false, true, false]);
         172
     }
 }

--- a/tests/runtime/list-in-variant/test.wit
+++ b/tests/runtime/list-in-variant/test.wit
@@ -23,7 +23,7 @@ interface to-test {
     bytes: list<u8>,
     unsigned-shorts: list<u16>,
     signed-shorts: list<s16>,
-    words: list<u32>,
+    booleans: list<bool>,
   }
   canonical-list-params: func(
     bytes: list<u8>,

--- a/tests/runtime/list-in-variant/test.wit
+++ b/tests/runtime/list-in-variant/test.wit
@@ -18,6 +18,20 @@ interface to-test {
   list-in-option-with-return: func(data: option<list<string>>) -> summary;
 
   top-level-list: func(items: list<string>) -> string;
+
+  record canonical-lists {
+    bytes: list<u8>,
+    unsigned-shorts: list<u16>,
+    signed-shorts: list<s16>,
+    words: list<u32>,
+  }
+  canonical-list-params: func(
+    bytes: list<u8>,
+    unsigned-shorts: list<u16>,
+    signed-shorts: list<s16>,
+    words: list<u32>,
+    nested: canonical-lists,
+  ) -> u32;
 }
 
 world test {

--- a/tests/runtime/lists/test.mbt
+++ b/tests/runtime/lists/test.mbt
@@ -84,9 +84,9 @@ pub fn list_minmax8(
 
 ///|
 pub fn list_minmax16(
-  a : Array[UInt],
-  b : Array[Int]
-) -> (Array[UInt], Array[Int]) {
+  a : FixedArray[UInt16],
+  b : FixedArray[Int16]
+) -> (FixedArray[UInt16], FixedArray[Int16]) {
   (a, b)
 }
 

--- a/tests/runtime/moonbit/http-background-hook/runner.mbt
+++ b/tests/runtime/moonbit/http-background-hook/runner.mbt
@@ -26,7 +26,7 @@ async fn run_hook(payload : Bytes, expected_error : String?) -> Unit {
     Ok(response) => response
     Err(_) => panic()
   }
-  guard response.get_status_code() == 202U else { panic() }
+  guard response.get_status_code() == 202 else { panic() }
 
   let (response_body, response_trailers) = response.consume_body(
     @async-core.Future::ready(Ok(())),

--- a/tests/runtime/moonbit/http-background-hook/test.mbt
+++ b/tests/runtime/moonbit/http-background-hook/test.mbt
@@ -56,7 +56,7 @@ pub async fn handle(
     Some(response_body),
     response_trailers,
   )
-  guard response.set_status_code(202U) is Ok(_) else {
+  guard response.set_status_code(202) is Ok(_) else {
     let error = @types.ErrorCode::InternalError(
       Some("failed to set hook response status"),
     )

--- a/tests/runtime/numbers/test.mbt
+++ b/tests/runtime/numbers/test.mbt
@@ -12,12 +12,12 @@ pub fn roundtrip_s8(a : Int) -> Int {
 }
 
 ///|
-pub fn roundtrip_u16(a : UInt) -> UInt {
+pub fn roundtrip_u16(a : UInt16) -> UInt16 {
   a
 }
 
 ///|
-pub fn roundtrip_s16(a : Int) -> Int {
+pub fn roundtrip_s16(a : Int16) -> Int16 {
   a
 }
 


### PR DESCRIPTION
## Why

MoonBit currently converts primitive list arguments to integer pointers and manages their cleanup manually when calling imported functions. MoonBit's typed FFI borrows can express that call-scoped lifetime directly, avoiding manual cleanup and reducing the risk of lifetime errors.

MoonBit also has representation-compatible array types for Canonical ABI `u16`, `s16`, and `bool` list elements, but the bindings do not currently treat those as primitive canonical lists.

## What changed

- Pass compatible primitive list arguments to synchronous flat imports as typed `FixedArray[T]` parameters using `#borrow`, while retaining the Canonical ABI's explicit length parameters.
- Treat `u16`, `s16`, and `bool` as primitive canonical list elements, represented as `FixedArray[UInt16]`, `FixedArray[Int16]`, and `FixedArray[Bool]`.

## Why this is correct

The borrowed FFI parameters keep their backing arrays alive for the duration of the imported call. Lists that cannot be passed as direct typed borrows continue to use the existing pointer lowering and cleanup path.

The added primitive list representations match their Canonical ABI element width and layout. Other element types, return allocation ownership, and stream/future behavior are unchanged.

## Scope

This PR is limited to typed borrows for compatible outgoing list arguments and primitive-list support for `u16`, `s16`, and `bool`. Stream bulk-copy optimization remains separate.
