### PR TITLE
Fix Markdown docs with source-like syntax

### DIFF
--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -49,6 +49,16 @@ impl Source {
     }
 
     pub fn push_str(&mut self, src: &str) {
+        self.push_str_impl(src, true);
+    }
+
+    /// Appends literal text with the current indentation without interpreting
+    /// braces or line comments as source syntax.
+    pub fn push_str_literal(&mut self, src: &str) {
+        self.push_str_impl(src, false);
+    }
+
+    fn push_str_impl(&mut self, src: &str, interpret_syntax: bool) {
         let lines = src.lines().collect::<Vec<_>>();
         for (i, line) in lines.iter().enumerate() {
             if !self.continuing_line {
@@ -61,11 +71,11 @@ impl Source {
             }
 
             let trimmed = line.trim();
-            if trimmed.starts_with("//") {
+            if interpret_syntax && trimmed.starts_with("//") {
                 self.in_line_comment = true;
             }
 
-            if !self.in_line_comment {
+            if interpret_syntax && !self.in_line_comment {
                 if trimmed.starts_with('}') && self.s.ends_with("  ") {
                     self.s.pop();
                     self.s.pop();
@@ -76,7 +86,7 @@ impl Source {
             } else {
                 line.trim_start()
             });
-            if !self.in_line_comment {
+            if interpret_syntax && !self.in_line_comment {
                 if trimmed.ends_with('{') {
                     self.indent += 1;
                 }
@@ -218,5 +228,14 @@ mod tests {
         }",
         );
         assert_eq!(s.s, "function() {\n  x\n}");
+    }
+
+    #[test]
+    fn literal_text_does_not_change_indentation() {
+        let mut s = Source::default();
+        s.indent(1);
+        s.push_str_literal("}\n{");
+        s.deindent(1);
+        assert_eq!(s.s, "  }\n  {");
     }
 }

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -444,7 +444,7 @@ impl InterfaceGenerator<'_> {
             None => "\n",
         };
         for line in docs.lines() {
-            self.push_str(line.trim());
+            self.r#gen.src.push_str_literal(line.trim());
             self.push_str("\n");
         }
     }

--- a/crates/markdown/tests/codegen.rs
+++ b/crates/markdown/tests/codegen.rs
@@ -1,0 +1,28 @@
+use wit_bindgen_core::{Files, wit_parser::Resolve};
+
+#[test]
+fn doc_line_starting_with_closing_brace() {
+    const WIT: &str = r#"
+        package a:b;
+
+        world w {
+          export x: interface {
+            record r {
+              /// }
+              f: u32,
+            }
+          }
+        }
+    "#;
+
+    let mut resolve = Resolve::default();
+    let package = resolve.push_str("test.wit", WIT).unwrap();
+    let world = resolve.select_world(&[package], Some("w")).unwrap();
+    let mut files = Files::default();
+    let mut generator = wit_bindgen_markdown::Opts::default().build();
+
+    generator.generate(&mut resolve, world, &mut files).unwrap();
+
+    let markdown = String::from_utf8(files.remove("w.md").unwrap()).unwrap();
+    assert!(markdown.contains("\n  <p>}\n"));
+}


### PR DESCRIPTION
Fixes #1480.

  Markdown doc text was passed through `Source::push_str`, which treats braces as generated-code structure. A doc line beginning with `}` could therefore reduce the tracked indentation before the
  surrounding documentation block was deindented, causing an overflow panic.

  Add a literal append path that preserves indentation without interpreting source syntax, use it for Markdown documentation, and cover the reported input with regression tests.

  ### Tests

  - `cargo test -p wit-bindgen-core -p wit-bindgen-markdown`
  - `cargo clippy -p wit-bindgen-core -p wit-bindgen-markdown --all-targets -- -D warnings`
  - `cargo fmt --all -- --check`
  - CLI generation using the reported WIT input