### PR TITLE
Fix C++ export resource header ordering

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -486,7 +486,8 @@ impl Cpp {
             let _ = std::mem::replace(&mut self.includes, store.includes);
             let _ = std::mem::replace(&mut self.h_src, store.src);
             let _ = std::mem::replace(&mut self.dependencies, store.dependencies);
-            self.includes.push(String::from("\"") + &filename + "\"");
+            self.h_src.change_namespace(&[]);
+            uwriteln!(self.h_src.src, "#include \"{filename}\"");
         }
     }
 }

--- a/tests/codegen/issue1658.wit
+++ b/tests/codegen/issue1658.wit
@@ -1,0 +1,15 @@
+package foo:bar;
+
+interface my-interface {
+  record options {
+    name: string,
+  }
+
+  resource my-resource {
+    constructor(o: options);
+  }
+}
+
+world my-world {
+  export my-interface;
+}


### PR DESCRIPTION
The C++ generator added exported resource class headers to the global include list, which is emitted before generated type definitions. As a result, a resource constructor using a generated record
  could reference that type before it was defined.

  Emit each generated resource header at its position in the topologically sorted header source while keeping the include outside the namespace. Add a code generation regression test for an exported
  resource constructor that takes a record parameter.

  ### Testing

  - Generated C++ source compiles successfully with wasi-sdk 30.
  - `cargo test --locked -p wit-bindgen-cpp`
  - `cargo test --locked --workspace --all-targets --exclude wit-bindgen-moonbit`
  - `cargo clippy --locked --workspace --all-targets -- -D warnings`
  - `cargo fmt --all -- --check`