### PR TITLE
fix(rust): fully qualify Option and Result types

### DIFF
--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -2324,7 +2324,7 @@ unsafe fn call_import(&mut self, _params: Self::ParamsLower, _results: *mut u8) 
             self.rustdoc(docs);
             self.push_str(&format!("pub type {name}"));
             self.print_generics(mode.lifetime);
-            self.push_str("= Option<");
+            self.push_str("= ::core::option::Option<");
             self.print_ty(payload, mode);
             self.push_str(">;\n");
         }
@@ -2335,7 +2335,7 @@ unsafe fn call_import(&mut self, _params: Self::ParamsLower, _results: *mut u8) 
             self.rustdoc(docs);
             self.push_str(&format!("pub type {name}"));
             self.print_generics(mode.lifetime);
-            self.push_str("= Result<");
+            self.push_str("= ::core::result::Result<");
             self.print_optional_ty(result.ok.as_ref(), mode);
             self.push_str(",");
             self.print_optional_ty(result.err.as_ref(), mode);
@@ -3144,14 +3144,14 @@ impl<'a, 'b> wit_bindgen_core::AnonymousTypeGenerator<'a> for AnonTypeGenerator<
     }
 
     fn anonymous_type_option(&mut self, _id: TypeId, t: &Type, _docs: &Docs) {
-        self.interface.push_str("Option<");
+        self.interface.push_str("::core::option::Option<");
         let mode = self.interface.filter_mode_preserve_top(t, self.mode);
         self.interface.print_ty(t, mode);
         self.interface.push_str(">");
     }
 
     fn anonymous_type_result(&mut self, _id: TypeId, r: &Result_, _docs: &Docs) {
-        self.interface.push_str("Result<");
+        self.interface.push_str("::core::result::Result<");
         self.interface.print_optional_ty(r.ok.as_ref(), self.mode);
         self.interface.push_str(",");
         self.interface.print_optional_ty(r.err.as_ref(), self.mode);

--- a/tests/runtime/rust/result-no-clobber/runner.rs
+++ b/tests/runtime/rust/result-no-clobber/runner.rs
@@ -1,0 +1,19 @@
+//@ args = ['--disable-run-ctors-once-workaround']
+
+include!(env!("BINDINGS"));
+
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    fn run() {
+        let faux_result = false;
+        let faux_option = true;
+        match the::test::i::no_clobber(faux_result, faux_option) {
+            Ok(_) => {}
+            Err(None) => {}
+            Err(Some(_)) => {}
+        };
+    }
+}

--- a/tests/runtime/rust/result-no-clobber/test.rs
+++ b/tests/runtime/rust/result-no-clobber/test.rs
@@ -1,0 +1,16 @@
+//@ args = ['--disable-run-ctors-once-workaround']
+
+include!(env!("BINDINGS"));
+
+struct Test;
+
+export!(Test);
+
+impl exports::the::test::i::Guest for Test {
+    fn no_clobber(
+        _faux_result: exports::the::test::i::Result,
+        _faux_option: exports::the::test::i::Option,
+    ) -> Result<(), Option<bool>> {
+        Err(None)
+    }
+}

--- a/tests/runtime/rust/result-no-clobber/test.wit
+++ b/tests/runtime/rust/result-no-clobber/test.wit
@@ -1,0 +1,18 @@
+package the:test;
+
+interface i {
+  type %result = bool;
+  type %option = bool;
+
+  no-clobber: func(faux-result: %result, faux-option: %option) -> result<_, option<bool>>;
+}
+
+world runner {
+  import i;
+
+  export run: func();
+}
+
+world test {
+  export i;
+}


### PR DESCRIPTION
When expanding the wit `option` and `result` types to rust, they were printed as `Option` and `Result` respectively. This can cause collisions with locally defined types that happen to share the same name.

For example:

```
type %result = bool;

// should return a result, but is generated returning the local alias
no-clobber: func() -> result<_, _>;
```

The generated types for `option` and `result` now expand to `::core::option::Option` and `::core::result::Result`.