### PR TITLE
fix(rust): restore `cabi_realloc` for `wasm32-unknown-unknown`

### DIFF
--- a/crates/guest-rust/src/rt/mod.rs
+++ b/crates/guest-rust/src/rt/mod.rs
@@ -111,7 +111,7 @@ impl<K: core::hash::Hash + Eq, V> WitMap<K, V> for std::collections::HashMap<K, 
 }
 
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
-#[cfg(target_env = "p1")]
+#[cfg(any(target_env = "p1", target_env = ""))]
 mod wit_bindgen_cabi_realloc;
 
 /// This function is called from generated bindings and will be deleted by
@@ -122,7 +122,7 @@ mod wit_bindgen_cabi_realloc;
 ///
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
 pub fn maybe_link_cabi_realloc() {
-    #[cfg(target_env = "p1")]
+    #[cfg(any(target_env = "p1", target_env = ""))]
     {
         unsafe extern "C" {
             fn cabi_realloc(
@@ -153,7 +153,7 @@ pub fn maybe_link_cabi_realloc() {
 /// `cabi_realloc` module above. It's otherwise never explicitly called.
 ///
 /// For more information about this see `./ci/rebuild-libwit-bindgen-cabi.sh`.
-#[cfg(target_env = "p1")]
+#[cfg(any(target_env = "p1", target_env = ""))]
 pub unsafe fn cabi_realloc(
     old_ptr: *mut u8,
     old_len: usize,


### PR DESCRIPTION
`cabi_realloc` was switched to only be added for `p1` targets instead of not being added for `p2` targets in #1663. This causes modules built with `wasm32-unknown-unknown` and then enriched into a component with `wasm-tools component new` to fail.