### PR TITLE
Fix tests on Rust nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "log",
  "regex",
  "serde",
+ "serde_json",
  "toml",
  "wac-graph",
  "wac-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ bitflags = "2.11.1"
 heck = { version = "0.5" }
 pulldown-cmark = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1" }
 clap = { version = "4.6.1", features = ["derive"] }
 indexmap = "2.0.0"
 prettyplease = "0.2.20"

--- a/crates/rust/Cargo.toml
+++ b/crates/rust/Cargo.toml
@@ -39,7 +39,7 @@ futures = { workspace = true }
 wit-bindgen = { path = '../guest-rust', features = ['async'] }
 test-helpers = { path = '../test-helpers' }
 # For use with the custom attributes test
-serde_json = "1"
+serde_json = { workspace = true }
 bytes = "1"
 
 [features]

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -25,6 +25,7 @@ heck = { workspace = true }
 log = "0.4.26"
 regex = "1.11.1"
 serde = { workspace = true }
+serde_json = { workspace = true }
 toml = "1.1.2"
 wasi-preview1-component-adapter-provider = "46.0.1"
 wac-parser = "0.10.0"

--- a/crates/test/src/c.rs
+++ b/crates/test/src/c.rs
@@ -187,5 +187,6 @@ fn verify(runner: &Runner, verify: &Verify<'_>, compiler: PathBuf) -> Result<()>
     .arg("-c")
     .arg("-o")
     .arg(verify.artifacts_dir.join("tmp.o"));
-    runner.run_command(&mut cmd)
+    runner.run_command(&mut cmd)?;
+    Ok(())
 }

--- a/crates/test/src/cpp.rs
+++ b/crates/test/src/cpp.rs
@@ -207,6 +207,7 @@ impl LanguageMethods for Cpp {
         .arg("-c")
         .arg("-o")
         .arg(verify.artifacts_dir.join("tmp.o"));
-        runner.run_command(&mut cmd)
+        runner.run_command(&mut cmd)?;
+        Ok(())
     }
 }

--- a/crates/test/src/csharp.rs
+++ b/crates/test/src/csharp.rs
@@ -144,6 +144,7 @@ impl LanguageMethods for Csharp {
             .arg(&wasm_filename);
         runner.run_command(&mut cmd)?;
 
-        runner.run_command(dotnet().current_dir(&dir).arg("clean"))
+        runner.run_command(dotnet().current_dir(&dir).arg("clean"))?;
+        Ok(())
     }
 }

--- a/crates/test/src/custom.rs
+++ b/crates/test/src/custom.rs
@@ -115,7 +115,8 @@ impl LanguageMethods for Language {
                 .arg("bindgen")
                 .env("WIT", &bindgen.wit_path)
                 .env("BINDINGS_DIR", dir),
-        )
+        )?;
+        Ok(())
     }
 
     fn prepare(&self, runner: &mut Runner) -> Result<()> {
@@ -126,7 +127,8 @@ impl LanguageMethods for Language {
             Command::new(&self.script)
                 .arg("prepare")
                 .env("PREP_DIR", &dir),
-        )
+        )?;
+        Ok(())
     }
 
     fn compile(&self, runner: &Runner, compile: &Compile<'_>) -> Result<()> {
@@ -142,7 +144,8 @@ impl LanguageMethods for Language {
                 .env("BINDINGS_DIR", &compile.bindings_dir)
                 .env("ARTIFACTS_DIR", &compile.artifacts_dir)
                 .env("OUTPUT", &compile.output),
-        )
+        )?;
+        Ok(())
     }
 
     fn verify(&self, runner: &Runner, verify: &Verify<'_>) -> Result<()> {
@@ -152,6 +155,7 @@ impl LanguageMethods for Language {
                 .env("WIT", verify.wit_test)
                 .env("BINDINGS_DIR", &verify.bindings_dir)
                 .env("ARTIFACTS_DIR", &verify.artifacts_dir),
-        )
+        )?;
+        Ok(())
     }
 }

--- a/crates/test/src/go.rs
+++ b/crates/test/src/go.rs
@@ -190,7 +190,8 @@ func main() {}
                 .arg(verify.artifacts_dir.join("tmp.wasm"))
                 .arg("-buildmode=c-shared")
                 .arg("-ldflags=-checklinkname=0"),
-        )
+        )?;
+        Ok(())
     }
 }
 

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -1049,7 +1049,7 @@ impl Runner {
 
     /// Helper to execute an external process and generate a helpful error
     /// message on failure.
-    fn run_command(&self, cmd: &mut Command) -> Result<()> {
+    fn run_command(&self, cmd: &mut Command) -> Result<String> {
         if self.opts.inherit_stderr {
             cmd.stderr(Stdio::inherit());
         }
@@ -1057,7 +1057,7 @@ impl Runner {
             .output()
             .with_context(|| format!("failed to spawn {cmd:?}"))?;
         if output.status.success() {
-            return Ok(());
+            return Ok(String::from_utf8_lossy(&output.stdout).into());
         }
 
         let mut error = format!(
@@ -1256,7 +1256,8 @@ trait LanguageMethods {
             cmd.arg(arg);
         }
 
-        runner.run_command(&mut cmd)
+        runner.run_command(&mut cmd)?;
+        Ok(())
     }
 
     /// Returns the default set of arguments that will be passed to

--- a/crates/test/src/rust.rs
+++ b/crates/test/src/rust.rs
@@ -48,17 +48,16 @@ struct RustConfig {
 
 #[derive(Deserialize)]
 #[serde(tag = "reason", rename_all = "kebab-case")]
-enum CargoMessage<'a> {
+enum CargoMessage {
     CompilerArtifact {
-        #[serde(borrow)]
-        target: CargoTarget<'a>,
-        filenames: Vec<&'a str>,
+        target: CargoTarget,
+        filenames: Vec<String>,
     },
 }
 
 #[derive(Deserialize, Debug)]
-struct CargoTarget<'a> {
-    name: &'a str,
+struct CargoTarget {
+    name: String,
 }
 
 impl LanguageMethods for Rust {
@@ -173,14 +172,14 @@ path = 'lib.rs'
             };
             match msg {
                 CargoMessage::CompilerArtifact { target, filenames } => {
-                    let lib = *filenames.iter().find(|f| !f.ends_with(".rmeta")).unwrap();
+                    let lib = filenames.iter().find(|f| !f.ends_with(".rmeta")).unwrap();
                     if target.name == "futures" {
-                        futures_rlib = Some(lib);
+                        futures_rlib = Some(lib.clone());
                     } else if target.name == "wit_bindgen" {
-                        wit_bindgen_rlib = Some(lib);
+                        wit_bindgen_rlib = Some(lib.clone());
                     }
-                    let dir = Path::new(lib).parent().unwrap();
-                    if deps_seen.insert(dir) {
+                    let dir = Path::new(&lib).parent().unwrap();
+                    if deps_seen.insert(dir.to_path_buf()) {
                         wit_bindgen_deps.push(dir.to_path_buf());
                     }
                 }

--- a/crates/test/src/rust.rs
+++ b/crates/test/src/rust.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use heck::ToSnakeCase;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -43,6 +44,21 @@ struct RustConfig {
     /// main crate.
     #[serde(default)]
     externs: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "reason", rename_all = "kebab-case")]
+enum CargoMessage<'a> {
+    CompilerArtifact {
+        #[serde(borrow)]
+        target: CargoTarget<'a>,
+        filenames: Vec<&'a str>,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+struct CargoTarget<'a> {
+    name: &'a str,
 }
 
 impl LanguageMethods for Rust {
@@ -136,30 +152,45 @@ path = 'lib.rs'
         super::write_if_different(&wit_bindgen.join("lib.rs"), "")?;
 
         println!("Building `wit-bindgen` from crates.io...");
-        runner.run_command(
+        let json = runner.run_command(
             Command::new("cargo")
                 .current_dir(&wit_bindgen)
                 .arg("build")
                 .arg("-pwit-bindgen")
                 .arg("-pfutures")
                 .arg("--target")
-                .arg(&opts.rust_target),
+                .arg(&opts.rust_target)
+                .arg("--message-format=json"),
         )?;
+        let mut wit_bindgen_rlib = None;
+        let mut futures_rlib = None;
+        let mut wit_bindgen_deps = Vec::new();
+        let mut deps_seen = HashSet::new();
 
-        let target_out_dir = wit_bindgen
-            .join("target")
-            .join(&opts.rust_target)
-            .join("debug");
-        let host_out_dir = wit_bindgen.join("target/debug");
-        let wit_bindgen_rlib = target_out_dir.join("libwit_bindgen.rlib");
-        let futures_rlib = target_out_dir.join("libfutures.rlib");
-        assert!(wit_bindgen_rlib.exists());
-        assert!(futures_rlib.exists());
+        for line in json.lines() {
+            let Ok(msg) = serde_json::from_str(line) else {
+                continue;
+            };
+            match msg {
+                CargoMessage::CompilerArtifact { target, filenames } => {
+                    let lib = *filenames.iter().find(|f| !f.ends_with(".rmeta")).unwrap();
+                    if target.name == "futures" {
+                        futures_rlib = Some(lib);
+                    } else if target.name == "wit_bindgen" {
+                        wit_bindgen_rlib = Some(lib);
+                    }
+                    let dir = Path::new(lib).parent().unwrap();
+                    if deps_seen.insert(dir) {
+                        wit_bindgen_deps.push(dir.to_path_buf());
+                    }
+                }
+            }
+        }
 
         runner.rust_state = Some(State {
-            wit_bindgen_rlib,
-            futures_rlib,
-            wit_bindgen_deps: vec![target_out_dir.join("deps"), host_out_dir.join("deps")],
+            wit_bindgen_rlib: wit_bindgen_rlib.unwrap().into(),
+            futures_rlib: futures_rlib.unwrap().into(),
+            wit_bindgen_deps,
         });
         Ok(())
     }

--- a/tests/runtime/numbers/runner.rs
+++ b/tests/runtime/numbers/runner.rs
@@ -8,36 +8,36 @@ impl Guest for Component {
     fn run() {
         use test::numbers::numbers::*;
         assert_eq!(roundtrip_u8(1), 1);
-        assert_eq!(roundtrip_u8(u8::min_value()), u8::min_value());
-        assert_eq!(roundtrip_u8(u8::max_value()), u8::max_value());
+        assert_eq!(roundtrip_u8(u8::MIN), u8::MIN);
+        assert_eq!(roundtrip_u8(u8::MAX), u8::MAX);
 
         assert_eq!(roundtrip_s8(1), 1);
-        assert_eq!(roundtrip_s8(i8::min_value()), i8::min_value());
-        assert_eq!(roundtrip_s8(i8::max_value()), i8::max_value());
+        assert_eq!(roundtrip_s8(i8::MIN), i8::MIN);
+        assert_eq!(roundtrip_s8(i8::MAX), i8::MAX);
 
         assert_eq!(roundtrip_u16(1), 1);
-        assert_eq!(roundtrip_u16(u16::min_value()), u16::min_value());
-        assert_eq!(roundtrip_u16(u16::max_value()), u16::max_value());
+        assert_eq!(roundtrip_u16(u16::MIN), u16::MIN);
+        assert_eq!(roundtrip_u16(u16::MAX), u16::MAX);
 
         assert_eq!(roundtrip_s16(1), 1);
-        assert_eq!(roundtrip_s16(i16::min_value()), i16::min_value());
-        assert_eq!(roundtrip_s16(i16::max_value()), i16::max_value());
+        assert_eq!(roundtrip_s16(i16::MIN), i16::MIN);
+        assert_eq!(roundtrip_s16(i16::MAX), i16::MAX);
 
         assert_eq!(roundtrip_u32(1), 1);
-        assert_eq!(roundtrip_u32(u32::min_value()), u32::min_value());
-        assert_eq!(roundtrip_u32(u32::max_value()), u32::max_value());
+        assert_eq!(roundtrip_u32(u32::MIN), u32::MIN);
+        assert_eq!(roundtrip_u32(u32::MAX), u32::MAX);
 
         assert_eq!(roundtrip_s32(1), 1);
-        assert_eq!(roundtrip_s32(i32::min_value()), i32::min_value());
-        assert_eq!(roundtrip_s32(i32::max_value()), i32::max_value());
+        assert_eq!(roundtrip_s32(i32::MIN), i32::MIN);
+        assert_eq!(roundtrip_s32(i32::MAX), i32::MAX);
 
         assert_eq!(roundtrip_u64(1), 1);
-        assert_eq!(roundtrip_u64(u64::min_value()), u64::min_value());
-        assert_eq!(roundtrip_u64(u64::max_value()), u64::max_value());
+        assert_eq!(roundtrip_u64(u64::MIN), u64::MIN);
+        assert_eq!(roundtrip_u64(u64::MAX), u64::MAX);
 
         assert_eq!(roundtrip_s64(1), 1);
-        assert_eq!(roundtrip_s64(i64::min_value()), i64::min_value());
-        assert_eq!(roundtrip_s64(i64::max_value()), i64::max_value());
+        assert_eq!(roundtrip_s64(i64::MIN), i64::MIN);
+        assert_eq!(roundtrip_s64(i64::MAX), i64::MAX);
 
         assert_eq!(roundtrip_f32(1.0), 1.0);
         assert_eq!(roundtrip_f32(f32::INFINITY), f32::INFINITY);


### PR DESCRIPTION
The build directory layout of Cargo is changing so this updates the build/run of Rust tests to read the JSON messages from Cargo about where artifacts are located.