### PR TITLE
Make the cli's `csharp` feature actually turn csharp off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ wit-bindgen-markdown = { path = 'crates/markdown', version = '0.60.0' }
 wit-bindgen-moonbit = { path = 'crates/moonbit', version = '0.60.0' }
 wit-bindgen-go = { path = 'crates/go', version = '0.60.0' }
 wit-bindgen = { path = 'crates/guest-rust', version = '0.60.0', default-features = false }
-wit-bindgen-test = { path = 'crates/test', version = '0.60.0' }
+wit-bindgen-test = { path = 'crates/test', version = '0.60.0', default-features = false }
 
 [workspace.lints.clippy]
 # The default set of lints in Clippy is viewed as "too noisy" right now so
@@ -117,7 +117,7 @@ cpp = ['dep:wit-bindgen-cpp']
 rust = ['dep:wit-bindgen-rust']
 markdown = ['dep:wit-bindgen-markdown']
 go = ['dep:wit-bindgen-go']
-csharp = ['dep:wit-bindgen-csharp']
+csharp = ['dep:wit-bindgen-csharp', 'wit-bindgen-test/csharp']
 csharp-mono = ['csharp']
 moonbit = ['dep:wit-bindgen-moonbit']
 async = []

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -38,5 +38,9 @@ wasmparser = { workspace = true, features = ["features"] }
 wat = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
-wit-bindgen-csharp = { workspace = true }
+wit-bindgen-csharp = { workspace = true, optional = true }
 libtest-mimic = "0.8.1"
+
+[features]
+default = ['csharp']
+csharp = ['dep:wit-bindgen-csharp']

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -15,6 +15,7 @@ use wit_component::{ComponentEncoder, StringEncoding};
 mod c;
 mod config;
 mod cpp;
+#[cfg(feature = "csharp")]
 mod csharp;
 mod custom;
 mod go;
@@ -226,6 +227,7 @@ enum Language {
     C,
     Cpp,
     Wat,
+    #[cfg(feature = "csharp")]
     Csharp,
     MoonBit,
     Go,
@@ -448,6 +450,7 @@ impl Runner {
             "c" => Language::C,
             "cpp" => Language::Cpp,
             "wat" => Language::Wat,
+            #[cfg(feature = "csharp")]
             "cs" => Language::Csharp,
             "mbt" => Language::MoonBit,
             "go" => Language::Go,
@@ -1320,6 +1323,7 @@ impl Language {
         Language::C,
         Language::Cpp,
         Language::Wat,
+        #[cfg(feature = "csharp")]
         Language::Csharp,
         Language::MoonBit,
         Language::Go,
@@ -1331,6 +1335,7 @@ impl Language {
             Language::C => &c::C,
             Language::Cpp => &cpp::Cpp,
             Language::Wat => &wat::Wat,
+            #[cfg(feature = "csharp")]
             Language::Csharp => &csharp::Csharp,
             Language::MoonBit => &moonbit::MoonBit,
             Language::Go => &go::Go,


### PR DESCRIPTION
`wit-bindgen-csharp` is `optional = true` in the cli, but the cli also depends on
`wit-bindgen-test` unconditionally, and that crate depended on `wit-bindgen-csharp`
outright. So the feature never actually removed anything:

```console
$ cargo tree --no-default-features -i wit-bindgen-csharp
wit-bindgen-csharp v0.60.0 (crates/csharp)
├── wit-bindgen-cli v0.60.0 (.)
└── wit-bindgen-test v0.60.0 (crates/test)
```

After this it's out of the graph for `--no-default-features` and for any single
non-csharp language, and still in for the default build and for
`--no-default-features --features csharp`.

`crates/test` is the only test driver that links a bindgen crate — the others shell
out — and it does so for `CSProject`, to write the .csproj. So `mod csharp` and the
`Language::Csharp` variant go behind the same feature. With csharp off the harness
no longer knows the `cs` extension and falls through to the `--custom` lookup, which
says the extension is unknown. Happy to keep the variant always present and error at
run time instead if you'd rather.

Closes #1510
