### PR TITLE
Add a `--locked` job to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
     - run: rustup target add wasm32-wasip1
-    - run: cargo test
+    - run: cargo test --locked
     - run: cargo test -p wit-bindgen-core
     - run: cargo test -p wit-bindgen
     - run: cargo test -p wit-bindgen --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,8 +1456,8 @@ dependencies = [
  "clap",
  "heck",
  "indexmap",
- "wasm-encoder 0.254.0",
- "wasm-metadata 0.254.0",
+ "wasm-encoder 0.257.0",
+ "wasm-metadata 0.257.0",
  "wit-bindgen-core",
  "wit-component",
 ]


### PR DESCRIPTION
The current lock file is updated when built, and this fixes the possibility of that happening again.