### PR TITLE
Unconditionally link wasip3 C-based intrinsics

### DIFF
--- a/crates/guest-rust/build.rs
+++ b/crates/guest-rust/build.rs
@@ -17,9 +17,7 @@ fn main() {
     if target_env == "p1" || target_env == "" {
         link_lib("cabi_realloc");
     }
-    if target_env == "p3" {
-        link_lib("cabi_wasip3");
-    }
+    link_lib("cabi_wasip3");
 }
 
 fn link_lib(name: &str) {


### PR DESCRIPTION
Don't take the target into account here since the crate could be compiled for any target and these intrinsics would still be necessary.