### PR TITLE
Ensure that an async function matches

### DIFF
--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -319,6 +319,10 @@ impl WorldGenerator for C {
     }
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
+        // Error about unused async configuration to help catch configuration
+        // errors.
+        self.opts.async_.ensure_all_used()?;
+
         let linking_symbol = component_type_object::linking_symbol(&self.world);
         self.c_include("<stdlib.h>");
         let snake = self.world.to_snake_case();

--- a/crates/go/src/lib.rs
+++ b/crates/go/src/lib.rs
@@ -877,6 +877,9 @@ impl WorldGenerator for Go {
 
     fn finish(&mut self, resolve: &Resolve, id: WorldId, files: &mut Files) -> Result<()> {
         _ = (resolve, id);
+        // Error about unused async configuration to help catch configuration
+        // errors.
+        self.opts.async_.ensure_all_used()?;
 
         let version = env!("CARGO_PKG_VERSION");
         let packages = resolve

--- a/crates/moonbit/src/lib.rs
+++ b/crates/moonbit/src/lib.rs
@@ -524,6 +524,10 @@ impl WorldGenerator for MoonBit {
     }
 
     fn finish(&mut self, _resolve: &Resolve, _id: WorldId, files: &mut Files) -> Result<()> {
+        // Error about unused async configuration to help catch configuration
+        // errors.
+        self.opts.async_.ensure_all_used()?;
+
         // If async is used, export async utils
         self.async_support.emit_runtime_files(files, VERSION);
 
@@ -3249,9 +3253,16 @@ mod tests {
 
     #[test]
     fn async_filters_respect_import_export_direction() {
+        // The world both imports and exports `run` so that each directional
+        // filter below matches something; an unmatched filter is now an error
+        // (see `AsyncFilterSet::ensure_all_used`), which would mask what this
+        // test is actually checking.
         let wit = r#"
             package a:b;
-            world runner { import run: func(); }
+            world runner {
+                import run: func();
+                export run: func();
+            }
         "#;
 
         let mut import_opts = Opts {


### PR DESCRIPTION
When testing with `componentize-go`, the `wit-bindgen go generate` was sometimes matching a sync vs async function def versus failing. 

This change copies exactly what the rust version does [here](https://github.com/bytecodealliance/wit-bindgen/blob/d6bc3a0f1eecb869ed46401a30f2871b0b095ff2/crates/rust/src/lib.rs#L1626-L1628)  for Go, and updated the C and Moonbit as well.

## Testing

Tested locally with componentize-go and using wasmCloud/go for a new NATS plugin. 

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
