### PR TITLE
feat(d): Improve export marking & naming

### DIFF
--- a/crates/d/src/lib.rs
+++ b/crates/d/src/lib.rs
@@ -650,9 +650,11 @@ impl WorldGenerator for D {
                     ));
 
                     if emit_exports_stubs {
+                        r#gen
+                            .stub_src
+                            .push_str(&format!("@witInterface(\"{}\")", wasm_import_module));
                         r#gen.stub_src.push_str(&format!(
-                            "@witExport(\"{}\", \"{}\")\nstruct {escaped_name}_STUB {{\n",
-                            wasm_import_module,
+                            "@witExport(\"{}\")\nstruct {escaped_name}_STUB {{\n",
                             ty.name.as_ref().unwrap()
                         ));
 
@@ -1446,10 +1448,11 @@ impl<'a> DInterfaceGenerator<'a> {
 
         if self.r#gen.opts.emit_export_stubs {
             self.stub_src.push_str(&format!(
-                "@witExport(\"{}\", \"{}\")\n",
+                "@witInterface(\"{}\")",
                 self.wasm_import_module.unwrap(),
-                func.name
             ));
+            self.stub_src
+                .push_str(&format!("@witExport(\"{}\")\n", func.name));
             if d_sig.static_member {
                 self.stub_src.push_str("static ");
             }

--- a/crates/d/src/lib.rs
+++ b/crates/d/src/lib.rs
@@ -1438,27 +1438,45 @@ impl<'a> DInterfaceGenerator<'a> {
                 .join(", ")
         ));
 
-        self.src.push_str(&format!(
-            "/// ditto\nalias {}_Impl = findWitExportFunc!(\"{}\", \"{}\", {0}_Sig, {}, {});\n",
-            d_sig.name,
-            self.wasm_import_module.unwrap(),
-            func.name,
-            d_sig.implicit_self,
-            match &func.kind {
-                FunctionKind::Freestanding | FunctionKind::AsyncFreestanding => "Impl",
-                _ => {
-                    "witExportsIn!_Resource_Impl"
-                }
+        match &func.kind {
+            FunctionKind::Freestanding | FunctionKind::AsyncFreestanding => {
+                self.src.push_str(&format!(
+                    "/// ditto\nalias {}_Impl = findWitExportFunc!(\"{}\", \"{}\", {0}_Sig, Impl);\n",
+                    d_sig.name,
+                    self.wasm_import_module.unwrap(),
+                    func.name
+                ));
             }
-        ));
+            _ => {
+                self.src.push_str(&format!(
+                    "/// ditto\nalias {}_Impl = findWitExportMethod!(_Resource_Impl, \"{}\", {0}_Sig, {});\n",
+                    d_sig.name,
+                    func.name,
+                    !d_sig.implicit_self,
+                ));
+            }
+        }
 
         if self.r#gen.opts.emit_export_stubs {
-            self.stub_src.push_str(&format!(
-                "@witInterface(\"{}\")",
-                self.wasm_import_module.unwrap(),
-            ));
+            if matches!(
+                &func.kind,
+                FunctionKind::Freestanding | FunctionKind::AsyncFreestanding
+            ) {
+                self.stub_src.push_str(&format!(
+                    "@witInterface(\"{}\")",
+                    self.wasm_import_module.unwrap(),
+                ));
+            }
+
+            let name = &func.name;
+            let name = match &func.kind {
+                FunctionKind::Freestanding | FunctionKind::AsyncFreestanding => name,
+                FunctionKind::Constructor(_) => "[constructor]",
+                _ => name.split(".").skip(1).next().unwrap(),
+            };
+
             self.stub_src
-                .push_str(&format!("@witExport(\"{}\")\n", func.name));
+                .push_str(&format!("@witExport(\"{}\")\n", name));
             if d_sig.static_member {
                 self.stub_src.push_str("static ");
             }

--- a/crates/d/src/lib.rs
+++ b/crates/d/src/lib.rs
@@ -844,13 +844,19 @@ impl WorldGenerator for D {
 
         world_src.push_str("\n\nprivate alias AliasSeq(T...) = T;\n");
         world_src.push_str("template Exports(Impl...) {\n");
+
+        world_src.push_str(&format!(
+            "\nalias FilteredImpl = {}.findWitExports!Impl;\n",
+            self.common_module
+        ));
+
         world_src.push_str("alias InterfaceExports = AliasSeq!(\n");
         world_src.indent(1);
         world_src.push_str(
             &self
                 .interface_exports
                 .iter()
-                .map(|fqn| format!("{fqn}.Exports!Impl"))
+                .map(|fqn| format!("{fqn}.Exports!FilteredImpl"))
                 .collect::<Vec<String>>()
                 .join(",\n"),
         );

--- a/crates/d/src/lib.rs
+++ b/crates/d/src/lib.rs
@@ -652,7 +652,7 @@ impl WorldGenerator for D {
                     if emit_exports_stubs {
                         r#gen
                             .stub_src
-                            .push_str(&format!("@witInterface(\"{}\")", wasm_import_module));
+                            .push_str(&format!("@witInterface(\"{wasm_import_module}\")"));
                         r#gen.stub_src.push_str(&format!(
                             "@witExport(\"{}\")\nstruct {escaped_name}_STUB {{\n",
                             ty.name.as_ref().unwrap()
@@ -1475,8 +1475,7 @@ impl<'a> DInterfaceGenerator<'a> {
                 _ => name.split(".").skip(1).next().unwrap(),
             };
 
-            self.stub_src
-                .push_str(&format!("@witExport(\"{}\")\n", name));
+            self.stub_src.push_str(&format!("@witExport(\"{name}\")\n"));
             if d_sig.static_member {
                 self.stub_src.push_str("static ");
             }

--- a/crates/d/src/wit_common.d
+++ b/crates/d/src/wit_common.d
@@ -479,26 +479,45 @@ template witInterfaceOf(alias Symbol) {
     }
 }
 
+template witNameOf(alias Symbol) {
+    alias udas = AliasSeq!();
+    static foreach (uda; __traits(getAttributes, Symbol)) {
+        static if (!is(uda) && is(typeof(uda) == witExport)) {
+            udas = AliasSeq!(udas, uda);
+        }
+    }
+
+    static assert(
+        udas.length <= 1,
+        "There must be at most one `@witExport` attached. Found multiple on `",
+        __traits(fullyQualifiedName, Symbol), "`.",
+    );
+
+    static if (udas.length) {
+        enum string witNameOf = udas[0].name;
+    } else {
+        enum string witNameOf = "";
+    }
+}
+
 template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl...) {
     static foreach(Func; Impl) {
-        static foreach(uda; __traits(getAttributes, Func)) {
-            static if (!is(uda) && is(typeof(uda) == witExport) && uda.name == name && witInterfaceOf!Func == mod) {
-                static assert(
-                    !is(Func) &&
-                    (is(typeof(Func) == function)),
-                    "The implementation of '", mod, "#", name, "' ",
-                    "`", __traits(fullyQualifiedName, findWitExportFunc), "` ",
-                    "must be a function or method."
-                );
+        static if (witNameOf!Func == name && witInterfaceOf!Func == mod) {
+            static assert(
+                !is(Func) &&
+                (is(typeof(Func) == function)),
+                "The implementation of '", mod, "#", name, "' ",
+                "`", __traits(fullyQualifiedName, findWitExportFunc), "` ",
+                "must be a function or method."
+            );
 
-                static assert(
-                    !is(typeof(findWitExportFunc) == void) || __traits(isSame, findWitExportFunc, Func),
-                    "There must be only one implementation of '", mod, "#", name, "'. ",
-                    "Found at least `", __traits(fullyQualifiedName, findWitExportFunc),
-                    "` and `", __traits(fullyQualifiedName, Func), "`."
-                );
-                alias findWitExportFunc = Func;
-            }
+            static assert(
+                !is(typeof(findWitExportFunc) == void) || __traits(isSame, findWitExportFunc, Func),
+                "There must be only one implementation of '", mod, "#", name, "'. ",
+                "Found at least `", __traits(fullyQualifiedName, findWitExportFunc),
+                "` and `", __traits(fullyQualifiedName, Func), "`."
+            );
+            alias findWitExportFunc = Func;
         }
     }
 
@@ -519,23 +538,21 @@ template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl
 
 template findWitExportResource(string mod, string name, Impl...) {
     static foreach(Resource; Impl) {
-        static foreach(uda; __traits(getAttributes, Resource)) {
-            static if (!is(uda) && is(typeof(uda) == witExport) && uda.name == name && witInterfaceOf!Resource == mod) {
-                static assert(
-                    is(Resource == struct),
-                    "The implementation of '", mod, "#", name, "' ",
-                    "`", __traits(fullyQualifiedName, findWitExportResource), "` ",
-                    "must be a struct."
-                );
+        static if (witNameOf!Resource == name && witInterfaceOf!Resource == mod) {
+            static assert(
+                is(Resource == struct),
+                "The implementation of '", mod, "#", name, "' ",
+                "`", __traits(fullyQualifiedName, findWitExportResource), "` ",
+                "must be a struct."
+            );
 
-                static assert(
-                    !is(typeof(findWitExportResource) == void) || __traits(isSame, findWitExportResource, Resource),
-                    "There must be only one implementation of '", mod, "#", name, "'. ",
-                    "Found at least `", __traits(fullyQualifiedName, findWitExportResource),
-                    "` and `", __traits(fullyQualifiedName, Resource), "`."
-                );
-                alias findWitExportResource = Resource;
-            }
+            static assert(
+                !is(typeof(findWitExportResource) == void) || __traits(isSame, findWitExportResource, Resource),
+                "There must be only one implementation of '", mod, "#", name, "'. ",
+                "Found at least `", __traits(fullyQualifiedName, findWitExportResource),
+                "` and `", __traits(fullyQualifiedName, Resource), "`."
+            );
+            alias findWitExportResource = Resource;
         }
     }
 
@@ -545,16 +562,21 @@ template findWitExportResource(string mod, string name, Impl...) {
     );
 }
 
-
-template witExportsIn(T) {
+public template witExportsIn(T) {
     alias witExportsIn = AliasSeq!();
 
-    static foreach(M; __traits(allMembers, T)) {
-        static foreach(Export; __traits(getOverloads, T, M)) {
-            static foreach(uda; __traits(getAttributes, Export)) {
-                static if (!is(uda) && is(typeof(uda) == witExport)) {
-                    witExportsIn = AliasSeq!(witExportsIn, Export);
-                }
+    static foreach(member; __traits(allMembers, T)) {
+        witExportsIn = AliasSeq!(witExportsIn, findWitExports!(__traits(getOverloads, T, member)));
+    }
+}
+
+public template findWitExports(Exports...) {
+    alias findWitExports = AliasSeq!();
+
+    static foreach (elem; Exports) {
+        static foreach(uda; __traits(getAttributes, elem)) {
+            static if (!is(uda) && is(typeof(uda) == witExport)) {
+                findWitExports = AliasSeq!(findWitExports, elem);
             }
         }
     }

--- a/crates/d/src/wit_common.d
+++ b/crates/d/src/wit_common.d
@@ -500,7 +500,18 @@ template witNameOf(alias Symbol) {
     }
 }
 
-template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl...) {
+template witNameInResourceOf(T, alias Func) {
+    enum resName = witNameOf!T;
+    enum name = witNameOf!Func;
+    
+    static if (name == "[constructor]") {
+        enum witNameInResourceOf = "[constructor]" ~ resName;
+    } else {
+        enum witNameInResourceOf = (__traits(isStaticFunction, Func) ? "[static]" : "[method]") ~ resName ~ "." ~ name;
+    }
+}
+
+template findWitExportFunc(string mod, string name, Sig, Impl...) {
     static foreach(Func; Impl) {
         static if (witNameOf!Func == name && witInterfaceOf!Func == mod) {
             static assert(
@@ -527,11 +538,65 @@ template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl
     );
 
     static assert(
-        is(typeof(&findWitExportFunc) : Sig) && __traits(isStaticFunction, findWitExportFunc) != implicitSelf,
+         __traits(isStaticFunction, findWitExportFunc),
+         "The implementation of '", mod, "#", name, "' ",
+         "`", __traits(fullyQualifiedName, findWitExportFunc), "` ",
+         "must be static.",
+    );
+    
+    static assert(
+        is(typeof(&findWitExportFunc) : Sig),
         "The implementation of '", mod, "#", name, "' ",
         "`", __traits(fullyQualifiedName, findWitExportFunc), "` ",
         "must conform to the necessary signature. ",
         "Found `", typeof(&findWitExportFunc), "`",
+        ", but expected `", Sig, "`"
+    );
+}
+
+template findWitExportMethod(T, string name, Sig, bool isStatic) {
+    alias Impl = witExportsIn!T;
+
+    enum mod = witInterfaceOf!T;
+    
+    static foreach(Func; Impl) {
+        static if (witNameInResourceOf!(T, Func) == name) {
+            static assert(
+                !is(Func) &&
+                (is(typeof(Func) == function)),
+                "The implementation of '", mod, "#", name, "' ",
+                "`", __traits(fullyQualifiedName, findWitExportMethod), "` ",
+                "must be a function or method."
+            );
+
+            static assert(
+                !is(typeof(findWitExportMethod) == void) || __traits(isSame, findWitExportMethod, Func),
+                "There must be only one implementation of '", mod, "#", name, "'. ",
+                "Found at least `", __traits(fullyQualifiedName, findWitExportMethod),
+                "` and `", __traits(fullyQualifiedName, Func), "`."
+            );
+            alias findWitExportMethod = Func;
+        }
+    }
+
+    static assert(
+        !is(typeof(findWitExportMethod) == void),
+        "Could not find implementation for '", mod, "#", name, "'"
+    );
+
+    static assert(
+        __traits(isStaticFunction, findWitExportMethod) == isStatic,
+        "The implementation of '", mod, "#", name, "' ",
+        "`", __traits(fullyQualifiedName, findWitExportMethod), "` ",
+        "must " ~ (isSttic ? "be static" : "have implicit `this`") ~ ".",
+    );
+    
+    static assert(
+        is(typeof(&findWitExportMethod) : Sig),
+        "The implementation of '", mod, "#", name, "' ",
+        "`", __traits(fullyQualifiedName, findWitExportMethod), "` ",
+        "must conform to the necessary signature. ",
+        "Found `", typeof(&findWitExportMethod), "`",
         ", but expected `", Sig, "`"
     );
 }

--- a/crates/d/src/wit_common.d
+++ b/crates/d/src/wit_common.d
@@ -8,7 +8,8 @@ alias wasmImport(string mod, string name) = AliasSeq!(
 
 enum wasmExport(string name) = llvmAttr("wasm-export-name", name);
 
-struct witExport { string mod; string name; }
+struct witInterface { string name; }
+struct witExport { string name; }
 
 /// Thin CABI compliant wrapper over `T[]`
 struct WitList(T) {
@@ -444,10 +445,44 @@ T[] mallocSlice(T)(size_t count) @nogc nothrow {
 alias AliasSeq(T...) = T;
 
 
+/+string kebabCase(string s) {
+    string res;
+    foreach (i, char c; s) {
+        if (c >= 'A' && c <= 'Z') {
+            if (i > 0 && i+1 < s.length) res ~= '-';
+            res ~= cast(char)(c + 32);
+        } else {
+            res ~= c;
+        }
+    }
+    return res;
+}+/
+
+template witInterfaceOf(alias Symbol) {
+    alias udas = AliasSeq!();
+    static foreach (uda; __traits(getAttributes, Symbol)) {
+        static if (!is(uda) && is(typeof(uda) == witInterface)) {
+            udas = AliasSeq!(udas, uda);
+        }
+    }
+
+    static assert(
+        udas.length <= 1,
+        "There must be at most one `@witInterface` attached. Found multiple on `",
+        __traits(fullyQualifiedName, Symbol), "`.",
+    );
+
+    static if (udas.length) {
+        enum string witInterfaceOf = udas[0].name;
+    } else {
+        enum string witInterfaceOf = "";
+    }
+}
+
 template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl...) {
     static foreach(Func; Impl) {
         static foreach(uda; __traits(getAttributes, Func)) {
-            static if (!is(uda) && is(typeof(uda) == witExport) && uda == witExport(mod, name)) {
+            static if (!is(uda) && is(typeof(uda) == witExport) && uda.name == name && witInterfaceOf!Func == mod) {
                 static assert(
                     !is(Func) &&
                     (is(typeof(Func) == function)),
@@ -485,7 +520,7 @@ template findWitExportFunc(string mod, string name, Sig, bool implicitSelf, Impl
 template findWitExportResource(string mod, string name, Impl...) {
     static foreach(Resource; Impl) {
         static foreach(uda; __traits(getAttributes, Resource)) {
-            static if (!is(uda) && is(typeof(uda) == witExport) && uda == witExport(mod, name)) {
+            static if (!is(uda) && is(typeof(uda) == witExport) && uda.name == name && witInterfaceOf!Resource == mod) {
                 static assert(
                     is(Resource == struct),
                     "The implementation of '", mod, "#", name, "' ",

--- a/crates/d/src/wit_common.d
+++ b/crates/d/src/wit_common.d
@@ -444,20 +444,6 @@ T[] mallocSlice(T)(size_t count) @nogc nothrow {
 // from std.meta
 alias AliasSeq(T...) = T;
 
-
-/+string kebabCase(string s) {
-    string res;
-    foreach (i, char c; s) {
-        if (c >= 'A' && c <= 'Z') {
-            if (i > 0 && i+1 < s.length) res ~= '-';
-            res ~= cast(char)(c + 32);
-        } else {
-            res ~= c;
-        }
-    }
-    return res;
-}+/
-
 template witInterfaceOf(alias Symbol) {
     alias udas = AliasSeq!();
     static foreach (uda; __traits(getAttributes, Symbol)) {
@@ -479,10 +465,34 @@ template witInterfaceOf(alias Symbol) {
     }
 }
 
+alias toKebabCase = (string s) { // lambda to satisfy `betterC` (use of GC)
+    if (s.length == 0) return "";
+    
+    char[] buf;
+    foreach (i, c; s) {
+        if (i > 0 && c >= 'A' && c <= 'Z') {
+            char prev = s[i - 1];
+            char next = ((i + 1) < s.length) ? s[i + 1] : '\0';
+            if (
+                (prev >= 'a' && prev <= 'z') || 
+                (
+                    next != '\0' &&
+                    prev >= 'A' && prev <= 'Z' &&
+                    !(next >= 'A' && next <= 'Z')
+                )
+            ) {
+                buf ~= '-';
+            }
+        }
+        buf ~= (c >= 'A' && c <= 'Z') ? (c + 32) : c;
+    }
+    return cast(string)buf;
+};
+
 template witNameOf(alias Symbol) {
     alias udas = AliasSeq!();
     static foreach (uda; __traits(getAttributes, Symbol)) {
-        static if (!is(uda) && is(typeof(uda) == witExport)) {
+        static if ((!is(uda) && is(typeof(uda) == witExport)) || is(uda == witExport)) {
             udas = AliasSeq!(udas, uda);
         }
     }
@@ -494,7 +504,17 @@ template witNameOf(alias Symbol) {
     );
 
     static if (udas.length) {
-        enum string witNameOf = udas[0].name;
+        static if (is(udas[0])) {
+            enum string witNameOf = toKebabCase(__traits(identifier, Symbol));
+        } else {
+            static assert(
+                udas[0].name.length,
+                "Specifying an empty name for `@witExport(...)` is not allowed. Found empty on `",
+                __traits(fullyQualifiedName, Symbol), "`. Omit the parenthesis and parameter",
+                " (i.e. use as `@witExport`) or specify non-empty name.",
+            );
+            enum string witNameOf = udas[0].name;
+        }
     } else {
         enum string witNameOf = "";
     }
@@ -640,7 +660,7 @@ public template findWitExports(Exports...) {
 
     static foreach (elem; Exports) {
         static foreach(uda; __traits(getAttributes, elem)) {
-            static if (!is(uda) && is(typeof(uda) == witExport)) {
+            static if ((!is(uda) && is(typeof(uda) == witExport)) || is(uda == witExport)) {
                 findWitExports = AliasSeq!(findWitExports, elem);
             }
         }

--- a/tests/runtime/common-types/leaf.d
+++ b/tests/runtime/common-types/leaf.d
@@ -1,21 +1,23 @@
 import wit.test.common.leaf;
 import wit.common;
 
-@witExport("test:common/to-test", "wrap")
-R1 wrap(F1 flag) {
-    switch (flag.bits) with (F1) {
-        case a.bits:
-            return R1(1, flag);
-        case b.bits:
-            return R1(2, flag);
-        default:
-            assert(0);
+@witInterface("test:common/to-test") {
+    @witExport("wrap")
+    R1 wrap(F1 flag) {
+        switch (flag.bits) with (F1) {
+            case a.bits:
+                return R1(1, flag);
+            case b.bits:
+                return R1(2, flag);
+            default:
+                assert(0);
+        }
     }
-}
-
-@witExport("test:common/to-test", "var-f")
-V1 varF() {
-    return V1.b(42);
+    
+    @witExport("var-f")
+    V1 varF() {
+        return V1.b(42);
+    }
 }
 
 alias Exports = wit.test.common.leaf.Exports!(

--- a/tests/runtime/common-types/leaf.d
+++ b/tests/runtime/common-types/leaf.d
@@ -2,7 +2,7 @@ import wit.test.common.leaf;
 import wit.common;
 
 @witInterface("test:common/to-test") {
-    @witExport("wrap")
+    @witExport
     R1 wrap(F1 flag) {
         switch (flag.bits) with (F1) {
             case a.bits:
@@ -14,7 +14,7 @@ import wit.common;
         }
     }
     
-    @witExport("var-f")
+    @witExport
     V1 varF() {
         return V1.b(42);
     }

--- a/tests/runtime/common-types/middle.d
+++ b/tests/runtime/common-types/middle.d
@@ -4,12 +4,12 @@ import wit.common;
 import imps = wit.test.common.to_test.imports;
 
 @witInterface("test:common/to-test") {
-    @witExport("wrap")
+    @witExport
     R1 wrap(F1 flag) {
         return imps.wrap(flag);
     }
     
-    @witExport("var-f")
+    @witExport
     V1 varF() {
         return imps.varF;
     }

--- a/tests/runtime/common-types/middle.d
+++ b/tests/runtime/common-types/middle.d
@@ -3,14 +3,16 @@ import wit.common;
 
 import imps = wit.test.common.to_test.imports;
 
-@witExport("test:common/to-test", "wrap")
-R1 wrap(F1 flag) {
-    return imps.wrap(flag);
-}
-
-@witExport("test:common/to-test", "var-f")
-V1 varF() {
-    return imps.varF;
+@witInterface("test:common/to-test") {
+    @witExport("wrap")
+    R1 wrap(F1 flag) {
+        return imps.wrap(flag);
+    }
+    
+    @witExport("var-f")
+    V1 varF() {
+        return imps.varF;
+    }
 }
 
 alias Exports = wit.test.common.middle.Exports!(

--- a/tests/runtime/common-types/runner.d
+++ b/tests/runtime/common-types/runner.d
@@ -2,7 +2,7 @@ import wit.test.common.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     R1 res = wrap(F1.a);
     assert(res.b == F1.a);

--- a/tests/runtime/common-types/runner.d
+++ b/tests/runtime/common-types/runner.d
@@ -1,7 +1,8 @@
 import wit.test.common.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     R1 res = wrap(F1.a);
     assert(res.b == F1.a);

--- a/tests/runtime/demo/runner.d
+++ b/tests/runtime/demo/runner.d
@@ -1,7 +1,8 @@
 import wit.a.b.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     x();
 }

--- a/tests/runtime/demo/runner.d
+++ b/tests/runtime/demo/runner.d
@@ -2,7 +2,7 @@ import wit.a.b.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     x();
 }

--- a/tests/runtime/demo/test.d
+++ b/tests/runtime/demo/test.d
@@ -1,7 +1,8 @@
 import wit.a.b.test;
 import wit.common;
 
-@witExport("a:b/the-test", "x")
+@witInterface("a:b/the-test")
+@witExport("x")
 void x() {
 }
 

--- a/tests/runtime/demo/test.d
+++ b/tests/runtime/demo/test.d
@@ -2,7 +2,7 @@ import wit.a.b.test;
 import wit.common;
 
 @witInterface("a:b/the-test")
-@witExport("x")
+@witExport
 void x() {
 }
 

--- a/tests/runtime/fixed-length-lists/runner.d
+++ b/tests/runtime/fixed-length-lists/runner.d
@@ -3,7 +3,8 @@
 import wit.test.fixed_length_lists.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     listParam([1, 2, 3, 4]);
     listParam2([[1, 2], [3, 4]]);

--- a/tests/runtime/fixed-length-lists/runner.d
+++ b/tests/runtime/fixed-length-lists/runner.d
@@ -4,7 +4,7 @@ import wit.test.fixed_length_lists.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     listParam([1, 2, 3, 4]);
     listParam2([[1, 2], [3, 4]]);

--- a/tests/runtime/fixed-length-lists/test.d
+++ b/tests/runtime/fixed-length-lists/test.d
@@ -2,51 +2,51 @@ import wit.test.fixed_length_lists.test;
 import wit.common;
 
 @witInterface("test:fixed-length-lists/to-test") {
-    @witExport("list-param")
+    @witExport
     void listParam(in uint[4] a) {
         assert(a == [1, 2, 3, 4]);
     }
     
-    @witExport("list-param2")
+    @witExport
     void listParam2(in uint[2][2] a) {
         enum uint[2][2] v = [[1, 2], [3, 4]];
         assert(a == v);
     }
     
-    @witExport("list-param3")
+    @witExport
     void listParam3(in int[20] a) {
         assert(a == [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20]);
     }
     
-    @witExport("list-minmax16")
+    @witExport
     Tuple!(ushort[4], short[4]) listMinmax16(in ushort[4] a, in short[4] b) {
         return tuple(a, b);
     }
     
     
-    @witExport("list-minmax-float")
+    @witExport
     Tuple!(float[2], double[2]) listMinmaxFloat(in float[2] a, in double[2] b) {
         return tuple(a, b);
     }
     
-    @witExport("list-roundtrip")
+    @witExport
     ubyte[12] listRoundtrip(in ubyte[12] a) => a;
     
-    @witExport("list-result")
+    @witExport
     ubyte[8] listResult() => ['0', '1', 'A', 'B', 'a', 'b', 128, 255];
     
-    @witExport("nested-roundtrip")
+    @witExport
     Tuple!(uint[2][2], int[2][2]) nestedRoundtrip(in uint[2][2] a, in int[2][2] b) {
         return tuple(a, b);
     }
     
-    @witExport("large-roundtrip")
+    @witExport
     Tuple!(uint[2][2], int[4][4]) largeRoundtrip(in uint[2][2] a, in int[4][4] b) {
         return tuple(a, b);
     }
     
-    @witExport("nightmare-on-cpp")
-    Nested[2] nightmareOnCpp(in Nested[2] a) {
+    @witExport
+    Nested[2] nightmareOnCPP(in Nested[2] a) {
         return a;
     }
 }
@@ -61,5 +61,5 @@ alias Exports = wit.test.fixed_length_lists.test.Exports!(
     listResult,
     nestedRoundtrip,
     largeRoundtrip,
-    nightmareOnCpp
+    nightmareOnCPP
 );

--- a/tests/runtime/fixed-length-lists/test.d
+++ b/tests/runtime/fixed-length-lists/test.d
@@ -1,52 +1,54 @@
 import wit.test.fixed_length_lists.test;
 import wit.common;
 
-@witExport("test:fixed-length-lists/to-test", "list-param")
-void listParam(in uint[4] a) {
-    assert(a == [1, 2, 3, 4]);
-}
-
-@witExport("test:fixed-length-lists/to-test", "list-param2")
-void listParam2(in uint[2][2] a) {
-    enum uint[2][2] v = [[1, 2], [3, 4]];
-    assert(a == v);
-}
-
-@witExport("test:fixed-length-lists/to-test", "list-param3")
-void listParam3(in int[20] a) {
-    assert(a == [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20]);
-}
-
-@witExport("test:fixed-length-lists/to-test", "list-minmax16")
-Tuple!(ushort[4], short[4]) listMinmax16(in ushort[4] a, in short[4] b) {
-    return tuple(a, b);
-}
-
-
-@witExport("test:fixed-length-lists/to-test", "list-minmax-float")
-Tuple!(float[2], double[2]) listMinmaxFloat(in float[2] a, in double[2] b) {
-    return tuple(a, b);
-}
-
-@witExport("test:fixed-length-lists/to-test", "list-roundtrip")
-ubyte[12] listRoundtrip(in ubyte[12] a) => a;
-
-@witExport("test:fixed-length-lists/to-test", "list-result")
-ubyte[8] listResult() => ['0', '1', 'A', 'B', 'a', 'b', 128, 255];
-
-@witExport("test:fixed-length-lists/to-test", "nested-roundtrip")
-Tuple!(uint[2][2], int[2][2]) nestedRoundtrip(in uint[2][2] a, in int[2][2] b) {
-    return tuple(a, b);
-}
-
-@witExport("test:fixed-length-lists/to-test", "large-roundtrip")
-Tuple!(uint[2][2], int[4][4]) largeRoundtrip(in uint[2][2] a, in int[4][4] b) {
-    return tuple(a, b);
-}
-
-@witExport("test:fixed-length-lists/to-test", "nightmare-on-cpp")
-Nested[2] nightmareOnCpp(in Nested[2] a) {
-    return a;
+@witInterface("test:fixed-length-lists/to-test") {
+    @witExport("list-param")
+    void listParam(in uint[4] a) {
+        assert(a == [1, 2, 3, 4]);
+    }
+    
+    @witExport("list-param2")
+    void listParam2(in uint[2][2] a) {
+        enum uint[2][2] v = [[1, 2], [3, 4]];
+        assert(a == v);
+    }
+    
+    @witExport("list-param3")
+    void listParam3(in int[20] a) {
+        assert(a == [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20]);
+    }
+    
+    @witExport("list-minmax16")
+    Tuple!(ushort[4], short[4]) listMinmax16(in ushort[4] a, in short[4] b) {
+        return tuple(a, b);
+    }
+    
+    
+    @witExport("list-minmax-float")
+    Tuple!(float[2], double[2]) listMinmaxFloat(in float[2] a, in double[2] b) {
+        return tuple(a, b);
+    }
+    
+    @witExport("list-roundtrip")
+    ubyte[12] listRoundtrip(in ubyte[12] a) => a;
+    
+    @witExport("list-result")
+    ubyte[8] listResult() => ['0', '1', 'A', 'B', 'a', 'b', 128, 255];
+    
+    @witExport("nested-roundtrip")
+    Tuple!(uint[2][2], int[2][2]) nestedRoundtrip(in uint[2][2] a, in int[2][2] b) {
+        return tuple(a, b);
+    }
+    
+    @witExport("large-roundtrip")
+    Tuple!(uint[2][2], int[4][4]) largeRoundtrip(in uint[2][2] a, in int[4][4] b) {
+        return tuple(a, b);
+    }
+    
+    @witExport("nightmare-on-cpp")
+    Nested[2] nightmareOnCpp(in Nested[2] a) {
+        return a;
+    }
 }
 
 alias Exports = wit.test.fixed_length_lists.test.Exports!(

--- a/tests/runtime/flavorful/runner.d
+++ b/tests/runtime/flavorful/runner.d
@@ -1,7 +1,8 @@
 import wit.test.flavorful.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     fListInRecord1(ListInRecord1(a: cast(WitString)"list_in_record1".witList));
 

--- a/tests/runtime/flavorful/runner.d
+++ b/tests/runtime/flavorful/runner.d
@@ -2,7 +2,7 @@ import wit.test.flavorful.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     fListInRecord1(ListInRecord1(a: cast(WitString)"list_in_record1".witList));
 

--- a/tests/runtime/flavorful/test.d
+++ b/tests/runtime/flavorful/test.d
@@ -2,46 +2,46 @@ import wit.test.flavorful.test;
 import wit.common;
 
 @witInterface("test:flavorful/to-test") {
-    @witExport("f-list-in-record1")
+    @witExport
     void fListInRecord1(in ListInRecord1 a) {
         assert(a.a == "list_in_record1");
     }
     
-    @witExport("f-list-in-record2")
+    @witExport
     ListInRecord2 fListInRecord2() {
         return (const ListInRecord2("list_in_record2".witList)).witClone;
     }
     
-    @witExport("f-list-in-record3")
+    @witExport
     ListInRecord3 fListInRecord3(in ListInRecord3 a) {
         assert(a.a == "list_in_record3 input");
         return (const ListInRecord3("list_in_record3 output".witList)).witClone;
     }
     
-    @witExport("f-list-in-record4")
+    @witExport
     ListInAlias fListInRecord4(in ListInAlias a) {
         assert(a.a == "input4");
         return (const ListInAlias("result4".witList)).witClone;
     }
     
-    @witExport("f-list-in-variant1")
+    @witExport
     void fListInVariant1(in ListInVariant1V1 a, in ListInVariant1V2 b) {
         assert(a.unwrap() == "foo");
         assert(b.unwrapErr() == "bar");
     }
     
-    @witExport("f-list-in-variant2")
+    @witExport
     Option!WitString fListInVariant2() {
         return some("list_in_variant2".witList).witClone;
     }
     
-    @witExport("f-list-in-variant3")
+    @witExport
     Option!WitString fListInVariant3(in ListInVariant3 a) {
         assert(a.unwrap() == "input3");
         return some("output3".witList).witClone;
     }
     
-    @witExport("errno-result")
+    @witExport
     Result!(void, MyErrno) errnoResult() {
         static bool first = true;
     
@@ -54,7 +54,7 @@ import wit.common;
     }
     
     
-    @witExport("list-typedefs")
+    @witExport
     Tuple!(ListTypedef2, ListTypedef3) listTypedefs(in ListTypedef a, in ListTypedef3 b) {
         assert(a == "typedef1");
         assert(b.length == 1);
@@ -72,7 +72,7 @@ import wit.common;
     
     
     
-    @witExport("list-of-variants")
+    @witExport
     Tuple!(WitList!bool, WitList!(Result!()), WitList!MyErrno) listOfVariants(in WitList!bool bools, in WitList!(Result!()) results, in WitList!MyErrno enums) {
         static immutable bool[] boolsCmp = [true, false];
         assert(bools == boolsCmp[]);

--- a/tests/runtime/flavorful/test.d
+++ b/tests/runtime/flavorful/test.d
@@ -1,95 +1,97 @@
 import wit.test.flavorful.test;
 import wit.common;
 
-@witExport("test:flavorful/to-test", "f-list-in-record1")
-void fListInRecord1(in ListInRecord1 a) {
-    assert(a.a == "list_in_record1");
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-record2")
-ListInRecord2 fListInRecord2() {
-    return (const ListInRecord2("list_in_record2".witList)).witClone;
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-record3")
-ListInRecord3 fListInRecord3(in ListInRecord3 a) {
-    assert(a.a == "list_in_record3 input");
-    return (const ListInRecord3("list_in_record3 output".witList)).witClone;
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-record4")
-ListInAlias fListInRecord4(in ListInAlias a) {
-    assert(a.a == "input4");
-    return (const ListInAlias("result4".witList)).witClone;
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-variant1")
-void fListInVariant1(in ListInVariant1V1 a, in ListInVariant1V2 b) {
-    assert(a.unwrap() == "foo");
-    assert(b.unwrapErr() == "bar");
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-variant2")
-Option!WitString fListInVariant2() {
-    return some("list_in_variant2".witList).witClone;
-}
-
-@witExport("test:flavorful/to-test", "f-list-in-variant3")
-Option!WitString fListInVariant3(in ListInVariant3 a) {
-    assert(a.unwrap() == "input3");
-    return some("output3".witList).witClone;
-}
-
-@witExport("test:flavorful/to-test", "errno-result")
-Result!(void, MyErrno) errnoResult() {
-    static bool first = true;
-
-    if (first) {
-        first = false;
-        return MyErrno.b.err!void;
-    } else {
-        return ok!MyErrno;
+@witInterface("test:flavorful/to-test") {
+    @witExport("f-list-in-record1")
+    void fListInRecord1(in ListInRecord1 a) {
+        assert(a.a == "list_in_record1");
     }
-}
-
-
-@witExport("test:flavorful/to-test", "list-typedefs")
-Tuple!(ListTypedef2, ListTypedef3) listTypedefs(in ListTypedef a, in ListTypedef3 b) {
-    assert(a == "typedef1");
-    assert(b.length == 1);
-    assert(b[0] == "typedef2");
-
-    WitString[1] strings = [
-        cast(WitString)"typedef4".witList
-    ];
-
-    return tuple(
-        (cast(immutable ubyte[])"typedef3").witList,
-        strings[].witList
-    ).witClone;
-}
-
-
-
-@witExport("test:flavorful/to-test", "list-of-variants")
-Tuple!(WitList!bool, WitList!(Result!()), WitList!MyErrno) listOfVariants(in WitList!bool bools, in WitList!(Result!()) results, in WitList!MyErrno enums) {
-    static immutable bool[] boolsCmp = [true, false];
-    assert(bools == boolsCmp[]);
-
-    static immutable Result!()[] resultsCmp = [ok!void, err!void];
-    assert(results == resultsCmp[]);
-
-    static immutable MyErrno[] enumsCmp = [MyErrno.success, MyErrno.a];
-    assert(enums == enumsCmp[]);
-
-    static immutable bool[] boolsOut = [false, true];
-    static immutable Result!(void)[] resultsOut = [err!void, ok!void];
-    static immutable MyErrno[] enumsOut = [MyErrno.a, MyErrno.b];
-    return tuple(
-        boolsOut.witList,
-        resultsOut.witList,
-        enumsOut.witList
-    ).witClone;
+    
+    @witExport("f-list-in-record2")
+    ListInRecord2 fListInRecord2() {
+        return (const ListInRecord2("list_in_record2".witList)).witClone;
+    }
+    
+    @witExport("f-list-in-record3")
+    ListInRecord3 fListInRecord3(in ListInRecord3 a) {
+        assert(a.a == "list_in_record3 input");
+        return (const ListInRecord3("list_in_record3 output".witList)).witClone;
+    }
+    
+    @witExport("f-list-in-record4")
+    ListInAlias fListInRecord4(in ListInAlias a) {
+        assert(a.a == "input4");
+        return (const ListInAlias("result4".witList)).witClone;
+    }
+    
+    @witExport("f-list-in-variant1")
+    void fListInVariant1(in ListInVariant1V1 a, in ListInVariant1V2 b) {
+        assert(a.unwrap() == "foo");
+        assert(b.unwrapErr() == "bar");
+    }
+    
+    @witExport("f-list-in-variant2")
+    Option!WitString fListInVariant2() {
+        return some("list_in_variant2".witList).witClone;
+    }
+    
+    @witExport("f-list-in-variant3")
+    Option!WitString fListInVariant3(in ListInVariant3 a) {
+        assert(a.unwrap() == "input3");
+        return some("output3".witList).witClone;
+    }
+    
+    @witExport("errno-result")
+    Result!(void, MyErrno) errnoResult() {
+        static bool first = true;
+    
+        if (first) {
+            first = false;
+            return MyErrno.b.err!void;
+        } else {
+            return ok!MyErrno;
+        }
+    }
+    
+    
+    @witExport("list-typedefs")
+    Tuple!(ListTypedef2, ListTypedef3) listTypedefs(in ListTypedef a, in ListTypedef3 b) {
+        assert(a == "typedef1");
+        assert(b.length == 1);
+        assert(b[0] == "typedef2");
+    
+        WitString[1] strings = [
+            cast(WitString)"typedef4".witList
+        ];
+    
+        return tuple(
+            (cast(immutable ubyte[])"typedef3").witList,
+            strings[].witList
+        ).witClone;
+    }
+    
+    
+    
+    @witExport("list-of-variants")
+    Tuple!(WitList!bool, WitList!(Result!()), WitList!MyErrno) listOfVariants(in WitList!bool bools, in WitList!(Result!()) results, in WitList!MyErrno enums) {
+        static immutable bool[] boolsCmp = [true, false];
+        assert(bools == boolsCmp[]);
+    
+        static immutable Result!()[] resultsCmp = [ok!void, err!void];
+        assert(results == resultsCmp[]);
+    
+        static immutable MyErrno[] enumsCmp = [MyErrno.success, MyErrno.a];
+        assert(enums == enumsCmp[]);
+    
+        static immutable bool[] boolsOut = [false, true];
+        static immutable Result!(void)[] resultsOut = [err!void, ok!void];
+        static immutable MyErrno[] enumsOut = [MyErrno.a, MyErrno.b];
+        return tuple(
+            boolsOut.witList,
+            resultsOut.witList,
+            enumsOut.witList
+        ).witClone;
+    }
 }
 
 alias Exports = wit.test.flavorful.test.Exports!(

--- a/tests/runtime/gated-features/runner.d
+++ b/tests/runtime/gated-features/runner.d
@@ -3,7 +3,8 @@
 import wit.foo.bar.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     y();
     z();

--- a/tests/runtime/gated-features/runner.d
+++ b/tests/runtime/gated-features/runner.d
@@ -4,7 +4,7 @@ import wit.foo.bar.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     y();
     z();

--- a/tests/runtime/gated-features/test.d
+++ b/tests/runtime/gated-features/test.d
@@ -5,10 +5,10 @@ import wit.common;
 
 
 @witInterface("foo:bar/bindings@1.2.3") {
-    @witExport("y")
+    @witExport
     void y() {}
     
-    @witExport("z")
+    @witExport
     void z() {}
 }
 

--- a/tests/runtime/gated-features/test.d
+++ b/tests/runtime/gated-features/test.d
@@ -3,11 +3,14 @@
 import wit.foo.bar.test;
 import wit.common;
 
-@witExport("foo:bar/bindings@1.2.3", "y")
-void y() {}
 
-@witExport("foo:bar/bindings@1.2.3", "z")
-void z() {}
+@witInterface("foo:bar/bindings@1.2.3") {
+    @witExport("y")
+    void y() {}
+    
+    @witExport("z")
+    void z() {}
+}
 
 alias Exports = wit.foo.bar.test.Exports!(
     y,

--- a/tests/runtime/list-in-variant/runner.d
+++ b/tests/runtime/list-in-variant/runner.d
@@ -2,7 +2,7 @@ import wit.test.list_in_variant.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     const WitString[2] hw = ["hello".witList, "world".witList];
     {

--- a/tests/runtime/list-in-variant/runner.d
+++ b/tests/runtime/list-in-variant/runner.d
@@ -1,7 +1,8 @@
 import wit.test.list_in_variant.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     const WitString[2] hw = ["hello".witList, "world".witList];
     {

--- a/tests/runtime/list-in-variant/test.d
+++ b/tests/runtime/list-in-variant/test.d
@@ -34,55 +34,57 @@ char[] commaJoin(in WitString[] strs) {
     return chars;
 }
 
-@witExport("test:list-in-variant/to-test", "list-in-option")
-WitString listInOption(in Option!(WitList!WitString) data) {
-    if (data.isSome) {
-        return data.unwrap.commaJoin.witList; // no clone
+@witInterface("test:list-in-variant/to-test") {
+    @witExport("list-in-option")
+    WitString listInOption(in Option!(WitList!WitString) data) {
+        if (data.isSome) {
+            return data.unwrap.commaJoin.witList; // no clone
+        }
+        return "none".witList.witClone;
     }
-    return "none".witList.witClone;
-}
-
-@witExport("test:list-in-variant/to-test", "list-in-variant")
-WitString listInVariant(in PayloadOrEmpty data) {
-    if (data.isWithData) {
-        return data.getWithData.commaJoin.witList; // no clone
+    
+    @witExport("list-in-variant")
+    WitString listInVariant(in PayloadOrEmpty data) {
+        if (data.isWithData) {
+            return data.getWithData.commaJoin.witList; // no clone
+        }
+        return "empty".witList.witClone;
     }
-    return "empty".witList.witClone;
-}
-
-@witExport("test:list-in-variant/to-test", "list-in-result")
-WitString listInResult(in Result!(WitList!WitString, WitString) data) {
-    if (data.isOk) {
-        return data.unwrap.commaJoin.witList;
+    
+    @witExport("list-in-result")
+    WitString listInResult(in Result!(WitList!WitString, WitString) data) {
+        if (data.isOk) {
+            return data.unwrap.commaJoin.witList;
+        }
+    
+    
+        auto errStr = data.unwrapErr;
+        void* ptr = malloc(errStr.length+4);
+        assert(ptr);
+        char[] chars = cast(char[])ptr[0..errStr.length+4];
+    
+        chars[0..4] = "err:";
+        foreach (i, ref chr; chars[4..$]) {
+            chr = errStr[i];
+        }
+    
+        return chars.witList; // no clone
     }
-
-
-    auto errStr = data.unwrapErr;
-    void* ptr = malloc(errStr.length+4);
-    assert(ptr);
-    char[] chars = cast(char[])ptr[0..errStr.length+4];
-
-    chars[0..4] = "err:";
-    foreach (i, ref chr; chars[4..$]) {
-        chr = errStr[i];
+    
+    @witExport("list-in-option-with-return")
+    Summary listInOptionWithReturn(in Option!(WitList!WitString) data) {
+        if (data.isSome) {
+            auto items = data.unwrap();
+            return Summary(items.length, items.commaJoin.witList); // no clone
+        }
+    
+        return Summary(0, "none".witList.witClone);
     }
-
-    return chars.witList; // no clone
-}
-
-@witExport("test:list-in-variant/to-test", "list-in-option-with-return")
-Summary listInOptionWithReturn(in Option!(WitList!WitString) data) {
-    if (data.isSome) {
-        auto items = data.unwrap();
-        return Summary(items.length, items.commaJoin.witList); // no clone
+    
+    @witExport("top-level-list")
+    WitString topLevelList(in WitList!WitString data) {
+        return data.commaJoin.witList; // no clone
     }
-
-    return Summary(0, "none".witList.witClone);
-}
-
-@witExport("test:list-in-variant/to-test", "top-level-list")
-WitString topLevelList(in WitList!WitString data) {
-    return data.commaJoin.witList; // no clone
 }
 
 alias Exports = wit.test.list_in_variant.test.Exports!(

--- a/tests/runtime/list-in-variant/test.d
+++ b/tests/runtime/list-in-variant/test.d
@@ -35,7 +35,7 @@ char[] commaJoin(in WitString[] strs) {
 }
 
 @witInterface("test:list-in-variant/to-test") {
-    @witExport("list-in-option")
+    @witExport
     WitString listInOption(in Option!(WitList!WitString) data) {
         if (data.isSome) {
             return data.unwrap.commaJoin.witList; // no clone
@@ -43,7 +43,7 @@ char[] commaJoin(in WitString[] strs) {
         return "none".witList.witClone;
     }
     
-    @witExport("list-in-variant")
+    @witExport
     WitString listInVariant(in PayloadOrEmpty data) {
         if (data.isWithData) {
             return data.getWithData.commaJoin.witList; // no clone
@@ -51,7 +51,7 @@ char[] commaJoin(in WitString[] strs) {
         return "empty".witList.witClone;
     }
     
-    @witExport("list-in-result")
+    @witExport
     WitString listInResult(in Result!(WitList!WitString, WitString) data) {
         if (data.isOk) {
             return data.unwrap.commaJoin.witList;
@@ -71,7 +71,7 @@ char[] commaJoin(in WitString[] strs) {
         return chars.witList; // no clone
     }
     
-    @witExport("list-in-option-with-return")
+    @witExport
     Summary listInOptionWithReturn(in Option!(WitList!WitString) data) {
         if (data.isSome) {
             auto items = data.unwrap();
@@ -81,7 +81,7 @@ char[] commaJoin(in WitString[] strs) {
         return Summary(0, "none".witList.witClone);
     }
     
-    @witExport("top-level-list")
+    @witExport
     WitString topLevelList(in WitList!WitString data) {
         return data.commaJoin.witList; // no clone
     }

--- a/tests/runtime/lists-alias/runner.d
+++ b/tests/runtime/lists-alias/runner.d
@@ -3,7 +3,7 @@ import cat = wit.my.lists.runner.imports.cat;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     cat.foo((cast(immutable ubyte[])"hello").witList);
 

--- a/tests/runtime/lists-alias/runner.d
+++ b/tests/runtime/lists-alias/runner.d
@@ -2,7 +2,8 @@ import wit.my.lists.runner;
 import cat = wit.my.lists.runner.imports.cat;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     cat.foo((cast(immutable ubyte[])"hello").witList);
 

--- a/tests/runtime/lists-alias/test.d
+++ b/tests/runtime/lists-alias/test.d
@@ -3,12 +3,12 @@ import wit.common;
 
 
 @witInterface("cat") {
-    @witExport("foo")
+    @witExport
     void foo(in WitList!ubyte x) {
         assert(x == (cast(immutable ubyte[])"hello").witList);
     }
     
-    @witExport("bar")
+    @witExport
     WitList!ubyte bar() {
         return (cast(immutable ubyte[])"world").witList.witClone;
     }

--- a/tests/runtime/lists-alias/test.d
+++ b/tests/runtime/lists-alias/test.d
@@ -1,14 +1,17 @@
 import wit.my.lists.test;
 import wit.common;
 
-@witExport("cat", "foo")
-void foo(in WitList!ubyte x) {
-    assert(x == (cast(immutable ubyte[])"hello").witList);
-}
 
-@witExport("cat", "bar")
-WitList!ubyte bar() {
-    return (cast(immutable ubyte[])"world").witList.witClone;
+@witInterface("cat") {
+    @witExport("foo")
+    void foo(in WitList!ubyte x) {
+        assert(x == (cast(immutable ubyte[])"hello").witList);
+    }
+    
+    @witExport("bar")
+    WitList!ubyte bar() {
+        return (cast(immutable ubyte[])"world").witList.witClone;
+    }
 }
 
 alias Exports = wit.my.lists.test.Exports!(

--- a/tests/runtime/lists/runner.d
+++ b/tests/runtime/lists/runner.d
@@ -6,7 +6,8 @@ extern extern(C) size_t walloc_allocated_bytes;
 extern(C) void* malloc(size_t size);
 extern(C) void free(void* ptr);
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto allocedAtFuncStart = walloc_allocated_bytes;
     auto allocedAtFuncStart2 = allocatedBytes;

--- a/tests/runtime/lists/runner.d
+++ b/tests/runtime/lists/runner.d
@@ -7,7 +7,7 @@ extern(C) void* malloc(size_t size);
 extern(C) void free(void* ptr);
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto allocedAtFuncStart = walloc_allocated_bytes;
     auto allocedAtFuncStart2 = allocatedBytes;

--- a/tests/runtime/lists/test.d
+++ b/tests/runtime/lists/test.d
@@ -1,94 +1,95 @@
 import wit.test.lists.test;
 import wit.common;
 
-@witExport("test:lists/to-test", "empty-list-param")
-void emptyListParam(in WitList!ubyte a) {
-}
-
-@witExport("test:lists/to-test", "empty-string-param")
-void emptyStringParam(in WitString a) {
-}
-
-@witExport("test:lists/to-test", "empty-list-result")
-WitList!ubyte emptyListResult() {
-    return WitList!ubyte();
-}
-
-@witExport("test:lists/to-test", "empty-string-result")
-WitString emptyStringResult() {
-    return WitString();
-}
-
-@witExport("test:lists/to-test", "list-param")
-void listParam(in WitList!ubyte a) {
-}
-
-@witExport("test:lists/to-test", "list-param2")
-void listParam2(in WitString a) {
-}
-
-@witExport("test:lists/to-test", "list-param3")
-void listParam3(in WitList!WitString a) {
-}
-
-@witExport("test:lists/to-test", "list-param4")
-void listParam4(in WitList!(WitList!WitString) a) {
-}
-
-@witExport("test:lists/to-test", "list-param5")
-void listParam5(in WitList!(Tuple!(ubyte, uint, ubyte)) a) {
-}
-
-@witExport("test:lists/to-test", "list-param-large")
-void listParamLarge(in WitList!WitString a) {
-}
-
-@witExport("test:lists/to-test", "list-result")
-WitList!ubyte listResult() {
-    immutable ubyte[5] outputs = [1, 2, 3, 4, 5];
-    return outputs.witList.witClone;
-}
-
-@witExport("test:lists/to-test", "list-result2")
-WitString listResult2() {
-    return "hello!".witList.witClone;
-}
-
-@witExport("test:lists/to-test", "list-result3")
-WitList!WitString listResult3() {
-    immutable WitString[2] outputs = ["hello,".witList, "world!".witList];
-    return outputs.witList.witClone;
-}
-
-template listMinmax(T, U, string suffix) {
-    @witExport("test:lists/to-test", "list-minmax"~suffix)
-    Tuple!(WitList!T, WitList!U) listMinmax(in WitList!T a, in WitList!U b) {
-        return tuple(a, b).witClone;
+@witInterface("test:lists/to-test") {
+    @witExport("empty-list-param")
+    void emptyListParam(in WitList!ubyte a) {
+    }
+    
+    @witExport("empty-string-param")
+    void emptyStringParam(in WitString a) {
+    }
+    
+    @witExport("empty-list-result")
+    WitList!ubyte emptyListResult() {
+        return WitList!ubyte();
+    }
+    
+    @witExport("empty-string-result")
+    WitString emptyStringResult() {
+        return WitString();
+    }
+    
+    @witExport("list-param")
+    void listParam(in WitList!ubyte a) {
+    }
+    
+    @witExport("list-param2")
+    void listParam2(in WitString a) {
+    }
+    
+    @witExport("list-param3")
+    void listParam3(in WitList!WitString a) {
+    }
+    
+    @witExport("list-param4")
+    void listParam4(in WitList!(WitList!WitString) a) {
+    }
+    
+    @witExport("list-param5")
+    void listParam5(in WitList!(Tuple!(ubyte, uint, ubyte)) a) {
+    }
+    
+    @witExport("list-param-large")
+    void listParamLarge(in WitList!WitString a) {
+    }
+    
+    @witExport("list-result")
+    WitList!ubyte listResult() {
+        immutable ubyte[5] outputs = [1, 2, 3, 4, 5];
+        return outputs.witList.witClone;
+    }
+    
+    @witExport("list-result2")
+    WitString listResult2() {
+        return "hello!".witList.witClone;
+    }
+    
+    @witExport("list-result3")
+    WitList!WitString listResult3() {
+        immutable WitString[2] outputs = ["hello,".witList, "world!".witList];
+        return outputs.witList.witClone;
+    }
+    
+    template listMinmax(T, U, string suffix) {
+        @witExport("list-minmax"~suffix)
+        Tuple!(WitList!T, WitList!U) listMinmax(in WitList!T a, in WitList!U b) {
+            return tuple(a, b).witClone;
+        }
+    }
+    
+    @witExport("list-roundtrip")
+    WitList!ubyte listRoundtrip(in WitList!ubyte a) {
+        return a.witClone;
+    }
+    
+    @witExport("string-roundtrip")
+    WitString stringRoundtrip(in WitString a) {
+        return a.witClone;
+    }
+    
+    @witExport("wasi-http-headers-roundtrip")
+    WitList!(Tuple!(WitString, WitList!ubyte)) wasiHttpHeadersRoundtrip(in WitList!(Tuple!(WitString, WitList!ubyte)) a) {
+        return a.witClone;
+    }
+    
+    
+    extern extern(C) size_t walloc_allocated_bytes;
+    @witExport("allocated-bytes")
+    size_t allocatedBytes() {
+        return walloc_allocated_bytes;
     }
 }
-
-@witExport("test:lists/to-test", "list-roundtrip")
-WitList!ubyte listRoundtrip(in WitList!ubyte a) {
-    return a.witClone;
-}
-
-@witExport("test:lists/to-test", "string-roundtrip")
-WitString stringRoundtrip(in WitString a) {
-    return a.witClone;
-}
-
-@witExport("test:lists/to-test", "wasi-http-headers-roundtrip")
-WitList!(Tuple!(WitString, WitList!ubyte)) wasiHttpHeadersRoundtrip(in WitList!(Tuple!(WitString, WitList!ubyte)) a) {
-    return a.witClone;
-}
-
-
-extern extern(C) size_t walloc_allocated_bytes;
-@witExport("test:lists/to-test", "allocated-bytes")
-size_t allocatedBytes() {
-    return walloc_allocated_bytes;
-}
-
 
 alias Exports = wit.test.lists.test.Exports!(
     emptyListParam,

--- a/tests/runtime/lists/test.d
+++ b/tests/runtime/lists/test.d
@@ -2,60 +2,60 @@ import wit.test.lists.test;
 import wit.common;
 
 @witInterface("test:lists/to-test") {
-    @witExport("empty-list-param")
+    @witExport
     void emptyListParam(in WitList!ubyte a) {
     }
     
-    @witExport("empty-string-param")
+    @witExport
     void emptyStringParam(in WitString a) {
     }
     
-    @witExport("empty-list-result")
+    @witExport
     WitList!ubyte emptyListResult() {
         return WitList!ubyte();
     }
     
-    @witExport("empty-string-result")
+    @witExport
     WitString emptyStringResult() {
         return WitString();
     }
     
-    @witExport("list-param")
+    @witExport
     void listParam(in WitList!ubyte a) {
     }
     
-    @witExport("list-param2")
+    @witExport
     void listParam2(in WitString a) {
     }
     
-    @witExport("list-param3")
+    @witExport
     void listParam3(in WitList!WitString a) {
     }
     
-    @witExport("list-param4")
+    @witExport
     void listParam4(in WitList!(WitList!WitString) a) {
     }
     
-    @witExport("list-param5")
+    @witExport
     void listParam5(in WitList!(Tuple!(ubyte, uint, ubyte)) a) {
     }
     
-    @witExport("list-param-large")
+    @witExport
     void listParamLarge(in WitList!WitString a) {
     }
     
-    @witExport("list-result")
+    @witExport
     WitList!ubyte listResult() {
         immutable ubyte[5] outputs = [1, 2, 3, 4, 5];
         return outputs.witList.witClone;
     }
     
-    @witExport("list-result2")
+    @witExport
     WitString listResult2() {
         return "hello!".witList.witClone;
     }
     
-    @witExport("list-result3")
+    @witExport
     WitList!WitString listResult3() {
         immutable WitString[2] outputs = ["hello,".witList, "world!".witList];
         return outputs.witList.witClone;
@@ -68,24 +68,24 @@ import wit.common;
         }
     }
     
-    @witExport("list-roundtrip")
+    @witExport
     WitList!ubyte listRoundtrip(in WitList!ubyte a) {
         return a.witClone;
     }
     
-    @witExport("string-roundtrip")
+    @witExport
     WitString stringRoundtrip(in WitString a) {
         return a.witClone;
     }
     
-    @witExport("wasi-http-headers-roundtrip")
+    @witExport
     WitList!(Tuple!(WitString, WitList!ubyte)) wasiHttpHeadersRoundtrip(in WitList!(Tuple!(WitString, WitList!ubyte)) a) {
         return a.witClone;
     }
     
     
     extern extern(C) size_t walloc_allocated_bytes;
-    @witExport("allocated-bytes")
+    @witExport
     size_t allocatedBytes() {
         return walloc_allocated_bytes;
     }

--- a/tests/runtime/many-arguments/runner.d
+++ b/tests/runtime/many-arguments/runner.d
@@ -2,7 +2,7 @@ import wit.test.many_arguments.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     manyArguments(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
 }

--- a/tests/runtime/many-arguments/runner.d
+++ b/tests/runtime/many-arguments/runner.d
@@ -1,7 +1,8 @@
 import wit.test.many_arguments.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     manyArguments(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
 }

--- a/tests/runtime/many-arguments/test.d
+++ b/tests/runtime/many-arguments/test.d
@@ -4,7 +4,7 @@ import wit.common;
 import std.meta : Repeat, AliasSeq;
 
 @witInterface("test:many-arguments/to-test")
-@witExport("many-arguments")
+@witExport
 void manyArguments(Repeat!(16, ulong) args) {
     assert(args == AliasSeq!(
         1,  2,  3,  4,  5,  6,  7,  8,

--- a/tests/runtime/many-arguments/test.d
+++ b/tests/runtime/many-arguments/test.d
@@ -3,7 +3,8 @@ import wit.common;
 
 import std.meta : Repeat, AliasSeq;
 
-@witExport("test:many-arguments/to-test", "many-arguments")
+@witInterface("test:many-arguments/to-test")
+@witExport("many-arguments")
 void manyArguments(Repeat!(16, ulong) args) {
     assert(args == AliasSeq!(
         1,  2,  3,  4,  5,  6,  7,  8,

--- a/tests/runtime/numbers/runner.d
+++ b/tests/runtime/numbers/runner.d
@@ -25,7 +25,7 @@ void doAsserts(alias func)() {
 }
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     doAsserts!roundtripU8;
     doAsserts!roundtripS8;

--- a/tests/runtime/numbers/runner.d
+++ b/tests/runtime/numbers/runner.d
@@ -24,7 +24,8 @@ void doAsserts(alias func)() {
     assert(func(c) == c);
 }
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     doAsserts!roundtripU8;
     doAsserts!roundtripS8;

--- a/tests/runtime/numbers/test.d
+++ b/tests/runtime/numbers/test.d
@@ -10,10 +10,10 @@ import wit.common;
     
     uint scalar;
     
-    @witExport("get-scalar")
+    @witExport
     auto getScalar() => scalar;
     
-    @witExport("set-scalar")
+    @witExport
     void setScalar(uint val) { scalar = val; }
 }
 

--- a/tests/runtime/numbers/test.d
+++ b/tests/runtime/numbers/test.d
@@ -1,18 +1,21 @@
 import wit.test.numbers.test;
 import wit.common;
 
-template roundtrip(T, string suffix) {
-    @witExport("test:numbers/numbers", "roundtrip-"~suffix)
-    T roundtrip(T val) => val;
+
+@witInterface("test:numbers/numbers") {
+    template roundtrip(T, string suffix) {
+        @witExport("roundtrip-"~suffix)
+        T roundtrip(T val) => val;
+    }
+    
+    uint scalar;
+    
+    @witExport("get-scalar")
+    auto getScalar() => scalar;
+    
+    @witExport("set-scalar")
+    void setScalar(uint val) { scalar = val; }
 }
-
-uint scalar;
-
-@witExport("test:numbers/numbers", "get-scalar")
-auto getScalar() => scalar;
-
-@witExport("test:numbers/numbers", "set-scalar")
-void setScalar(uint val) { scalar = val; }
 
 alias Exports = wit.test.numbers.test.Exports!(
     roundtrip!(ubyte, "u8"),

--- a/tests/runtime/options/runner.d
+++ b/tests/runtime/options/runner.d
@@ -2,7 +2,7 @@ import wit.test.options.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     optionNoneParam(none!WitString);
     optionSomeParam("foo".witList.some);

--- a/tests/runtime/options/runner.d
+++ b/tests/runtime/options/runner.d
@@ -1,7 +1,8 @@
 import wit.test.options.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     optionNoneParam(none!WitString);
     optionSomeParam("foo".witList.some);

--- a/tests/runtime/options/test.d
+++ b/tests/runtime/options/test.d
@@ -4,29 +4,29 @@ import wit.common;
 import std.meta : Repeat, AliasSeq;
 
 @witInterface("test:options/to-test") {
-    @witExport("option-none-param")
+    @witExport
     void optionNoneParam(in Option!WitString a) {
     }
     
-    @witExport("option-some-param")
+    @witExport
     void optionSomeParam(in Option!WitString a) {
     }
     
-    @witExport("option-none-result")
+    @witExport
     Option!WitString optionNoneResult() {
         return none!WitString;
     }
     
-    @witExport("option-some-result")
+    @witExport
     Option!WitString optionSomeResult() {
         return "foo".witList.witClone.some;
     }
     
-    @witExport("option-roundtrip")
+    @witExport
     Option!WitString optionRoundtrip(in Option!WitString a) {
         return a.witClone;
     }
-    @witExport("double-option-roundtrip")
+    @witExport
     Option!(Option!uint) doubleOptionRoundtrip(in Option!(Option!uint) a) {
         return a.witClone;
     }

--- a/tests/runtime/options/test.d
+++ b/tests/runtime/options/test.d
@@ -3,33 +3,34 @@ import wit.common;
 
 import std.meta : Repeat, AliasSeq;
 
-@witExport("test:options/to-test", "option-none-param")
-void optionNoneParam(in Option!WitString a) {
+@witInterface("test:options/to-test") {
+    @witExport("option-none-param")
+    void optionNoneParam(in Option!WitString a) {
+    }
+    
+    @witExport("option-some-param")
+    void optionSomeParam(in Option!WitString a) {
+    }
+    
+    @witExport("option-none-result")
+    Option!WitString optionNoneResult() {
+        return none!WitString;
+    }
+    
+    @witExport("option-some-result")
+    Option!WitString optionSomeResult() {
+        return "foo".witList.witClone.some;
+    }
+    
+    @witExport("option-roundtrip")
+    Option!WitString optionRoundtrip(in Option!WitString a) {
+        return a.witClone;
+    }
+    @witExport("double-option-roundtrip")
+    Option!(Option!uint) doubleOptionRoundtrip(in Option!(Option!uint) a) {
+        return a.witClone;
+    }
 }
-
-@witExport("test:options/to-test", "option-some-param")
-void optionSomeParam(in Option!WitString a) {
-}
-
-@witExport("test:options/to-test", "option-none-result")
-Option!WitString optionNoneResult() {
-    return none!WitString;
-}
-
-@witExport("test:options/to-test", "option-some-result")
-Option!WitString optionSomeResult() {
-    return "foo".witList.witClone.some;
-}
-
-@witExport("test:options/to-test", "option-roundtrip")
-Option!WitString optionRoundtrip(in Option!WitString a) {
-    return a.witClone;
-}
-@witExport("test:options/to-test", "double-option-roundtrip")
-Option!(Option!uint) doubleOptionRoundtrip(in Option!(Option!uint) a) {
-    return a.witClone;
-}
-
 
 alias Exports = wit.test.options.test.Exports!(
     optionNoneParam,

--- a/tests/runtime/package-with-version/runner.d
+++ b/tests/runtime/package-with-version/runner.d
@@ -2,7 +2,7 @@ import wit.my.inline.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     Bar.makeNew().witDrop;
 }

--- a/tests/runtime/package-with-version/runner.d
+++ b/tests/runtime/package-with-version/runner.d
@@ -1,7 +1,8 @@
 import wit.my.inline.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     Bar.makeNew().witDrop;
 }

--- a/tests/runtime/package-with-version/test.d
+++ b/tests/runtime/package-with-version/test.d
@@ -6,8 +6,7 @@ import std.meta : Repeat, AliasSeq;
 @witInterface("my:inline/foo@0.0.0")
 @witExport("bar")
 struct BarImpl {
-    @witInterface("my:inline/foo@0.0.0")
-    @witExport("[constructor]bar")
+    @witExport("[constructor]")
     static Bar constructor() {
         return Bar.makeNew((out typeof(this) self) {
         });

--- a/tests/runtime/package-with-version/test.d
+++ b/tests/runtime/package-with-version/test.d
@@ -3,9 +3,11 @@ import wit.common;
 
 import std.meta : Repeat, AliasSeq;
 
-@witExport("my:inline/foo@0.0.0", "bar")
+@witInterface("my:inline/foo@0.0.0")
+@witExport("bar")
 struct BarImpl {
-    @witExport("my:inline/foo@0.0.0", "[constructor]bar")
+    @witInterface("my:inline/foo@0.0.0")
+    @witExport("[constructor]bar")
     static Bar constructor() {
         return Bar.makeNew((out typeof(this) self) {
         });

--- a/tests/runtime/records/runner.d
+++ b/tests/runtime/records/runner.d
@@ -1,7 +1,8 @@
 import wit.test.records.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     assert(multipleResults() == tuple(ubyte(4), ushort(5)));
 

--- a/tests/runtime/records/runner.d
+++ b/tests/runtime/records/runner.d
@@ -2,7 +2,7 @@ import wit.test.records.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     assert(multipleResults() == tuple(ubyte(4), ushort(5)));
 

--- a/tests/runtime/records/test.d
+++ b/tests/runtime/records/test.d
@@ -3,41 +3,42 @@ import wit.common;
 
 import std.meta : Repeat, AliasSeq;
 
-@witExport("test:records/to-test", "multiple-results")
-Tuple!(ubyte, ushort) multipleResults() {
-    return tuple(ubyte(4), ushort(5));
+@witInterface("test:records/to-test") {
+    @witExport("multiple-results")
+    Tuple!(ubyte, ushort) multipleResults() {
+        return tuple(ubyte(4), ushort(5));
+    }
+    
+    @witExport("swap-tuple")
+    Tuple!(uint, ubyte) swapTuple(in Tuple!(ubyte, uint) a) {
+        return tuple(a[1], a[0]);
+    }
+    
+    @witExport("roundtrip-flags1")
+    F1 roundtripFlags1(F1 a) {
+        return a;
+    }
+    
+    @witExport("roundtrip-flags2")
+    F2 roundtripFlags2(F2 a) {
+        return a;
+    }
+    
+    @witExport("roundtrip-flags3")
+    Tuple!(Flag8, Flag16, Flag32) roundtripFlags3(Flag8 a, Flag16 b, Flag32 c) {
+        return tuple(a, b, c);
+    }
+    
+    @witExport("roundtrip-record1")
+    R1 roundtripRecord1(in R1 a) {
+        return a;
+    }
+    
+    @witExport("tuple1")
+    Tuple!(ubyte) tuple1(in Tuple!(ubyte) a) {
+        return tuple(a[0]);
+    }
 }
-
-@witExport("test:records/to-test", "swap-tuple")
-Tuple!(uint, ubyte) swapTuple(in Tuple!(ubyte, uint) a) {
-    return tuple(a[1], a[0]);
-}
-
-@witExport("test:records/to-test", "roundtrip-flags1")
-F1 roundtripFlags1(F1 a) {
-    return a;
-}
-
-@witExport("test:records/to-test", "roundtrip-flags2")
-F2 roundtripFlags2(F2 a) {
-    return a;
-}
-
-@witExport("test:records/to-test", "roundtrip-flags3")
-Tuple!(Flag8, Flag16, Flag32) roundtripFlags3(Flag8 a, Flag16 b, Flag32 c) {
-    return tuple(a, b, c);
-}
-
-@witExport("test:records/to-test", "roundtrip-record1")
-R1 roundtripRecord1(in R1 a) {
-    return a;
-}
-
-@witExport("test:records/to-test", "tuple1")
-Tuple!(ubyte) tuple1(in Tuple!(ubyte) a) {
-    return tuple(a[0]);
-}
-
 
 alias Exports = wit.test.records.test.Exports!(
     multipleResults,

--- a/tests/runtime/records/test.d
+++ b/tests/runtime/records/test.d
@@ -4,37 +4,37 @@ import wit.common;
 import std.meta : Repeat, AliasSeq;
 
 @witInterface("test:records/to-test") {
-    @witExport("multiple-results")
+    @witExport
     Tuple!(ubyte, ushort) multipleResults() {
         return tuple(ubyte(4), ushort(5));
     }
     
-    @witExport("swap-tuple")
+    @witExport
     Tuple!(uint, ubyte) swapTuple(in Tuple!(ubyte, uint) a) {
         return tuple(a[1], a[0]);
     }
     
-    @witExport("roundtrip-flags1")
+    @witExport
     F1 roundtripFlags1(F1 a) {
         return a;
     }
     
-    @witExport("roundtrip-flags2")
+    @witExport
     F2 roundtripFlags2(F2 a) {
         return a;
     }
     
-    @witExport("roundtrip-flags3")
+    @witExport
     Tuple!(Flag8, Flag16, Flag32) roundtripFlags3(Flag8 a, Flag16 b, Flag32 c) {
         return tuple(a, b, c);
     }
     
-    @witExport("roundtrip-record1")
+    @witExport
     R1 roundtripRecord1(in R1 a) {
         return a;
     }
     
-    @witExport("tuple1")
+    @witExport
     Tuple!(ubyte) tuple1(in Tuple!(ubyte) a) {
         return tuple(a[0]);
     }

--- a/tests/runtime/resource-borrow/runner.d
+++ b/tests/runtime/resource-borrow/runner.d
@@ -1,7 +1,8 @@
 import wit.test.resource_borrow.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto thing = Thing.makeNew(42);
     scope(exit) thing.witDrop;

--- a/tests/runtime/resource-borrow/runner.d
+++ b/tests/runtime/resource-borrow/runner.d
@@ -2,7 +2,7 @@ import wit.test.resource_borrow.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto thing = Thing.makeNew(42);
     scope(exit) thing.witDrop;

--- a/tests/runtime/resource-borrow/test.d
+++ b/tests/runtime/resource-borrow/test.d
@@ -15,7 +15,7 @@ import wit.common;
         }
     }
     
-    @witExport("foo")
+    @witExport
     uint foo(Thing.Borrow v) {
         return v.rep!ThingImpl.val + 2;
     }

--- a/tests/runtime/resource-borrow/test.d
+++ b/tests/runtime/resource-borrow/test.d
@@ -1,21 +1,25 @@
 import wit.test.resource_borrow.test;
 import wit.common;
 
-@witExport("test:resource-borrow/to-test", "thing")
-struct ThingImpl {
-    uint val;
 
-    @witExport("test:resource-borrow/to-test", "[constructor]thing")
-    static Thing constructor(uint v) {
-        return Thing.makeNew((out typeof(this) self) {
-            self.val = v + 1;
-        });
+@witInterface("test:resource-borrow/to-test") {
+    @witExport("thing")
+    struct ThingImpl {
+        uint val;
+    
+        @witInterface("test:resource-borrow/to-test")
+        @witExport("[constructor]thing")
+        static Thing constructor(uint v) {
+            return Thing.makeNew((out typeof(this) self) {
+                self.val = v + 1;
+            });
+        }
     }
-}
-
-@witExport("test:resource-borrow/to-test", "foo")
-uint foo(Thing.Borrow v) {
-    return v.rep!ThingImpl.val + 2;
+    
+    @witExport("foo")
+    uint foo(Thing.Borrow v) {
+        return v.rep!ThingImpl.val + 2;
+    }
 }
 
 alias Exports = wit.test.resource_borrow.test.Exports!(

--- a/tests/runtime/resource-borrow/test.d
+++ b/tests/runtime/resource-borrow/test.d
@@ -7,8 +7,7 @@ import wit.common;
     struct ThingImpl {
         uint val;
     
-        @witInterface("test:resource-borrow/to-test")
-        @witExport("[constructor]thing")
+        @witExport("[constructor]")
         static Thing constructor(uint v) {
             return Thing.makeNew((out typeof(this) self) {
                 self.val = v + 1;

--- a/tests/runtime/resource-import-and-export/intermediate.d
+++ b/tests/runtime/resource-import-and-export/intermediate.d
@@ -4,28 +4,31 @@ import wit.test.resource_import_and_export.test.exports : ThingExport = Thing;
 
 import wit.common;
 
-@witExport("test:resource-import-and-export/test", "thing")
+@witInterface("test:resource-import-and-export/test")
+@witExport("thing")
 struct ThingImpl {
     ThingImport thing;
 
-    @witExport("test:resource-import-and-export/test", "[constructor]thing")
+    @witInterface("test:resource-import-and-export/test"):
+    
+    @witExport("[constructor]thing")
     static ThingExport constructor(uint v) {
         return ThingExport.makeNew((out typeof(this) self) {
             self.thing = ThingImport.makeNew(v + 1);
         });
     }
 
-    @witExport("test:resource-import-and-export/test", "[method]thing.foo")
+    @witExport("[method]thing.foo")
     uint foo() {
         return thing.foo + 2;
     }
 
-    @witExport("test:resource-import-and-export/test", "[method]thing.bar")
+    @witExport("[method]thing.bar")
     void bar(uint v) {
         thing.bar(v + 3);
     }
 
-    @witExport("test:resource-import-and-export/test", "[static]thing.baz")
+    @witExport("[static]thing.baz")
     static ThingExport baz(ThingExport a, ThingExport b) {
         scope(exit) {
             a.witDrop;
@@ -47,7 +50,8 @@ struct ThingImpl {
     }
 }
 
-@witExport("$root", "toplevel-export")
+@witInterface("$root")
+@witExport("toplevel-export")
 ThingImport toplevelExport(ThingImport input) {
     // `input` not dropped b/c ownership transferred
     // to `toplevelImport`

--- a/tests/runtime/resource-import-and-export/intermediate.d
+++ b/tests/runtime/resource-import-and-export/intermediate.d
@@ -9,26 +9,24 @@ import wit.common;
 struct ThingImpl {
     ThingImport thing;
 
-    @witInterface("test:resource-import-and-export/test"):
-    
-    @witExport("[constructor]thing")
+    @witExport("[constructor]")
     static ThingExport constructor(uint v) {
         return ThingExport.makeNew((out typeof(this) self) {
             self.thing = ThingImport.makeNew(v + 1);
         });
     }
 
-    @witExport("[method]thing.foo")
+    @witExport("foo")
     uint foo() {
         return thing.foo + 2;
     }
 
-    @witExport("[method]thing.bar")
+    @witExport("bar")
     void bar(uint v) {
         thing.bar(v + 3);
     }
 
-    @witExport("[static]thing.baz")
+    @witExport("baz")
     static ThingExport baz(ThingExport a, ThingExport b) {
         scope(exit) {
             a.witDrop;

--- a/tests/runtime/resource-import-and-export/intermediate.d
+++ b/tests/runtime/resource-import-and-export/intermediate.d
@@ -16,17 +16,17 @@ struct ThingImpl {
         });
     }
 
-    @witExport("foo")
+    @witExport
     uint foo() {
         return thing.foo + 2;
     }
 
-    @witExport("bar")
+    @witExport
     void bar(uint v) {
         thing.bar(v + 3);
     }
 
-    @witExport("baz")
+    @witExport
     static ThingExport baz(ThingExport a, ThingExport b) {
         scope(exit) {
             a.witDrop;
@@ -49,7 +49,7 @@ struct ThingImpl {
 }
 
 @witInterface("$root")
-@witExport("toplevel-export")
+@witExport
 ThingImport toplevelExport(ThingImport input) {
     // `input` not dropped b/c ownership transferred
     // to `toplevelImport`

--- a/tests/runtime/resource-import-and-export/leaf-thing.d
+++ b/tests/runtime/resource-import-and-export/leaf-thing.d
@@ -16,17 +16,17 @@ struct ThingImpl {
         });
     }
 
-    @witExport("foo")
+    @witExport
     uint foo() {
         return val + 2;
     }
 
-    @witExport("bar")
+    @witExport
     void bar(uint v) {
         val = v + 3;
     }
 
-    @witExport("baz")
+    @witExport
     static Thing baz(Thing a, Thing b) {
         return ThingImpl.constructor(
             a.rep!ThingImpl.foo + b.rep!ThingImpl.foo + 4

--- a/tests/runtime/resource-import-and-export/leaf-thing.d
+++ b/tests/runtime/resource-import-and-export/leaf-thing.d
@@ -9,26 +9,24 @@ import wit.common;
 struct ThingImpl {
     uint val;
 
-    @witInterface("test:resource-import-and-export/test"):
-    
-    @witExport("[constructor]thing")
+    @witExport("[constructor]")
     static Thing constructor(uint v) {
         return Thing.makeNew((out typeof(this) self) {
             self.val = v + 1;
         });
     }
 
-    @witExport("[method]thing.foo")
+    @witExport("foo")
     uint foo() {
         return val + 2;
     }
 
-    @witExport("[method]thing.bar")
+    @witExport("bar")
     void bar(uint v) {
         val = v + 3;
     }
 
-    @witExport("[static]thing.baz")
+    @witExport("baz")
     static Thing baz(Thing a, Thing b) {
         return ThingImpl.constructor(
             a.rep!ThingImpl.foo + b.rep!ThingImpl.foo + 4

--- a/tests/runtime/resource-import-and-export/leaf-thing.d
+++ b/tests/runtime/resource-import-and-export/leaf-thing.d
@@ -4,28 +4,31 @@ import wit.test.resource_import_and_export.leaf_thing;
 
 import wit.common;
 
-@witExport("test:resource-import-and-export/test", "thing")
+@witInterface("test:resource-import-and-export/test")
+@witExport("thing")
 struct ThingImpl {
     uint val;
 
-    @witExport("test:resource-import-and-export/test", "[constructor]thing")
+    @witInterface("test:resource-import-and-export/test"):
+    
+    @witExport("[constructor]thing")
     static Thing constructor(uint v) {
         return Thing.makeNew((out typeof(this) self) {
             self.val = v + 1;
         });
     }
 
-    @witExport("test:resource-import-and-export/test", "[method]thing.foo")
+    @witExport("[method]thing.foo")
     uint foo() {
         return val + 2;
     }
 
-    @witExport("test:resource-import-and-export/test", "[method]thing.bar")
+    @witExport("[method]thing.bar")
     void bar(uint v) {
         val = v + 3;
     }
 
-    @witExport("test:resource-import-and-export/test", "[static]thing.baz")
+    @witExport("[static]thing.baz")
     static Thing baz(Thing a, Thing b) {
         return ThingImpl.constructor(
             a.rep!ThingImpl.foo + b.rep!ThingImpl.foo + 4

--- a/tests/runtime/resource-import-and-export/leaf-toplevel.d
+++ b/tests/runtime/resource-import-and-export/leaf-toplevel.d
@@ -5,7 +5,7 @@ import wit.test.resource_import_and_export.leaf_toplevel;
 import wit.common;
 
 @witInterface("$root")
-@witExport("toplevel-export")
+@witExport
 Thing toplevelExport(Thing input) {
     // `input` not dropped b/c ownership transferred
     // via return

--- a/tests/runtime/resource-import-and-export/leaf-toplevel.d
+++ b/tests/runtime/resource-import-and-export/leaf-toplevel.d
@@ -4,7 +4,8 @@ import wit.test.resource_import_and_export.leaf_toplevel;
 
 import wit.common;
 
-@witExport("$root", "toplevel-export")
+@witInterface("$root")
+@witExport("toplevel-export")
 Thing toplevelExport(Thing input) {
     // `input` not dropped b/c ownership transferred
     // via return

--- a/tests/runtime/resource-import-and-export/runner.d
+++ b/tests/runtime/resource-import-and-export/runner.d
@@ -2,7 +2,7 @@ import wit.test.resource_import_and_export.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto thing1 = Thing.makeNew(42);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource-import-and-export/runner.d
+++ b/tests/runtime/resource-import-and-export/runner.d
@@ -1,7 +1,8 @@
 import wit.test.resource_import_and_export.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto thing1 = Thing.makeNew(42);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource_aggregates/runner.d
+++ b/tests/runtime/resource_aggregates/runner.d
@@ -1,7 +1,8 @@
 import wit.test.resource_aggregates.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto r2Thing = Thing.makeNew(1);
     scope(exit) r2Thing.witDrop;

--- a/tests/runtime/resource_aggregates/runner.d
+++ b/tests/runtime/resource_aggregates/runner.d
@@ -2,7 +2,7 @@ import wit.test.resource_aggregates.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto r2Thing = Thing.makeNew(1);
     scope(exit) r2Thing.witDrop;

--- a/tests/runtime/resource_aggregates/test.d
+++ b/tests/runtime/resource_aggregates/test.d
@@ -3,61 +3,64 @@ import wit.test.resource_aggregates.test;
 import wit.common;
 import std.algorithm.iteration : sum, map;
 
-@witExport("test:resource-aggregates/to-test", "thing")
-struct ThingImpl {
-    uint val;
-
-    @witExport("test:resource-aggregates/to-test", "[constructor]thing")
-    static Thing constructor(uint v) {
-        return Thing.makeNew((out typeof(this) self) {
-            self.val = v + 1;
-        });
+@witInterface("test:resource-aggregates/to-test") {
+    @witExport("thing")
+    struct ThingImpl {
+        uint val;
+    
+        @witInterface("test:resource-aggregates/to-test")
+        @witExport("[constructor]thing")
+        static Thing constructor(uint v) {
+            return Thing.makeNew((out typeof(this) self) {
+                self.val = v + 1;
+            });
+        }
     }
-}
-
-@witExport("test:resource-aggregates/to-test", "foo")
-uint foo(
-    scope ref R1 r1, scope ref R2 r2, scope ref R3 r3,
-    scope ref T1 t1, scope ref T2 t2,
-    scope ref V1 v1, scope ref V2 v2,
-    scope ref L1 l1, scope ref L2 l2,
-    scope ref Option!Thing o1, scope ref Option!(Thing.Borrow) o2,
-    scope ref Result!(Thing, void) result1, scope ref Result!(Thing.Borrow, void) result2
-) {
-    scope(exit) {
-        r1.witDrop;
-        r2.witDrop;
-        r3.witDrop;
-        t1.witDrop;
-        t2.witDrop;
-        v1.witDrop;
-        v2.witDrop;
-        l1.witDrop;
-        l2.witDrop;
-        o1.witDrop;
-        o2.witDrop;
-        result1.witDrop;
-        result2.witDrop;
+    
+    @witExport("foo")
+    uint foo(
+        scope ref R1 r1, scope ref R2 r2, scope ref R3 r3,
+        scope ref T1 t1, scope ref T2 t2,
+        scope ref V1 v1, scope ref V2 v2,
+        scope ref L1 l1, scope ref L2 l2,
+        scope ref Option!Thing o1, scope ref Option!(Thing.Borrow) o2,
+        scope ref Result!(Thing, void) result1, scope ref Result!(Thing.Borrow, void) result2
+    ) {
+        scope(exit) {
+            r1.witDrop;
+            r2.witDrop;
+            r3.witDrop;
+            t1.witDrop;
+            t2.witDrop;
+            v1.witDrop;
+            v2.witDrop;
+            l1.witDrop;
+            l2.witDrop;
+            o1.witDrop;
+            o2.witDrop;
+            result1.witDrop;
+            result2.witDrop;
+        }
+    
+        return (
+            r1.thing.rep!ThingImpl.val
+            + r2.thing.rep!ThingImpl.val
+            + r3.thing1.rep!ThingImpl.val
+            + r3.thing2.rep!ThingImpl.val
+            + t1[0].rep!ThingImpl.val
+            + t1[1].thing.rep!ThingImpl.val
+            + t2[0].rep!ThingImpl.val
+            + v1.getThing.rep!ThingImpl.val
+            + v2.getThing.rep!ThingImpl.val
+            + l1[].map!((a) => a.rep!ThingImpl.val).sum
+            + l2[].map!((a) => a.rep!ThingImpl.val).sum
+            + o1.unwrap.rep!ThingImpl.val
+            + o2.unwrap.rep!ThingImpl.val
+            + result1.unwrap.rep!ThingImpl.val
+            + result2.unwrap.rep!ThingImpl.val
+            + 3
+        );
     }
-
-    return (
-          r1.thing.rep!ThingImpl.val
-        + r2.thing.rep!ThingImpl.val
-        + r3.thing1.rep!ThingImpl.val
-        + r3.thing2.rep!ThingImpl.val
-        + t1[0].rep!ThingImpl.val
-        + t1[1].thing.rep!ThingImpl.val
-        + t2[0].rep!ThingImpl.val
-        + v1.getThing.rep!ThingImpl.val
-        + v2.getThing.rep!ThingImpl.val
-        + l1[].map!((a) => a.rep!ThingImpl.val).sum
-        + l2[].map!((a) => a.rep!ThingImpl.val).sum
-        + o1.unwrap.rep!ThingImpl.val
-        + o2.unwrap.rep!ThingImpl.val
-        + result1.unwrap.rep!ThingImpl.val
-        + result2.unwrap.rep!ThingImpl.val
-        + 3
-    );
 }
 
 alias Exports = wit.test.resource_aggregates.test.Exports!(

--- a/tests/runtime/resource_aggregates/test.d
+++ b/tests/runtime/resource_aggregates/test.d
@@ -8,8 +8,7 @@ import std.algorithm.iteration : sum, map;
     struct ThingImpl {
         uint val;
     
-        @witInterface("test:resource-aggregates/to-test")
-        @witExport("[constructor]thing")
+        @witExport("[constructor]")
         static Thing constructor(uint v) {
             return Thing.makeNew((out typeof(this) self) {
                 self.val = v + 1;

--- a/tests/runtime/resource_aggregates/test.d
+++ b/tests/runtime/resource_aggregates/test.d
@@ -16,7 +16,7 @@ import std.algorithm.iteration : sum, map;
         }
     }
     
-    @witExport("foo")
+    @witExport
     uint foo(
         scope ref R1 r1, scope ref R2 r2, scope ref R3 r3,
         scope ref T1 t1, scope ref T2 t2,

--- a/tests/runtime/resource_alias/runner.d
+++ b/tests/runtime/resource_alias/runner.d
@@ -5,7 +5,8 @@ import wit.test.resource_alias.e2.imports : a2 = a, Foo2 = Foo;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto fooE1 = Foo1(
         x: X.makeNew(42)

--- a/tests/runtime/resource_alias/runner.d
+++ b/tests/runtime/resource_alias/runner.d
@@ -6,7 +6,7 @@ import wit.test.resource_alias.e2.imports : a2 = a, Foo2 = Foo;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto fooE1 = Foo1(
         x: X.makeNew(42)

--- a/tests/runtime/resource_alias/test.d
+++ b/tests/runtime/resource_alias/test.d
@@ -5,28 +5,32 @@ import wit.test.resource_alias.e2.exports : Foo2 = Foo, Bar, Y;
 
 import wit.common;
 
-@witExport("test:resource-alias/e1", "x")
-struct XImpl {
-    uint val;
-
-    @witExport("test:resource-alias/e1", "[constructor]x")
-    static X constructor(uint v) {
-        return X.makeNew((out typeof(this) self) {
-            self.val = v;
-        });
+@witInterface("test:resource-alias/e1") {
+    @witExport("x")
+    struct XImpl {
+        uint val;
+        
+        @witInterface("test:resource-alias/e1")
+        @witExport("[constructor]x")
+        static X constructor(uint v) {
+            return X.makeNew((out typeof(this) self) {
+                self.val = v;
+            });
+        }
+    }
+    
+    @witExport("a")
+    WitList!X a1(ref scope Foo1 f) {
+        // `f.x` consumed by return
+    
+        immutable X[1] ret = [f.x];
+    
+        return ret.witList.witClone;
     }
 }
 
-@witExport("test:resource-alias/e1", "a")
-WitList!X a1(ref scope Foo1 f) {
-    // `f.x` consumed by return
-
-    immutable X[1] ret = [f.x];
-
-    return ret.witList.witClone;
-}
-
-@witExport("test:resource-alias/e2", "a")
+@witInterface("test:resource-alias/e2")
+@witExport("a")
 WitList!Y a2(ref scope Foo2 f, ref scope Bar g, Y.Borrow h) {
     // `f.x` consumed by return
     // `f.g` consumed by return

--- a/tests/runtime/resource_alias/test.d
+++ b/tests/runtime/resource_alias/test.d
@@ -10,8 +10,7 @@ import wit.common;
     struct XImpl {
         uint val;
         
-        @witInterface("test:resource-alias/e1")
-        @witExport("[constructor]x")
+        @witExport("[constructor]")
         static X constructor(uint v) {
             return X.makeNew((out typeof(this) self) {
                 self.val = v;

--- a/tests/runtime/resource_alias_redux/runner.d
+++ b/tests/runtime/resource_alias_redux/runner.d
@@ -7,7 +7,7 @@ import wit.test.resource_alias_redux.resource_alias2.imports : Foo2 = Foo;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto thing1 = Thing.makeNew("Ni Hao".witList);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource_alias_redux/runner.d
+++ b/tests/runtime/resource_alias_redux/runner.d
@@ -6,7 +6,8 @@ import wit.test.resource_alias_redux.resource_alias2.imports : Foo2 = Foo;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto thing1 = Thing.makeNew("Ni Hao".witList);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource_alias_redux/test.d
+++ b/tests/runtime/resource_alias_redux/test.d
@@ -25,16 +25,14 @@ char[] concat(in char[] a, in char[] b) {
     struct ThingImpl {
         const(char)[] str;
         
-        @witInterface("test:resource-alias-redux/resource-alias1"):
-    
-        @witExport("[constructor]thing")
+        @witExport("[constructor]")
         static Thing1 constructor(in WitString msg) {
             return Thing1.makeNew((out typeof(this) self) {
                 self.str = concat(msg, " GuestThing");
             });
         }
     
-        @witExport("[method]thing.get")
+        @witExport("get")
         WitString get() {
             return concat(str, " GuestThing.get").witList; // no clone; already on C heap
         }

--- a/tests/runtime/resource_alias_redux/test.d
+++ b/tests/runtime/resource_alias_redux/test.d
@@ -20,34 +20,39 @@ char[] concat(in char[] a, in char[] b) {
     return ptr[0..a.length+b.length];
 }
 
-@witExport("test:resource-alias-redux/resource-alias1", "thing")
-struct ThingImpl {
-    const(char)[] str;
-
-    @witExport("test:resource-alias-redux/resource-alias1", "[constructor]thing")
-    static Thing1 constructor(in WitString msg) {
-        return Thing1.makeNew((out typeof(this) self) {
-            self.str = concat(msg, " GuestThing");
-        });
+@witInterface("test:resource-alias-redux/resource-alias1") {
+    @witExport("thing")
+    struct ThingImpl {
+        const(char)[] str;
+        
+        @witInterface("test:resource-alias-redux/resource-alias1"):
+    
+        @witExport("[constructor]thing")
+        static Thing1 constructor(in WitString msg) {
+            return Thing1.makeNew((out typeof(this) self) {
+                self.str = concat(msg, " GuestThing");
+            });
+        }
+    
+        @witExport("[method]thing.get")
+        WitString get() {
+            return concat(str, " GuestThing.get").witList; // no clone; already on C heap
+        }
     }
-
-    @witExport("test:resource-alias-redux/resource-alias1", "[method]thing.get")
-    WitString get() {
-        return concat(str, " GuestThing.get").witList; // no clone; already on C heap
+    
+    @witExport("a")
+    WitList!Thing1 a(scope ref Foo1 f) {
+        scope(exit) f.witDrop;
+    
+        Thing1[1] things = [f.thing];
+        f.thing = Thing1.init; // consumed
+    
+        return things.witList.witClone;
     }
 }
 
-@witExport("test:resource-alias-redux/resource-alias1", "a")
-WitList!Thing1 a(scope ref Foo1 f) {
-    scope(exit) f.witDrop;
-
-    Thing1[1] things = [f.thing];
-    f.thing = Thing1.init; // consumed
-
-    return things.witList.witClone;
-}
-
-@witExport("test:resource-alias-redux/resource-alias2", "b")
+@witInterface("test:resource-alias-redux/resource-alias2")
+@witExport("b")
 WitList!Thing2 b(scope ref Foo2 f, scope ref Bar g) {
     scope(exit) {
         f.witDrop;
@@ -61,11 +66,11 @@ WitList!Thing2 b(scope ref Foo2 f, scope ref Bar g) {
     return things.witList.witClone;
 }
 
-@witExport("the-test", "test")
+@witInterface("the-test")
+@witExport("test")
 WitList!Thing1 test(scope ref WitList!Thing1 things) {
     return things.witClone;
 }
-
 
 alias Exports = wit.test.resource_alias_redux.test.Exports!(
     ThingImpl,

--- a/tests/runtime/resource_alias_redux/test.d
+++ b/tests/runtime/resource_alias_redux/test.d
@@ -32,13 +32,13 @@ char[] concat(in char[] a, in char[] b) {
             });
         }
     
-        @witExport("get")
+        @witExport
         WitString get() {
             return concat(str, " GuestThing.get").witList; // no clone; already on C heap
         }
     }
     
-    @witExport("a")
+    @witExport
     WitList!Thing1 a(scope ref Foo1 f) {
         scope(exit) f.witDrop;
     
@@ -50,7 +50,7 @@ char[] concat(in char[] a, in char[] b) {
 }
 
 @witInterface("test:resource-alias-redux/resource-alias2")
-@witExport("b")
+@witExport
 WitList!Thing2 b(scope ref Foo2 f, scope ref Bar g) {
     scope(exit) {
         f.witDrop;
@@ -65,7 +65,7 @@ WitList!Thing2 b(scope ref Foo2 f, scope ref Bar g) {
 }
 
 @witInterface("the-test")
-@witExport("test")
+@witExport
 WitList!Thing1 test(scope ref WitList!Thing1 things) {
     return things.witClone;
 }

--- a/tests/runtime/resource_borrow_in_record/runner.d
+++ b/tests/runtime/resource_borrow_in_record/runner.d
@@ -2,7 +2,8 @@ import wit.test.resource_borrow_in_record.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto thing1 = Thing.makeNew("Bonjour".witList);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource_borrow_in_record/runner.d
+++ b/tests/runtime/resource_borrow_in_record/runner.d
@@ -3,7 +3,7 @@ import wit.test.resource_borrow_in_record.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto thing1 = Thing.makeNew("Bonjour".witList);
     scope(exit) thing1.witDrop;

--- a/tests/runtime/resource_borrow_in_record/test.d
+++ b/tests/runtime/resource_borrow_in_record/test.d
@@ -29,13 +29,13 @@ char[] concat(in char[] a, in char[] b) {
             });
         }
     
-        @witExport("get")
+        @witExport
         WitString get() {
             return concat(contents, " get").witList;
         }
     }
     
-    @witExport("test")
+    @witExport
     WitList!Thing test(ref scope WitList!Foo list) {
         if (list.length == 0) return WitList!Thing();
     

--- a/tests/runtime/resource_borrow_in_record/test.d
+++ b/tests/runtime/resource_borrow_in_record/test.d
@@ -17,42 +17,46 @@ char[] concat(in char[] a, in char[] b) {
     return ptr[0..a.length+b.length];
 }
 
-@witExport("test:resource-borrow-in-record/to-test", "thing")
-struct ThingImpl {
-    const(char)[] contents;
-
-    @witExport("test:resource-borrow-in-record/to-test", "[constructor]thing")
-    static Thing constructor(in WitString v) {
-        return Thing.makeNew((out typeof(this) self) {
-            self.contents = concat(v, " new");
-        });
+@witInterface("test:resource-borrow-in-record/to-test") {
+    @witExport("thing")
+    struct ThingImpl {
+        const(char)[] contents;
+    
+        @witInterface("test:resource-borrow-in-record/to-test"):
+        
+        @witExport("[constructor]thing")
+        static Thing constructor(in WitString v) {
+            return Thing.makeNew((out typeof(this) self) {
+                self.contents = concat(v, " new");
+            });
+        }
+    
+        @witExport("[method]thing.get")
+        WitString get() {
+            return concat(contents, " get").witList;
+        }
     }
-
-    @witExport("test:resource-borrow-in-record/to-test", "[method]thing.get")
-    WitString get() {
-        return concat(contents, " get").witList;
+    
+    @witExport("test")
+    WitList!Thing test(ref scope WitList!Foo list) {
+        if (list.length == 0) return WitList!Thing();
+    
+        auto ptr = cast(Thing*)malloc(Thing.sizeof*list.length);
+        assert(ptr);
+    
+        auto things = ptr[0..list.length];
+    
+        foreach (i, ref thing; things) {
+            auto orig = list[i].thing.rep!ThingImpl.contents;
+            auto str = concat(orig, " test");
+    
+            thing = Thing.makeNew((out ThingImpl self) {
+                self.contents = str;
+            });
+        }
+    
+        return things.witList; // already on C heap; no clone
     }
-}
-
-@witExport("test:resource-borrow-in-record/to-test", "test")
-WitList!Thing test(ref scope WitList!Foo list) {
-    if (list.length == 0) return WitList!Thing();
-
-    auto ptr = cast(Thing*)malloc(Thing.sizeof*list.length);
-    assert(ptr);
-
-    auto things = ptr[0..list.length];
-
-    foreach (i, ref thing; things) {
-        auto orig = list[i].thing.rep!ThingImpl.contents;
-        auto str = concat(orig, " test");
-
-        thing = Thing.makeNew((out ThingImpl self) {
-            self.contents = str;
-        });
-    }
-
-    return things.witList; // already on C heap; no clone
 }
 
 alias Exports = wit.test.resource_borrow_in_record.test.Exports!(

--- a/tests/runtime/resource_borrow_in_record/test.d
+++ b/tests/runtime/resource_borrow_in_record/test.d
@@ -22,16 +22,14 @@ char[] concat(in char[] a, in char[] b) {
     struct ThingImpl {
         const(char)[] contents;
     
-        @witInterface("test:resource-borrow-in-record/to-test"):
-        
-        @witExport("[constructor]thing")
+        @witExport("[constructor]")
         static Thing constructor(in WitString v) {
             return Thing.makeNew((out typeof(this) self) {
                 self.contents = concat(v, " new");
             });
         }
     
-        @witExport("[method]thing.get")
+        @witExport("get")
         WitString get() {
             return concat(contents, " get").witList;
         }

--- a/tests/runtime/resource_floats/intermediate.d
+++ b/tests/runtime/resource_floats/intermediate.d
@@ -19,12 +19,12 @@ struct FloatImpl {
         });
     }
 
-    @witExport("get")
+    @witExport
     double get() {
         return val.get + 3;
     }
 
-    @witExport("add")
+    @witExport
     static EFloat add(EFloat a, double b) {
         scope(exit) a.witDrop;
 
@@ -38,7 +38,7 @@ struct FloatImpl {
 }
 
 @witInterface("$root")
-@witExport("add")
+@witExport
 static IFloat2 add(IFloat2.Borrow a, IFloat2.Borrow b) {
     scope(exit) {
         a.witDrop;

--- a/tests/runtime/resource_floats/intermediate.d
+++ b/tests/runtime/resource_floats/intermediate.d
@@ -7,23 +7,26 @@ import wit.test.resource_floats.test.imports : IFloat2 = Float;
 
 import wit.common;
 
-@witExport("exports", "float")
+@witInterface("exports")
+@witExport("float")
 struct FloatImpl {
     IFloat1 val;
 
-    @witExport("exports", "[constructor]float")
+    @witInterface("exports"):
+    
+    @witExport("[constructor]float")
     static EFloat constructor(double v) {
         return EFloat.makeNew((out typeof(this) self) {
             self.val = IFloat1.makeNew(v + 1);
         });
     }
 
-    @witExport("exports", "[method]float.get")
+    @witExport("[method]float.get")
     double get() {
         return val.get + 3;
     }
 
-    @witExport("exports", "[static]float.add")
+    @witExport("[static]float.add")
     static EFloat add(EFloat a, double b) {
         scope(exit) a.witDrop;
 
@@ -36,8 +39,8 @@ struct FloatImpl {
     }
 }
 
-
-@witExport("$root", "add")
+@witInterface("$root")
+@witExport("add")
 static IFloat2 add(IFloat2.Borrow a, IFloat2.Borrow b) {
     scope(exit) {
         a.witDrop;

--- a/tests/runtime/resource_floats/intermediate.d
+++ b/tests/runtime/resource_floats/intermediate.d
@@ -12,21 +12,19 @@ import wit.common;
 struct FloatImpl {
     IFloat1 val;
 
-    @witInterface("exports"):
-    
-    @witExport("[constructor]float")
+    @witExport("[constructor]")
     static EFloat constructor(double v) {
         return EFloat.makeNew((out typeof(this) self) {
             self.val = IFloat1.makeNew(v + 1);
         });
     }
 
-    @witExport("[method]float.get")
+    @witExport("get")
     double get() {
         return val.get + 3;
     }
 
-    @witExport("[static]float.add")
+    @witExport("add")
     static EFloat add(EFloat a, double b) {
         scope(exit) a.witDrop;
 

--- a/tests/runtime/resource_floats/leaf.d
+++ b/tests/runtime/resource_floats/leaf.d
@@ -17,12 +17,12 @@ struct FloatImpl {
         });
     }
 
-    @witExport("get")
+    @witExport
     double get() {
         return val + 4;
     }
 
-    @witExport("add")
+    @witExport
     static Float add(Float a, double b) {
         scope(exit) a.witDrop;
 
@@ -44,7 +44,7 @@ struct Float2Impl {
         });
     }
 
-    @witExport("get")
+    @witExport
     double get() {
         return val + 3;
     }

--- a/tests/runtime/resource_floats/leaf.d
+++ b/tests/runtime/resource_floats/leaf.d
@@ -10,21 +10,19 @@ import wit.common;
 struct FloatImpl {
     double val;
 
-    @witInterface("imports"):
-
-    @witExport("[constructor]float")
+    @witExport("[constructor]")
     static Float constructor(double v) {
         return Float.makeNew((out typeof(this) self) {
             self.val = v + 2;
         });
     }
 
-    @witExport("[method]float.get")
+    @witExport("get")
     double get() {
         return val + 4;
     }
 
-    @witExport("[static]float.add")
+    @witExport("add")
     static Float add(Float a, double b) {
         scope(exit) a.witDrop;
 
@@ -39,16 +37,14 @@ struct FloatImpl {
 struct Float2Impl {
     double val;
 
-    @witInterface("test:resource-floats/test"):
-    
-    @witExport("[constructor]float")
+    @witExport("[constructor]")
     static Float2 constructor(double v) {
         return Float2.makeNew((out typeof(this) self) {
             self.val = v + 1;
         });
     }
 
-    @witExport("[method]float.get")
+    @witExport("get")
     double get() {
         return val + 3;
     }

--- a/tests/runtime/resource_floats/leaf.d
+++ b/tests/runtime/resource_floats/leaf.d
@@ -5,23 +5,26 @@ import wit.test.resource_floats.leaf.exports.imports : Float;
 import wit.test.resource_floats.test.exports : Float2 = Float;
 import wit.common;
 
-@witExport("imports", "float")
+@witInterface("imports")
+@witExport("float")
 struct FloatImpl {
     double val;
 
-    @witExport("imports", "[constructor]float")
+    @witInterface("imports"):
+
+    @witExport("[constructor]float")
     static Float constructor(double v) {
         return Float.makeNew((out typeof(this) self) {
             self.val = v + 2;
         });
     }
 
-    @witExport("imports", "[method]float.get")
+    @witExport("[method]float.get")
     double get() {
         return val + 4;
     }
 
-    @witExport("imports", "[static]float.add")
+    @witExport("[static]float.add")
     static Float add(Float a, double b) {
         scope(exit) a.witDrop;
 
@@ -31,18 +34,21 @@ struct FloatImpl {
     }
 }
 
-@witExport("test:resource-floats/test", "float")
+@witInterface("test:resource-floats/test")
+@witExport("float")
 struct Float2Impl {
     double val;
 
-    @witExport("test:resource-floats/test", "[constructor]float")
+    @witInterface("test:resource-floats/test"):
+    
+    @witExport("[constructor]float")
     static Float2 constructor(double v) {
         return Float2.makeNew((out typeof(this) self) {
             self.val = v + 1;
         });
     }
 
-    @witExport("test:resource-floats/test", "[method]float.get")
+    @witExport("[method]float.get")
     double get() {
         return val + 3;
     }

--- a/tests/runtime/resource_floats/runner.d
+++ b/tests/runtime/resource_floats/runner.d
@@ -5,7 +5,7 @@ import wit.test.resource_floats.runner.imports.exports : Float2 = Float;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto float1 = Float.makeNew(42);
     scope(exit) float1.witDrop;

--- a/tests/runtime/resource_floats/runner.d
+++ b/tests/runtime/resource_floats/runner.d
@@ -4,7 +4,8 @@ import wit.test.resource_floats.runner.imports.exports : Float2 = Float;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto float1 = Float.makeNew(42);
     scope(exit) float1.witDrop;

--- a/tests/runtime/resource_with_lists/leaf.d
+++ b/tests/runtime/resource_with_lists/leaf.d
@@ -17,11 +17,14 @@ ubyte[] concat(in ubyte[] a, in char[] b) {
     return ptr[0..a.length+b.length];
 }
 
-@witExport("test:resource-with-lists/test", "thing")
+@witInterface("test:resource-with-lists/test")
+@witExport("thing")
 struct ThingImpl {
     ubyte[] val;
 
-    @witExport("test:resource-with-lists/test", "[constructor]thing")
+    @witInterface("test:resource-with-lists/test"):
+    
+    @witExport("[constructor]thing")
     static Thing constructor(in WitList!ubyte a) {
         return Thing.makeNew((out typeof(this) self) {
             auto result = a.concat(" HostThing");
@@ -30,13 +33,13 @@ struct ThingImpl {
         });
     }
 
-    @witExport("test:resource-with-lists/test", "[method]thing.foo")
+    @witExport("[method]thing.foo")
     WitList!ubyte foo() {
         auto result = val.concat(" HostThing.foo");
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("test:resource-with-lists/test", "[method]thing.bar")
+    @witExport("[method]thing.bar")
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.bar");
 
@@ -45,7 +48,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("test:resource-with-lists/test", "[static]thing.baz")
+    @witExport("[static]thing.baz")
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.baz");
         return result.witList; // no clone, no free; already on C heap

--- a/tests/runtime/resource_with_lists/leaf.d
+++ b/tests/runtime/resource_with_lists/leaf.d
@@ -22,9 +22,7 @@ ubyte[] concat(in ubyte[] a, in char[] b) {
 struct ThingImpl {
     ubyte[] val;
 
-    @witInterface("test:resource-with-lists/test"):
-    
-    @witExport("[constructor]thing")
+    @witExport("[constructor]")
     static Thing constructor(in WitList!ubyte a) {
         return Thing.makeNew((out typeof(this) self) {
             auto result = a.concat(" HostThing");
@@ -33,13 +31,13 @@ struct ThingImpl {
         });
     }
 
-    @witExport("[method]thing.foo")
+    @witExport("foo")
     WitList!ubyte foo() {
         auto result = val.concat(" HostThing.foo");
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("[method]thing.bar")
+    @witExport("bar")
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.bar");
 
@@ -48,7 +46,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("[static]thing.baz")
+    @witExport("baz")
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.baz");
         return result.witList; // no clone, no free; already on C heap

--- a/tests/runtime/resource_with_lists/leaf.d
+++ b/tests/runtime/resource_with_lists/leaf.d
@@ -31,13 +31,13 @@ struct ThingImpl {
         });
     }
 
-    @witExport("foo")
+    @witExport
     WitList!ubyte foo() {
         auto result = val.concat(" HostThing.foo");
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("bar")
+    @witExport
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.bar");
 
@@ -46,7 +46,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("baz")
+    @witExport
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto result = l.concat(" HostThing.baz");
         return result.witList; // no clone, no free; already on C heap

--- a/tests/runtime/resource_with_lists/resource-with-lists.d
+++ b/tests/runtime/resource_with_lists/resource-with-lists.d
@@ -26,9 +26,7 @@ ubyte[] concat(in ubyte[] a, in char[] b) {
 struct ThingImpl {
     IThing val;
 
-    @witInterface("test:resource-with-lists/test"):
-    
-    @witExport("[constructor]thing")
+    @witExport("[constructor]")
     static EThing constructor(in WitList!ubyte a) {
         return EThing.makeNew((out typeof(this) self) {
             auto result = a.concat(" Thing");
@@ -38,7 +36,7 @@ struct ThingImpl {
         });
     }
 
-    @witExport("[method]thing.foo")
+    @witExport("foo")
     WitList!ubyte foo() {
         auto list = val.foo;
         scope(exit) list.witFree;
@@ -47,7 +45,7 @@ struct ThingImpl {
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("[method]thing.bar")
+    @witExport("bar")
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" Thing.bar");
         scope(exit) free(result.ptr);
@@ -56,7 +54,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("[static]thing.baz")
+    @witExport("baz")
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto input = l.concat(" Thing.baz");
         scope(exit) free(input.ptr);

--- a/tests/runtime/resource_with_lists/resource-with-lists.d
+++ b/tests/runtime/resource_with_lists/resource-with-lists.d
@@ -21,11 +21,14 @@ ubyte[] concat(in ubyte[] a, in char[] b) {
     return ptr[0..a.length+b.length];
 }
 
-@witExport("test:resource-with-lists/test", "thing")
+@witInterface("test:resource-with-lists/test")
+@witExport("thing")
 struct ThingImpl {
     IThing val;
 
-    @witExport("test:resource-with-lists/test", "[constructor]thing")
+    @witInterface("test:resource-with-lists/test"):
+    
+    @witExport("[constructor]thing")
     static EThing constructor(in WitList!ubyte a) {
         return EThing.makeNew((out typeof(this) self) {
             auto result = a.concat(" Thing");
@@ -35,7 +38,7 @@ struct ThingImpl {
         });
     }
 
-    @witExport("test:resource-with-lists/test", "[method]thing.foo")
+    @witExport("[method]thing.foo")
     WitList!ubyte foo() {
         auto list = val.foo;
         scope(exit) list.witFree;
@@ -44,7 +47,7 @@ struct ThingImpl {
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("test:resource-with-lists/test", "[method]thing.bar")
+    @witExport("[method]thing.bar")
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" Thing.bar");
         scope(exit) free(result.ptr);
@@ -53,7 +56,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("test:resource-with-lists/test", "[static]thing.baz")
+    @witExport("[static]thing.baz")
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto input = l.concat(" Thing.baz");
         scope(exit) free(input.ptr);

--- a/tests/runtime/resource_with_lists/resource-with-lists.d
+++ b/tests/runtime/resource_with_lists/resource-with-lists.d
@@ -36,7 +36,7 @@ struct ThingImpl {
         });
     }
 
-    @witExport("foo")
+    @witExport
     WitList!ubyte foo() {
         auto list = val.foo;
         scope(exit) list.witFree;
@@ -45,7 +45,7 @@ struct ThingImpl {
         return result.witList; // no clone, no free; already on C heap
     }
 
-    @witExport("bar")
+    @witExport
     auto bar(in WitList!ubyte l) {
         auto result = l.concat(" Thing.bar");
         scope(exit) free(result.ptr);
@@ -54,7 +54,7 @@ struct ThingImpl {
     }
 
 
-    @witExport("baz")
+    @witExport
     static WitList!ubyte baz(in WitList!ubyte l) {
         auto input = l.concat(" Thing.baz");
         scope(exit) free(input.ptr);

--- a/tests/runtime/resource_with_lists/runner.d
+++ b/tests/runtime/resource_with_lists/runner.d
@@ -3,7 +3,7 @@ import wit.test.resource_with_lists.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     auto thingInstance = Thing.makeNew((cast(immutable ubyte[])"Hi").witList);
     scope(exit) thingInstance.witDrop;

--- a/tests/runtime/resource_with_lists/runner.d
+++ b/tests/runtime/resource_with_lists/runner.d
@@ -2,7 +2,8 @@ import wit.test.resource_with_lists.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     auto thingInstance = Thing.makeNew((cast(immutable ubyte[])"Hi").witList);
     scope(exit) thingInstance.witDrop;

--- a/tests/runtime/resources/leaf.d
+++ b/tests/runtime/resources/leaf.d
@@ -12,17 +12,17 @@ import wit.common;
             return Y.makeNew((out typeof(this) self) { self.val = a; });
         }
 
-        @witExport("get-a")
+        @witExport
         int getA() {
             return val;
         }
 
-        @witExport("set-a")
+        @witExport
         void setA(int a) {
             val = a;
         }
 
-        @witExport("add")
+        @witExport
         static Y add(Y y, int a) {
             scope (exit)
                 y.witDrop;

--- a/tests/runtime/resources/leaf.d
+++ b/tests/runtime/resources/leaf.d
@@ -2,34 +2,41 @@ import wit.test.resources.leaf;
 
 import wit.common;
 
-@witExport("imports", "y")
-struct YImpl {
-    int val;
+@witInterface("imports") {
+    @witExport("y")
+    struct YImpl {
+        int val;
 
-    @witExport("imports", "[constructor]y")
-    static Y constructor(int a) {
-        return Y.makeNew((out typeof(this) self) {
-            self.val = a;
-        });
-    }
+    @witInterface("imports") :
 
-    @witExport("imports", "[method]y.get-a")
-    int getA() {
-        return val;
-    }
+        @witExport("[constructor]y")
+        static Y constructor(int a)
+        {
+            return Y.makeNew((out typeof(this) self) { self.val = a; });
+        }
 
-    @witExport("imports", "[method]y.set-a")
-    void setA(int a) {
-        val = a;
-    }
+        @witExport("[method]y.get-a")
+        int getA()
+        {
+            return val;
+        }
 
-    @witExport("imports", "[static]y.add")
-    static Y add(Y y, int a) {
-        scope(exit) y.witDrop;
+        @witExport("[method]y.set-a")
+        void setA(int a)
+        {
+            val = a;
+        }
 
-        return Y.makeNew((out typeof(this) self) {
-            self.val = y.rep!YImpl.getA + a;
-        });
+        @witExport("[static]y.add")
+        static Y add(Y y, int a)
+        {
+            scope (exit)
+                y.witDrop;
+
+            return Y.makeNew((out typeof(this) self) {
+                self.val = y.rep!YImpl.getA + a;
+            });
+        }
     }
 }
 

--- a/tests/runtime/resources/leaf.d
+++ b/tests/runtime/resources/leaf.d
@@ -7,29 +7,23 @@ import wit.common;
     struct YImpl {
         int val;
 
-    @witInterface("imports") :
-
-        @witExport("[constructor]y")
-        static Y constructor(int a)
-        {
+        @witExport("[constructor]")
+        static Y constructor(int a) {
             return Y.makeNew((out typeof(this) self) { self.val = a; });
         }
 
-        @witExport("[method]y.get-a")
-        int getA()
-        {
+        @witExport("get-a")
+        int getA() {
             return val;
         }
 
-        @witExport("[method]y.set-a")
-        void setA(int a)
-        {
+        @witExport("set-a")
+        void setA(int a) {
             val = a;
         }
 
-        @witExport("[static]y.add")
-        static Y add(Y y, int a)
-        {
+        @witExport("add")
+        static Y add(Y y, int a) {
             scope (exit)
                 y.witDrop;
 

--- a/tests/runtime/resources/resources.d
+++ b/tests/runtime/resources/resources.d
@@ -2,152 +2,158 @@ import wit.test.resources.resources;
 
 import wit.common;
 
-@witExport("exports", "x")
-struct XImpl {
-    int val;
-
-    @witExport("exports", "[constructor]x")
-    static X constructor(int a) {
-        return X.makeNew((out typeof(this) self) {
-            self.val = a;
-        });
+@witInterface("exports") {
+    @witExport("x")
+    struct XImpl {
+        int val;
+    
+        @witInterface("exports"):
+        
+        @witExport("[constructor]x")
+        static X constructor(int a) {
+            return X.makeNew((out typeof(this) self) {
+                self.val = a;
+            });
+        }
+    
+        @witExport("[method]x.get-a")
+        int getA() {
+            return val;
+        }
+    
+        @witExport("[method]x.set-a")
+        void setA(int a) {
+            val = a;
+        }
+    
+        @witExport("[static]x.add")
+        static X add(X x, int a) {
+            scope(exit) x.witDrop;
+    
+            return X.makeNew((out typeof(this) self) {
+                self.val = x.rep!XImpl.getA + a;
+            });
+        }
     }
-
-    @witExport("exports", "[method]x.get-a")
-    int getA() {
-        return val;
+    
+    @witExport("z")
+    struct ZImpl {
+        static uint numDropped = 0;
+    
+        int val;
+    
+        @witInterface("exports"):
+        
+        @witExport("[constructor]z")
+        static Z constructor(int a) {
+            return Z.makeNew((out typeof(this) self) {
+                self.val = a;
+            });
+        }
+    
+        @witExport("[method]z.get-a")
+        int getA() {
+            return val;
+        }
+    
+        @witExport("[static]z.num-dropped")
+        static uint getNumDropped() {
+            return numDropped + 1;
+        }
+    
+        ~this() {
+            numDropped += 1;
+        }
     }
-
-    @witExport("exports", "[method]x.set-a")
-    void setA(int a) {
-        val = a;
+    
+    @witExport("kebab-case")
+    struct KebabCaseImpl {
+        uint val;
+        
+        @witInterface("exports"):
+        
+        @witExport("[constructor]kebab-case")
+        static KebabCase constructor(uint a) {
+            return KebabCase.makeNew((out typeof(this) self) {
+                self.val = a;
+            });
+        }
+    
+        @witExport("[method]kebab-case.get-a")
+        uint getA() {
+            return val;
+        }
+    
+        @witExport("[static]kebab-case.take-owned")
+        static uint takeOwned(KebabCase k) {
+            scope(exit) k.witDrop;
+    
+            return k.rep!KebabCaseImpl.getA;
+        }
     }
-
-    @witExport("exports", "[static]x.add")
-    static X add(X x, int a) {
-        scope(exit) x.witDrop;
-
-        return X.makeNew((out typeof(this) self) {
-            self.val = x.rep!XImpl.getA + a;
-        });
+    
+    
+    @witExport("add")
+    Z add(Z.Borrow a, Z.Borrow b) {
+        scope(exit) {
+            a.witDrop;
+            b.witDrop;
+        }
+    
+        return ZImpl.constructor(a.rep!ZImpl.val + b.rep!ZImpl.val);
+    }
+    
+    
+    @witExport("consume")
+    void consume(X x) {
+        x.witDrop;
+    }
+    
+    
+    @witExport("test-imports")
+    Result!(void, WitString) testImports() {
+        {
+            auto y = Y.makeNew(10);
+            scope(exit) y.witDrop;
+            assert(y.getA == 10);
+            y.setA(20);
+            assert(y.getA == 20);
+    
+            auto y2 = Y.add(y, 20);
+            scope(exit) y2.witDrop;
+            y = Y.init; // consumed
+            assert(y2.getA == 40);
+        }
+    
+        {
+            auto y1 = Y.makeNew(1);
+            scope(exit) y1.witDrop;
+            auto y2 = Y.makeNew(2);
+            scope(exit) y2.witDrop;
+    
+            assert(y1.getA == 1);
+            assert(y2.getA == 2);
+    
+            y1.setA(10);
+            y2.setA(20);
+            assert(y1.getA == 10);
+            assert(y2.getA == 20);
+    
+            auto y3 = Y.add(y1, 20);
+            scope(exit) y3.witDrop;
+            y1 = Y.init; // consumed
+            assert(y3.getA == 30);
+    
+            auto y4 = Y.add(y2, 30);
+            scope(exit) y4.witDrop;
+            y2 = Y.init; // consumed
+            assert(y4.getA == 50);
+        }
+    
+    
+        return ok!WitString;
     }
 }
-
-@witExport("exports", "z")
-struct ZImpl {
-    static uint numDropped = 0;
-
-    int val;
-
-    @witExport("exports", "[constructor]z")
-    static Z constructor(int a) {
-        return Z.makeNew((out typeof(this) self) {
-            self.val = a;
-        });
-    }
-
-    @witExport("exports", "[method]z.get-a")
-    int getA() {
-        return val;
-    }
-
-    @witExport("exports", "[static]z.num-dropped")
-    static uint getNumDropped() {
-        return numDropped + 1;
-    }
-
-    ~this() {
-        numDropped += 1;
-    }
-}
-
-@witExport("exports", "kebab-case")
-struct KebabCaseImpl {
-    uint val;
-
-    @witExport("exports", "[constructor]kebab-case")
-    static KebabCase constructor(uint a) {
-        return KebabCase.makeNew((out typeof(this) self) {
-            self.val = a;
-        });
-    }
-
-    @witExport("exports", "[method]kebab-case.get-a")
-    uint getA() {
-        return val;
-    }
-
-    @witExport("exports", "[static]kebab-case.take-owned")
-    static uint takeOwned(KebabCase k) {
-        scope(exit) k.witDrop;
-
-        return k.rep!KebabCaseImpl.getA;
-    }
-}
-
-
-@witExport("exports", "add")
-Z add(Z.Borrow a, Z.Borrow b) {
-    scope(exit) {
-        a.witDrop;
-        b.witDrop;
-    }
-
-    return ZImpl.constructor(a.rep!ZImpl.val + b.rep!ZImpl.val);
-}
-
-
-@witExport("exports", "consume")
-void consume(X x) {
-    x.witDrop;
-}
-
-
-@witExport("exports", "test-imports")
-Result!(void, WitString) testImports() {
-    {
-        auto y = Y.makeNew(10);
-        scope(exit) y.witDrop;
-        assert(y.getA == 10);
-        y.setA(20);
-        assert(y.getA == 20);
-
-        auto y2 = Y.add(y, 20);
-        scope(exit) y2.witDrop;
-        y = Y.init; // consumed
-        assert(y2.getA == 40);
-    }
-
-    {
-        auto y1 = Y.makeNew(1);
-        scope(exit) y1.witDrop;
-        auto y2 = Y.makeNew(2);
-        scope(exit) y2.witDrop;
-
-        assert(y1.getA == 1);
-        assert(y2.getA == 2);
-
-        y1.setA(10);
-        y2.setA(20);
-        assert(y1.getA == 10);
-        assert(y2.getA == 20);
-
-        auto y3 = Y.add(y1, 20);
-        scope(exit) y3.witDrop;
-        y1 = Y.init; // consumed
-        assert(y3.getA == 30);
-
-        auto y4 = Y.add(y2, 30);
-        scope(exit) y4.witDrop;
-        y2 = Y.init; // consumed
-        assert(y4.getA == 50);
-    }
-
-
-    return ok!WitString;
-}
-
-
 
 alias Exports = wit.test.resources.resources.Exports!(
     XImpl,

--- a/tests/runtime/resources/resources.d
+++ b/tests/runtime/resources/resources.d
@@ -14,17 +14,17 @@ import wit.common;
             });
         }
     
-        @witExport("get-a")
+        @witExport
         int getA() {
             return val;
         }
     
-        @witExport("set-a")
+        @witExport
         void setA(int a) {
             val = a;
         }
     
-        @witExport("add")
+        @witExport
         static X add(X x, int a) {
             scope(exit) x.witDrop;
     
@@ -47,7 +47,7 @@ import wit.common;
             });
         }
     
-        @witExport("get-a")
+        @witExport
         int getA() {
             return val;
         }
@@ -73,12 +73,12 @@ import wit.common;
             });
         }
     
-        @witExport("get-a")
+        @witExport
         uint getA() {
             return val;
         }
     
-        @witExport("take-owned")
+        @witExport
         static uint takeOwned(KebabCase k) {
             scope(exit) k.witDrop;
     
@@ -87,7 +87,7 @@ import wit.common;
     }
     
     
-    @witExport("add")
+    @witExport
     Z add(Z.Borrow a, Z.Borrow b) {
         scope(exit) {
             a.witDrop;
@@ -98,13 +98,13 @@ import wit.common;
     }
     
     
-    @witExport("consume")
+    @witExport
     void consume(X x) {
         x.witDrop;
     }
     
     
-    @witExport("test-imports")
+    @witExport
     Result!(void, WitString) testImports() {
         {
             auto y = Y.makeNew(10);

--- a/tests/runtime/resources/resources.d
+++ b/tests/runtime/resources/resources.d
@@ -7,26 +7,24 @@ import wit.common;
     struct XImpl {
         int val;
     
-        @witInterface("exports"):
-        
-        @witExport("[constructor]x")
+        @witExport("[constructor]")
         static X constructor(int a) {
             return X.makeNew((out typeof(this) self) {
                 self.val = a;
             });
         }
     
-        @witExport("[method]x.get-a")
+        @witExport("get-a")
         int getA() {
             return val;
         }
     
-        @witExport("[method]x.set-a")
+        @witExport("set-a")
         void setA(int a) {
             val = a;
         }
     
-        @witExport("[static]x.add")
+        @witExport("add")
         static X add(X x, int a) {
             scope(exit) x.witDrop;
     
@@ -42,21 +40,19 @@ import wit.common;
     
         int val;
     
-        @witInterface("exports"):
-        
-        @witExport("[constructor]z")
+        @witExport("[constructor]")
         static Z constructor(int a) {
             return Z.makeNew((out typeof(this) self) {
                 self.val = a;
             });
         }
     
-        @witExport("[method]z.get-a")
+        @witExport("get-a")
         int getA() {
             return val;
         }
     
-        @witExport("[static]z.num-dropped")
+        @witExport("num-dropped")
         static uint getNumDropped() {
             return numDropped + 1;
         }
@@ -70,21 +66,19 @@ import wit.common;
     struct KebabCaseImpl {
         uint val;
         
-        @witInterface("exports"):
-        
-        @witExport("[constructor]kebab-case")
+        @witExport("[constructor]")
         static KebabCase constructor(uint a) {
             return KebabCase.makeNew((out typeof(this) self) {
                 self.val = a;
             });
         }
     
-        @witExport("[method]kebab-case.get-a")
+        @witExport("get-a")
         uint getA() {
             return val;
         }
     
-        @witExport("[static]kebab-case.take-owned")
+        @witExport("take-owned")
         static uint takeOwned(KebabCase k) {
             scope(exit) k.witDrop;
     

--- a/tests/runtime/resources/runner.d
+++ b/tests/runtime/resources/runner.d
@@ -2,7 +2,8 @@ import wit.test.resources.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     {
         auto result = testImports();

--- a/tests/runtime/resources/runner.d
+++ b/tests/runtime/resources/runner.d
@@ -3,7 +3,7 @@ import wit.test.resources.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     {
         auto result = testImports();

--- a/tests/runtime/results/intermediate.d
+++ b/tests/runtime/results/intermediate.d
@@ -4,32 +4,32 @@ import imports = wit.test.results.test.imports;
 import wit.common;
 
 @witInterface("test:results/test") {
-    @witExport("string-error")
+    @witExport
     Result!(float, WitString) stringError(float a) {
         return imports.stringError(a);
     }
     
-    @witExport("enum-error")
+    @witExport
     Result!(float, E) enumError(float a) {
         return imports.enumError(a);
     }
     
-    @witExport("record-error")
+    @witExport
     Result!(float, E2) recordError(float a) {
         return imports.recordError(a);
     }
     
-    @witExport("variant-error")
+    @witExport
     Result!(float, E3) variantError(float a) {
         return imports.variantError(a);
     }
     
-    @witExport("empty-error")
+    @witExport
     Result!(uint, void) emptyError(uint a) {
         return imports.emptyError(a);
     }
     
-    @witExport("double-error")
+    @witExport
     Result!(Result!(void, WitString), WitString) doubleError(uint a) {
         return imports.doubleError(a);
     }

--- a/tests/runtime/results/intermediate.d
+++ b/tests/runtime/results/intermediate.d
@@ -3,34 +3,36 @@ import imports = wit.test.results.test.imports;
 
 import wit.common;
 
-@witExport("test:results/test", "string-error")
-Result!(float, WitString) stringError(float a) {
-    return imports.stringError(a);
-}
-
-@witExport("test:results/test", "enum-error")
-Result!(float, E) enumError(float a) {
-    return imports.enumError(a);
-}
-
-@witExport("test:results/test", "record-error")
-Result!(float, E2) recordError(float a) {
-    return imports.recordError(a);
-}
-
-@witExport("test:results/test", "variant-error")
-Result!(float, E3) variantError(float a) {
-    return imports.variantError(a);
-}
-
-@witExport("test:results/test", "empty-error")
-Result!(uint, void) emptyError(uint a) {
-    return imports.emptyError(a);
-}
-
-@witExport("test:results/test", "double-error")
-Result!(Result!(void, WitString), WitString) doubleError(uint a) {
-    return imports.doubleError(a);
+@witInterface("test:results/test") {
+    @witExport("string-error")
+    Result!(float, WitString) stringError(float a) {
+        return imports.stringError(a);
+    }
+    
+    @witExport("enum-error")
+    Result!(float, E) enumError(float a) {
+        return imports.enumError(a);
+    }
+    
+    @witExport("record-error")
+    Result!(float, E2) recordError(float a) {
+        return imports.recordError(a);
+    }
+    
+    @witExport("variant-error")
+    Result!(float, E3) variantError(float a) {
+        return imports.variantError(a);
+    }
+    
+    @witExport("empty-error")
+    Result!(uint, void) emptyError(uint a) {
+        return imports.emptyError(a);
+    }
+    
+    @witExport("double-error")
+    Result!(Result!(void, WitString), WitString) doubleError(uint a) {
+        return imports.doubleError(a);
+    }
 }
 
 alias Exports = wit.test.results.intermediate.Exports!(

--- a/tests/runtime/results/leaf.d
+++ b/tests/runtime/results/leaf.d
@@ -3,7 +3,7 @@ import wit.test.results.leaf;
 import wit.common;
 
 @witInterface("test:results/test") {
-    @witExport("string-error")
+    @witExport
     Result!(float, WitString) stringError(float a) {
         if (a == 0.0) {
             return "zero".witList.witClone.err!float;
@@ -12,7 +12,7 @@ import wit.common;
         return a.ok!WitString;
     }
     
-    @witExport("enum-error")
+    @witExport
     Result!(float, E) enumError(float a) {
         if (a == 0.0) {
             return E.a.err!float;
@@ -21,7 +21,7 @@ import wit.common;
         return a.ok!E;
     }
     
-    @witExport("record-error")
+    @witExport
     Result!(float, E2) recordError(float a) {
         if (a == 0.0) {
             return E2(
@@ -38,7 +38,7 @@ import wit.common;
         return a.ok!E2;
     }
     
-    @witExport("variant-error")
+    @witExport
     Result!(float, E3) variantError(float a) {
         if (a == 0.0) {
             return E3.e2(E2(
@@ -54,7 +54,7 @@ import wit.common;
         return a.ok!E3;
     }
     
-    @witExport("empty-error")
+    @witExport
     Result!(uint, void) emptyError(uint a) {
         if (a == 0) {
             return err!uint;
@@ -65,7 +65,7 @@ import wit.common;
         return a.ok!void;
     }
     
-    @witExport("double-error")
+    @witExport
     Result!(Result!(void, WitString), WitString) doubleError(uint a) {
         if (a == 0) {
             return ok!WitString.ok!WitString;

--- a/tests/runtime/results/leaf.d
+++ b/tests/runtime/results/leaf.d
@@ -2,77 +2,79 @@ import wit.test.results.leaf;
 
 import wit.common;
 
-@witExport("test:results/test", "string-error")
-Result!(float, WitString) stringError(float a) {
-    if (a == 0.0) {
-        return "zero".witList.witClone.err!float;
+@witInterface("test:results/test") {
+    @witExport("string-error")
+    Result!(float, WitString) stringError(float a) {
+        if (a == 0.0) {
+            return "zero".witList.witClone.err!float;
+        }
+    
+        return a.ok!WitString;
     }
-
-    return a.ok!WitString;
-}
-
-@witExport("test:results/test", "enum-error")
-Result!(float, E) enumError(float a) {
-    if (a == 0.0) {
-        return E.a.err!float;
+    
+    @witExport("enum-error")
+    Result!(float, E) enumError(float a) {
+        if (a == 0.0) {
+            return E.a.err!float;
+        }
+    
+        return a.ok!E;
     }
-
-    return a.ok!E;
-}
-
-@witExport("test:results/test", "record-error")
-Result!(float, E2) recordError(float a) {
-    if (a == 0.0) {
-        return E2(
-            line: 420,
-            column: 0
-        ).err!float;
-    } else if (a == 1.0) {
-        return E2(
-            line: 77,
-            column: 2
-        ).err!float;
+    
+    @witExport("record-error")
+    Result!(float, E2) recordError(float a) {
+        if (a == 0.0) {
+            return E2(
+                line: 420,
+                column: 0
+            ).err!float;
+        } else if (a == 1.0) {
+            return E2(
+                line: 77,
+                column: 2
+            ).err!float;
+        }
+    
+        return a.ok!E2;
     }
-
-    return a.ok!E2;
-}
-
-@witExport("test:results/test", "variant-error")
-Result!(float, E3) variantError(float a) {
-    if (a == 0.0) {
-        return E3.e2(E2(
-            line: 420,
-            column: 0
-        )).err!float;
-    } else if (a == 1.0) {
-        return E3.e1(E.b).err!float;
-    } else if (a == 2.0) {
-        return E3.e1(E.c).err!float;
+    
+    @witExport("variant-error")
+    Result!(float, E3) variantError(float a) {
+        if (a == 0.0) {
+            return E3.e2(E2(
+                line: 420,
+                column: 0
+            )).err!float;
+        } else if (a == 1.0) {
+            return E3.e1(E.b).err!float;
+        } else if (a == 2.0) {
+            return E3.e1(E.c).err!float;
+        }
+    
+        return a.ok!E3;
     }
-
-    return a.ok!E3;
-}
-
-@witExport("test:results/test", "empty-error")
-Result!(uint, void) emptyError(uint a) {
-    if (a == 0) {
-        return err!uint;
-    } else if (a == 1) {
-        return 42u.ok!void;
+    
+    @witExport("empty-error")
+    Result!(uint, void) emptyError(uint a) {
+        if (a == 0) {
+            return err!uint;
+        } else if (a == 1) {
+            return 42u.ok!void;
+        }
+    
+        return a.ok!void;
     }
-
-    return a.ok!void;
-}
-
-@witExport("test:results/test", "double-error")
-Result!(Result!(void, WitString), WitString) doubleError(uint a) {
-    if (a == 0) {
-        return ok!WitString.ok!WitString;
-    } else if (a == 1) {
-        return "one".witList.witClone.err!void.ok!WitString;
+    
+    @witExport("double-error")
+    Result!(Result!(void, WitString), WitString) doubleError(uint a) {
+        if (a == 0) {
+            return ok!WitString.ok!WitString;
+        } else if (a == 1) {
+            return "one".witList.witClone.err!void.ok!WitString;
+        }
+    
+        return "two".witList.witClone.err!(Result!(void, WitString));
     }
-
-    return "two".witList.witClone.err!(Result!(void, WitString));
 }
 
 alias Exports = wit.test.results.leaf.Exports!(

--- a/tests/runtime/results/runner.d
+++ b/tests/runtime/results/runner.d
@@ -2,7 +2,8 @@ import wit.test.results.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     {
         auto result = stringError(0.0);

--- a/tests/runtime/results/runner.d
+++ b/tests/runtime/results/runner.d
@@ -3,7 +3,7 @@ import wit.test.results.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     {
         auto result = stringError(0.0);

--- a/tests/runtime/strings-alias/runner.d
+++ b/tests/runtime/strings-alias/runner.d
@@ -3,7 +3,7 @@ import wit.my.strings.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     foo("hello".witList);
 

--- a/tests/runtime/strings-alias/runner.d
+++ b/tests/runtime/strings-alias/runner.d
@@ -2,7 +2,8 @@ import wit.my.strings.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     foo("hello".witList);
 

--- a/tests/runtime/strings-alias/test.d
+++ b/tests/runtime/strings-alias/test.d
@@ -3,12 +3,12 @@ import wit.my.strings.test;
 import wit.common;
 
 @witInterface("cat") {
-    @witExport("foo")
+    @witExport
     void foo(in MyString str) {
         assert(str == "hello");
     }
     
-    @witExport("bar")
+    @witExport
     MyString bar() {
         return "world".witList.witClone;
     }

--- a/tests/runtime/strings-alias/test.d
+++ b/tests/runtime/strings-alias/test.d
@@ -2,14 +2,16 @@ import wit.my.strings.test;
 
 import wit.common;
 
-@witExport("cat", "foo")
-void foo(in MyString str) {
-    assert(str == "hello");
-}
-
-@witExport("cat", "bar")
-MyString bar() {
-    return "world".witList.witClone;
+@witInterface("cat") {
+    @witExport("foo")
+    void foo(in MyString str) {
+        assert(str == "hello");
+    }
+    
+    @witExport("bar")
+    MyString bar() {
+        return "world".witList.witClone;
+    }
 }
 
 alias Exports = wit.my.strings.test.Exports!(

--- a/tests/runtime/strings-simple/runner.d
+++ b/tests/runtime/strings-simple/runner.d
@@ -3,7 +3,7 @@ import wit.my.strings.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     foo("hello".witList);
 

--- a/tests/runtime/strings-simple/runner.d
+++ b/tests/runtime/strings-simple/runner.d
@@ -2,7 +2,8 @@ import wit.my.strings.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     foo("hello".witList);
 

--- a/tests/runtime/strings-simple/test.d
+++ b/tests/runtime/strings-simple/test.d
@@ -3,12 +3,12 @@ import wit.my.strings.test;
 import wit.common;
 
 @witInterface("cat") {
-    @witExport("foo")
+    @witExport
     void foo(in WitString str) {
         assert(str == "hello");
     }
     
-    @witExport("bar")
+    @witExport
     WitString bar() {
         return "world".witList.witClone;
     }

--- a/tests/runtime/strings-simple/test.d
+++ b/tests/runtime/strings-simple/test.d
@@ -2,14 +2,16 @@ import wit.my.strings.test;
 
 import wit.common;
 
-@witExport("cat", "foo")
-void foo(in WitString str) {
-    assert(str == "hello");
-}
-
-@witExport("cat", "bar")
-WitString bar() {
-    return "world".witList.witClone;
+@witInterface("cat") {
+    @witExport("foo")
+    void foo(in WitString str) {
+        assert(str == "hello");
+    }
+    
+    @witExport("bar")
+    WitString bar() {
+        return "world".witList.witClone;
+    }
 }
 
 alias Exports = wit.my.strings.test.Exports!(

--- a/tests/runtime/strings/runner.d
+++ b/tests/runtime/strings/runner.d
@@ -2,7 +2,8 @@ import wit.test.strings.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     takeBasic("latin utf16".witList);
 

--- a/tests/runtime/strings/runner.d
+++ b/tests/runtime/strings/runner.d
@@ -3,7 +3,7 @@ import wit.test.strings.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     takeBasic("latin utf16".witList);
 

--- a/tests/runtime/strings/test.d
+++ b/tests/runtime/strings/test.d
@@ -4,22 +4,22 @@ import wit.common;
 
 
 @witInterface("test:strings/to-test") {
-    @witExport("take-basic")
+    @witExport
     void takeBasic(in WitString str) {
         assert(str == "latin utf16");
     }
     
-    @witExport("return-unicode")
+    @witExport
     WitString returnUnicode() {
         return "🚀🚀🚀 𠈄𓀀".witList.witClone;
     }
     
-    @witExport("return-empty")
+    @witExport
     WitString returnEmpty() {
         return WitString();
     }
     
-    @witExport("roundtrip")
+    @witExport
     WitString roundtrip(in WitString str) {
         return str.witClone;
     }

--- a/tests/runtime/strings/test.d
+++ b/tests/runtime/strings/test.d
@@ -2,26 +2,28 @@ import wit.test.strings.test;
 
 import wit.common;
 
-@witExport("test:strings/to-test", "take-basic")
-void takeBasic(in WitString str) {
-    assert(str == "latin utf16");
-}
 
-@witExport("test:strings/to-test", "return-unicode")
-WitString returnUnicode() {
-    return "🚀🚀🚀 𠈄𓀀".witList.witClone;
+@witInterface("test:strings/to-test") {
+    @witExport("take-basic")
+    void takeBasic(in WitString str) {
+        assert(str == "latin utf16");
+    }
+    
+    @witExport("return-unicode")
+    WitString returnUnicode() {
+        return "🚀🚀🚀 𠈄𓀀".witList.witClone;
+    }
+    
+    @witExport("return-empty")
+    WitString returnEmpty() {
+        return WitString();
+    }
+    
+    @witExport("roundtrip")
+    WitString roundtrip(in WitString str) {
+        return str.witClone;
+    }
 }
-
-@witExport("test:strings/to-test", "return-empty")
-WitString returnEmpty() {
-    return WitString();
-}
-
-@witExport("test:strings/to-test", "roundtrip")
-WitString roundtrip(in WitString str) {
-    return str.witClone;
-}
-
 
 alias Exports = wit.test.strings.test.Exports!(
     takeBasic,

--- a/tests/runtime/symbol-conflicts/runner.d
+++ b/tests/runtime/symbol-conflicts/runner.d
@@ -2,7 +2,8 @@ import wit.my.inline.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     wit.my.inline.foo1.imports.foo();
     wit.my.inline.foo2.imports.foo();

--- a/tests/runtime/symbol-conflicts/runner.d
+++ b/tests/runtime/symbol-conflicts/runner.d
@@ -3,7 +3,7 @@ import wit.my.inline.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     wit.my.inline.foo1.imports.foo();
     wit.my.inline.foo2.imports.foo();

--- a/tests/runtime/symbol-conflicts/test.d
+++ b/tests/runtime/symbol-conflicts/test.d
@@ -2,16 +2,20 @@ import wit.my.inline.test;
 
 import wit.common;
 
-@witExport("my:inline/foo1", "foo")
+@witInterface("my:inline/foo1")
+@witExport("foo")
 void foo1() {}
 
-@witExport("my:inline/foo2", "foo")
+@witInterface("my:inline/foo2")
+@witExport("foo")
 void foo2() {}
 
-@witExport("my:inline/bar1", "bar")
+@witInterface("my:inline/bar1")
+@witExport("bar")
 WitString bar1() { return WitString(); }
 
-@witExport("my:inline/bar2", "bar")
+@witInterface("my:inline/bar2")
+@witExport("bar")
 WitString bar2() { return WitString(); }
 
 

--- a/tests/runtime/unused-types/runner.d
+++ b/tests/runtime/unused-types/runner.d
@@ -4,7 +4,8 @@ import wit.foo.bar.component.common : UnusedEnum, UnusedRecord, UnusedVariant;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     foo();
 }

--- a/tests/runtime/unused-types/runner.d
+++ b/tests/runtime/unused-types/runner.d
@@ -5,7 +5,7 @@ import wit.foo.bar.component.common : UnusedEnum, UnusedRecord, UnusedVariant;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     foo();
 }

--- a/tests/runtime/unused-types/test.d
+++ b/tests/runtime/unused-types/test.d
@@ -5,7 +5,7 @@ import wit.foo.bar.component.common : UnusedEnum, UnusedRecord, UnusedVariant;
 import wit.common;
 
 @witInterface("foo:bar/component")
-@witExport("foo")
+@witExport
 void foo() {}
 
 alias Exports = wit.foo.bar.test.Exports!(

--- a/tests/runtime/unused-types/test.d
+++ b/tests/runtime/unused-types/test.d
@@ -4,7 +4,8 @@ import wit.foo.bar.component.common : UnusedEnum, UnusedRecord, UnusedVariant;
 
 import wit.common;
 
-@witExport("foo:bar/component", "foo")
+@witInterface("foo:bar/component")
+@witExport("foo")
 void foo() {}
 
 alias Exports = wit.foo.bar.test.Exports!(

--- a/tests/runtime/variants/runner.d
+++ b/tests/runtime/variants/runner.d
@@ -2,7 +2,8 @@ import wit.test.variants.runner;
 
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     assert(roundtripOption(1.0f.some) == ubyte(1).some);
     assert(roundtripOption(none!float) == none!ubyte);

--- a/tests/runtime/variants/runner.d
+++ b/tests/runtime/variants/runner.d
@@ -3,7 +3,7 @@ import wit.test.variants.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     assert(roundtripOption(1.0f.some) == ubyte(1).some);
     assert(roundtripOption(none!float) == none!ubyte);

--- a/tests/runtime/variants/test.d
+++ b/tests/runtime/variants/test.d
@@ -2,37 +2,39 @@ import wit.test.variants.test;
 
 import wit.common;
 
-@witExport("test:variants/to-test", "roundtrip-option")
-Option!ubyte roundtripOption(in Option!float a) {
-    if (a.isSome) return (cast(ubyte)a.unwrap).some;
-    return none!ubyte;
-}
-
-@witExport("test:variants/to-test", "roundtrip-result")
-Result!(double, ubyte) roundtripResult(in Result!(uint, float) a) {
-    if (a.isOk) return (cast(double)a.unwrap).ok!ubyte;
-    return (cast(ubyte)a.unwrapErr).err!double;
-}
-
-@witExport("test:variants/to-test", "roundtrip-enum")
-E1 roundtripEnum(E1 a) => a;
-
-@witExport("test:variants/to-test", "invert-bool")
-bool invertBool(bool a) => !a;
-
-@witExport("test:variants/to-test", "variant-casts")
-Casts variantCasts(in Casts a) => a;
-
-@witExport("test:variants/to-test", "variant-zeros")
-Zeros variantZeros(in Zeros a) => a;
-
-@witExport("test:variants/to-test", "variant-typedefs")
-void variantTypedefs(in Option!uint, bool, in Result!uint) {}
-
-
-@witExport("test:variants/to-test", "variant-enums")
-Tuple!(bool, Result!void, MyErrno) variantEnums(bool a, in Result!void b, MyErrno c) {
-    return tuple(a, b, c);
+@witInterface("test:variants/to-test") {
+    @witExport("roundtrip-option")
+    Option!ubyte roundtripOption(in Option!float a) {
+        if (a.isSome) return (cast(ubyte)a.unwrap).some;
+        return none!ubyte;
+    }
+    
+    @witExport("roundtrip-result")
+    Result!(double, ubyte) roundtripResult(in Result!(uint, float) a) {
+        if (a.isOk) return (cast(double)a.unwrap).ok!ubyte;
+        return (cast(ubyte)a.unwrapErr).err!double;
+    }
+    
+    @witExport("roundtrip-enum")
+    E1 roundtripEnum(E1 a) => a;
+    
+    @witExport("invert-bool")
+    bool invertBool(bool a) => !a;
+    
+    @witExport("variant-casts")
+    Casts variantCasts(in Casts a) => a;
+    
+    @witExport("variant-zeros")
+    Zeros variantZeros(in Zeros a) => a;
+    
+    @witExport("variant-typedefs")
+    void variantTypedefs(in Option!uint, bool, in Result!uint) {}
+    
+    
+    @witExport("variant-enums")
+    Tuple!(bool, Result!void, MyErrno) variantEnums(bool a, in Result!void b, MyErrno c) {
+        return tuple(a, b, c);
+    }
 }
 
 alias Exports = wit.test.variants.test.Exports!(

--- a/tests/runtime/variants/test.d
+++ b/tests/runtime/variants/test.d
@@ -3,35 +3,35 @@ import wit.test.variants.test;
 import wit.common;
 
 @witInterface("test:variants/to-test") {
-    @witExport("roundtrip-option")
+    @witExport
     Option!ubyte roundtripOption(in Option!float a) {
         if (a.isSome) return (cast(ubyte)a.unwrap).some;
         return none!ubyte;
     }
     
-    @witExport("roundtrip-result")
+    @witExport
     Result!(double, ubyte) roundtripResult(in Result!(uint, float) a) {
         if (a.isOk) return (cast(double)a.unwrap).ok!ubyte;
         return (cast(ubyte)a.unwrapErr).err!double;
     }
     
-    @witExport("roundtrip-enum")
+    @witExport
     E1 roundtripEnum(E1 a) => a;
     
-    @witExport("invert-bool")
+    @witExport
     bool invertBool(bool a) => !a;
     
-    @witExport("variant-casts")
+    @witExport
     Casts variantCasts(in Casts a) => a;
     
-    @witExport("variant-zeros")
+    @witExport
     Zeros variantZeros(in Zeros a) => a;
     
-    @witExport("variant-typedefs")
+    @witExport
     void variantTypedefs(in Option!uint, bool, in Result!uint) {}
     
     
-    @witExport("variant-enums")
+    @witExport
     Tuple!(bool, Result!void, MyErrno) variantEnums(bool a, in Result!void b, MyErrno c) {
         return tuple(a, b, c);
     }

--- a/tests/runtime/versions/runner.d
+++ b/tests/runtime/versions/runner.d
@@ -1,7 +1,8 @@
 import wit.test.versions.runner;
 import wit.common;
 
-@witExport("$root", "run")
+@witInterface("$root")
+@witExport("run")
 void run() {
     import v1 = wit.test.dep_0_1_0.test.imports;
 

--- a/tests/runtime/versions/runner.d
+++ b/tests/runtime/versions/runner.d
@@ -2,7 +2,7 @@ import wit.test.versions.runner;
 import wit.common;
 
 @witInterface("$root")
-@witExport("run")
+@witExport
 void run() {
     import v1 = wit.test.dep_0_1_0.test.imports;
 

--- a/tests/runtime/versions/test.d
+++ b/tests/runtime/versions/test.d
@@ -1,17 +1,21 @@
 import wit.test.versions.test;
 import wit.common;
 
-@witExport("test:dep/test@0.1.0", "x")
-float x_v1() => 1.0;
+@witInterface("test:dep/test@0.1.0") {
+    @witExport("x")
+    float x_v1() => 1.0;
+    
+    @witExport("y")
+    float y(float a) => 1.0 + a;
+}
 
-@witExport("test:dep/test@0.1.0", "y")
-float y(float a) => 1.0 + a;
-
-@witExport("test:dep/test@0.2.0", "x")
-float x_v2() => 2.0;
-
-@witExport("test:dep/test@0.2.0", "z")
-float z(float a, float b) => 2.0 + a + b;
+@witInterface("test:dep/test@0.2.0") {
+    @witExport("x")
+    float x_v2() => 2.0;
+    
+    @witExport("z")
+    float z(float a, float b) => 2.0 + a + b;
+}
 
 alias Exports = wit.test.versions.test.Exports!(
     x_v1,

--- a/tests/runtime/versions/test.d
+++ b/tests/runtime/versions/test.d
@@ -5,7 +5,7 @@ import wit.common;
     @witExport("x")
     float x_v1() => 1.0;
     
-    @witExport("y")
+    @witExport
     float y(float a) => 1.0 + a;
 }
 
@@ -13,7 +13,7 @@ import wit.common;
     @witExport("x")
     float x_v2() => 2.0;
     
-    @witExport("z")
+    @witExport
     float z(float a, float b) => 2.0 + a + b;
 }
 


### PR DESCRIPTION
Reworks the marking of `@witExport` to greatly reduce verbosity. `@witInterface` is now a separate UDA from `@witExport`, allowing the same `@witInterface` to easily be bulk applied to symbols. Within a resource, `@witInterface` is not needed and is inferred from the interface of the resource in question.

`@witExport` also now allows omitting the name, instead inferring it by kebab-casing what's assumed to be the camelCase or PascalCase name of the symbol identifier. Furthermore, when specified, `@witExport` also only requires the name of the actual method in question. No need to to include `[method]`/`[static]`, or the name of the resource. e.g. `[method]x.foo` is now specified as just `foo`.