### PR TITLE
fix(d): Fix crashes with large component type embeddings

### DIFF
--- a/crates/d/src/lib.rs
+++ b/crates/d/src/lib.rs
@@ -904,6 +904,38 @@ impl WorldGenerator for D {
             .unwrap();
 
             world_src.push_str(&format!(
+                "private enum componentTypeBytes = x\"{}\n\";\n",
+                &component_type
+                    .iter()
+                    .map(|b| format!("{b:02X}"))
+                    .enumerate()
+                    .fold(String::default(), |a, (i, b)| {
+                        if (i % 39) == 0 { a + "\n" + &b } else { a + &b }
+                    })
+            ));
+
+            world_src.push_str(
+                "
+                private enum componentTypeStr = (() {
+                    immutable input = componentTypeBytes;
+                    auto result = new char[input.length*3];
+
+                    foreach (i, b; input) {
+                        result[(i*3)+0] = '\\\\';
+
+                        ubyte n1 = (b >> 4) & 0xF;
+                        result[(i*3)+1] = n1 < 0xA ? cast(char)('0'+n1) : cast(char)('A'+(n1-0xA));
+
+                        ubyte n2 = b & 0xF;
+                        result[(i*3)+2] = n2 < 0xA ? cast(char)('0'+n2) : cast(char)('A'+(n2-0xA));
+                    }
+
+                    return cast(string)result;
+                })();
+                ",
+            );
+
+            world_src.push_str(&format!(
                 "
                 pragma(inline, false)
                 package({}) void __wit_bindgen_component_type_force_link() pure @nogc nothrow {{}}
@@ -914,19 +946,12 @@ impl WorldGenerator for D {
                         \"\",
                         \"\",
                         `!wasm.custom_sections = !{{!0}}
-                !0 = !{{!\"component-type:wit-bindgen:{version}:{pkg}:{world_name}:{opts_suffix}\", !\"{}\"}}`,
+                !0 = !{{!\"component-type:wit-bindgen:{version}:{pkg}:{world_name}:{opts_suffix}\", !\"`~componentTypeStr~`\"}}`,
                         void
                     );
                 }}
                 ",
-                self.root_pkg,
-                &component_type
-                    .iter()
-                    .map(|b| format!("\\{b:02X}"))
-                    .enumerate()
-                    .fold(String::default(), |a, (i, b)| {
-                        if (i % 24) == 0 { a + "`\n~`" + &b } else { a + &b }
-                    })
+                self.root_pkg
             ));
         }
 


### PR DESCRIPTION
Currently, when trying to compile generated D bindings against sufficiently large components, there ends up being a stack overflow (or so it seems) in the compiler due to the potentially MASSIVE tree of concatenation expressions used to join the possibly thousands of lines of strings together to form the LLVM IR for the component type section.

Line breaks are needed to keep editors from choking trying to process (e.g. split, syntax highlight, etc.) what would an absurdly long line.

To fix this issue, the raw bytes of the encoded component type are instead embedded as a hex-string (which allows whitespace freely within without it affecting the final contents), and is transformed on the D side at compile time into the string that needs to be embedded into the IR.