### PR TITLE
Remove `'static` constraint in `block_on`

### DIFF
--- a/crates/guest-rust/src/rt/async_support.rs
+++ b/crates/guest-rust/src/rt/async_support.rs
@@ -654,8 +654,7 @@ pub unsafe fn callback(event0: u32, event1: u32, event2: u32) -> u32 {
 ///
 /// This uses `waitable-set.wait` to poll for progress on any in-progress calls
 /// to async-lowered imports as necessary.
-// TODO: refactor so `'static` bounds aren't necessary
-pub fn block_on<T: 'static>(future: impl Future<Output = T>) -> T {
+pub fn block_on<T>(future: impl Future<Output = T>) -> T {
     let mut result = None;
     let mut state = TaskState::new(Box::pin(async {
         result = Some(future.await);

--- a/tests/runtime/rust-async-and-block-on/runner.rs
+++ b/tests/runtime/rust-async-and-block-on/runner.rs
@@ -13,6 +13,10 @@ export!(Component);
 
 impl Guest for Component {
     async fn run() {
+        let value = String::from("borrowed");
+        let borrowed = block_on(async { value.as_str() });
+        assert_eq!(borrowed, "borrowed");
+
         let (writer, reader) = wit_stream::new::<u8>();
         let reader = a::b::i::launder(reader);
         let noop_cx = &mut Context::from_waker(Waker::noop());


### PR DESCRIPTION
It looks like that's left over from an older implementation and isn't required anymore.